### PR TITLE
feat: CLI tool and Personal Access Token system

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -111,6 +111,16 @@ function getDb(): Database {
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      tokenHash TEXT NOT NULL UNIQUE,
+      scopes TEXT NOT NULL DEFAULT '["*"]',
+      createdAt TEXT NOT NULL,
+      lastUsedAt TEXT,
+      expiresAt TEXT
+    );
   `);
 
   // Migrations for existing databases
@@ -355,4 +365,14 @@ export interface DailyStatsRow {
 export interface SettingRow {
   key: string;
   value: string;
+}
+
+export interface ApiTokenRow {
+  id: string;
+  name: string;
+  tokenHash: string;
+  scopes: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,11 +21,14 @@ import extractUrl from './routes/extract-url';
 import importRoutes from './routes/import';
 import journalCorrect from './routes/journal-correct';
 import llmStatus from './routes/llm-status';
+import tokens from './routes/tokens';
+import { authMiddleware } from './lib/auth';
 
 const app = new Hono();
 
 app.use('*', cors());
 app.use('*', logger());
+app.use('/api/*', authMiddleware);
 
 app.route('/api/collections', collections);
 app.route('/api/lessons', lessons);
@@ -45,6 +48,7 @@ app.route('/api/extract-url', extractUrl);
 app.route('/api/import', importRoutes);
 app.route('/api/journal-correct', journalCorrect);
 app.route('/api/llm-status', llmStatus);
+app.route('/api/tokens', tokens);
 
 // Capture unhandled errors to Sentry/GlitchTip
 app.onError((err, c) => {

--- a/api/src/lib/auth.test.ts
+++ b/api/src/lib/auth.test.ts
@@ -1,12 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Hono } from 'hono';
-import { createHash, randomBytes, randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import { db } from '../db';
 import { authMiddleware } from './auth';
-
-function hashToken(token: string): string {
-  return createHash('sha256').update(token).digest('hex');
-}
+import { hashToken } from './crypto';
 
 function createTestToken(scopes: string[] = ['*'], expiresAt?: string): string {
   const token = `ltr_${randomBytes(32).toString('base64url')}`;
@@ -29,6 +26,7 @@ function buildApp(): Hono {
   app.post('/api/collections', (c) => c.json({ ok: true }));
   app.get('/api/stats', (c) => c.json({ ok: true }));
   app.get('/api/tokens', (c) => c.json({ ok: true }));
+  app.post('/api/tokens', (c) => c.json({ ok: true }));
   return app;
 }
 
@@ -65,6 +63,13 @@ describe('Auth middleware', () => {
     expect(res.status).toBe(401);
   });
 
+  test('returns 401 for empty Bearer value', async () => {
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: 'Bearer ' },
+    });
+    expect(res.status).toBe(401);
+  });
+
   test('passes through with valid token and wildcard scope', async () => {
     const token = createTestToken(['*']);
     const res = await app.request('/api/collections', {
@@ -79,6 +84,38 @@ describe('Auth middleware', () => {
       headers: { Authorization: `Bearer ${token}` },
     });
     expect(res.status).toBe(200);
+  });
+
+  test('passes through with category wildcard scope', async () => {
+    const token = createTestToken(['collections:*']);
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+
+    // Write should also work with category wildcard
+    const res2 = await app.request('/api/collections', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title: 'test' }),
+    });
+    expect(res2.status).toBe(200);
+  });
+
+  test('passes through with multiple specific scopes', async () => {
+    const token = createTestToken(['collections:read', 'stats:read']);
+    const res1 = await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request('/api/stats', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res2.status).toBe(200);
   });
 
   test('returns 403 for insufficient scope', async () => {
@@ -114,11 +151,18 @@ describe('Auth middleware', () => {
     expect(body.error).toBe('Token has expired');
   });
 
-  test('tokens route is unprotected (no scope check)', async () => {
-    const token = createTestToken(['stats:read']); // no token management scope
+  test('blocks PAT access to token management routes', async () => {
+    const token = createTestToken(['*']);
     const res = await app.request('/api/tokens', {
       headers: { Authorization: `Bearer ${token}` },
     });
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('local access');
+  });
+
+  test('allows unauthenticated access to token routes', async () => {
+    const res = await app.request('/api/tokens');
     expect(res.status).toBe(200);
   });
 

--- a/api/src/lib/auth.test.ts
+++ b/api/src/lib/auth.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Hono } from 'hono';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import { db } from '../db';
+import { authMiddleware } from './auth';
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function createTestToken(scopes: string[] = ['*'], expiresAt?: string): string {
+  const token = `ltr_${randomBytes(32).toString('base64url')}`;
+  const id = randomUUID();
+  db.prepare(`
+    INSERT INTO api_tokens (id, name, tokenHash, scopes, createdAt, expiresAt)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(id, 'test-token', hashToken(token), JSON.stringify(scopes), new Date().toISOString(), expiresAt || null);
+  return token;
+}
+
+function cleanupTokens(): void {
+  db.prepare("DELETE FROM api_tokens WHERE name = 'test-token'").run();
+}
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('/api/*', authMiddleware);
+  app.get('/api/collections', (c) => c.json({ ok: true }));
+  app.post('/api/collections', (c) => c.json({ ok: true }));
+  app.get('/api/stats', (c) => c.json({ ok: true }));
+  app.get('/api/tokens', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('Auth middleware', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = buildApp();
+    cleanupTokens();
+  });
+
+  afterEach(() => {
+    cleanupTokens();
+  });
+
+  test('passes through when no Authorization header', async () => {
+    const res = await app.request('/api/collections');
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 401 for invalid token', async () => {
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: 'Bearer ltr_invalid_token' },
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('Invalid token');
+  });
+
+  test('returns 401 for malformed Authorization header', async () => {
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: 'Basic abc123' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('passes through with valid token and wildcard scope', async () => {
+    const token = createTestToken(['*']);
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('passes through with valid token and matching scope', async () => {
+    const token = createTestToken(['collections:read']);
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('returns 403 for insufficient scope', async () => {
+    const token = createTestToken(['stats:read']);
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Insufficient scope');
+  });
+
+  test('returns 403 for read scope on write operation', async () => {
+    const token = createTestToken(['collections:read']);
+    const res = await app.request('/api/collections', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title: 'test' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 401 for expired token', async () => {
+    const token = createTestToken(['*'], '2020-01-01T00:00:00Z');
+    const res = await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('Token has expired');
+  });
+
+  test('tokens route is unprotected (no scope check)', async () => {
+    const token = createTestToken(['stats:read']); // no token management scope
+    const res = await app.request('/api/tokens', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('updates lastUsedAt on successful auth', async () => {
+    const token = createTestToken(['*']);
+    await app.request('/api/collections', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const row = db.prepare('SELECT lastUsedAt FROM api_tokens WHERE name = ?').get('test-token') as { lastUsedAt: string | null };
+    expect(row.lastUsedAt).not.toBeNull();
+  });
+});

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from 'hono/factory';
-import { createHash, timingSafeEqual } from 'crypto';
 import { db, ApiTokenRow } from '../db';
+import { hashToken } from './crypto';
 
 const SCOPE_MAP: Record<string, { read: string; write: string }> = {
   collections:     { read: 'collections:read', write: 'collections:write' },
@@ -23,17 +23,12 @@ const SCOPE_MAP: Record<string, { read: string; write: string }> = {
   'llm-status':    { read: 'settings:read',    write: 'settings:write' },
 };
 
-function hashToken(token: string): Buffer {
-  return createHash('sha256').update(token).digest();
+function getResourceFromPath(path: string): string | null {
+  const segments = path.split('/').filter(Boolean);
+  return segments[1] || null; // segments[0] = 'api'
 }
 
-function getRequiredScope(path: string, method: string): string | null {
-  // Extract resource from path: /api/<resource>/...
-  const segments = path.split('/').filter(Boolean);
-  const resource = segments[1]; // segments[0] = 'api'
-
-  if (!resource || resource === 'tokens') return null; // tokens route is unprotected
-
+function getRequiredScope(resource: string, method: string): string | null {
   const mapping = SCOPE_MAP[resource];
   if (!mapping) return null;
 
@@ -52,6 +47,15 @@ function tokenHasScope(tokenScopes: string[], requiredScope: string): boolean {
   return false;
 }
 
+function parseScopes(scopesJson: string): string[] {
+  try {
+    const parsed = JSON.parse(scopesJson);
+    return Array.isArray(parsed) ? parsed : ['*'];
+  } catch {
+    return ['*'];
+  }
+}
+
 export const authMiddleware = createMiddleware(async (c, next) => {
   const authHeader = c.req.header('Authorization');
 
@@ -68,18 +72,18 @@ export const authMiddleware = createMiddleware(async (c, next) => {
     return c.json({ error: 'Missing token' }, 401);
   }
 
-  // Hash the presented token and look it up
-  const presentedHash = hashToken(token);
-  const rows = db.prepare('SELECT * FROM api_tokens').all() as ApiTokenRow[];
-
-  let matchedToken: ApiTokenRow | null = null;
-  for (const row of rows) {
-    const storedHash = Buffer.from(row.tokenHash, 'hex');
-    if (storedHash.length === presentedHash.length && timingSafeEqual(presentedHash, storedHash)) {
-      matchedToken = row;
-      break;
-    }
+  // Block PAT access to token management routes — tokens can only be
+  // managed via local/unauthenticated access (browser Settings UI)
+  const resource = getResourceFromPath(c.req.path);
+  if (resource === 'tokens') {
+    return c.json({ error: 'Token management is only available via local access' }, 403);
   }
+
+  // Hash the presented token and look it up via indexed column
+  const hex = hashToken(token);
+  const matchedToken = db.prepare(
+    'SELECT * FROM api_tokens WHERE tokenHash = ?'
+  ).get(hex) as ApiTokenRow | undefined;
 
   if (!matchedToken) {
     return c.json({ error: 'Invalid token' }, 401);
@@ -91,20 +95,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
   }
 
   // Check scope
-  const requiredScope = getRequiredScope(c.req.path, c.req.method);
-  if (requiredScope) {
-    const scopes: string[] = JSON.parse(matchedToken.scopes);
-    if (!tokenHasScope(scopes, requiredScope)) {
-      return c.json({ error: `Insufficient scope. Required: ${requiredScope}` }, 403);
+  if (resource) {
+    const requiredScope = getRequiredScope(resource, c.req.method);
+    if (requiredScope) {
+      const scopes = parseScopes(matchedToken.scopes);
+      if (!tokenHasScope(scopes, requiredScope)) {
+        return c.json({ error: `Insufficient scope. Required: ${requiredScope}` }, 403);
+      }
     }
   }
 
   // Store token info in context for routes that need it
   c.set('tokenId', matchedToken.id);
   c.set('tokenName', matchedToken.name);
-  c.set('tokenScopes', JSON.parse(matchedToken.scopes));
+  c.set('tokenScopes', parseScopes(matchedToken.scopes));
 
-  // Update lastUsedAt (non-blocking)
+  // Update lastUsedAt
   db.prepare('UPDATE api_tokens SET lastUsedAt = ? WHERE id = ?')
     .run(new Date().toISOString(), matchedToken.id);
 

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -1,0 +1,112 @@
+import { createMiddleware } from 'hono/factory';
+import { createHash, timingSafeEqual } from 'crypto';
+import { db, ApiTokenRow } from '../db';
+
+const SCOPE_MAP: Record<string, { read: string; write: string }> = {
+  collections:     { read: 'collections:read', write: 'collections:write' },
+  lessons:         { read: 'collections:read', write: 'collections:write' },
+  vocab:           { read: 'vocab:read',       write: 'vocab:write' },
+  'known-words':   { read: 'vocab:read',       write: 'vocab:write' },
+  cloze:           { read: 'vocab:read',       write: 'vocab:write' },
+  stats:           { read: 'stats:read',       write: 'stats:write' },
+  settings:        { read: 'settings:read',    write: 'settings:write' },
+  translate:       { read: 'vocab:read',       write: 'vocab:read' },
+  explain:         { read: 'vocab:read',       write: 'vocab:read' },
+  tts:             { read: 'vocab:read',       write: 'vocab:read' },
+  tatoeba:         { read: 'vocab:read',       write: 'vocab:read' },
+  anki:            { read: 'settings:read',    write: 'settings:write' },
+  'study-ping':    { read: 'stats:read',       write: 'stats:write' },
+  data:            { read: 'data:export',      write: 'data:import' },
+  'extract-url':   { read: 'collections:write', write: 'collections:write' },
+  import:          { read: 'collections:write', write: 'collections:write' },
+  'journal-correct': { read: 'vocab:read',     write: 'vocab:read' },
+  'llm-status':    { read: 'settings:read',    write: 'settings:write' },
+};
+
+function hashToken(token: string): Buffer {
+  return createHash('sha256').update(token).digest();
+}
+
+function getRequiredScope(path: string, method: string): string | null {
+  // Extract resource from path: /api/<resource>/...
+  const segments = path.split('/').filter(Boolean);
+  const resource = segments[1]; // segments[0] = 'api'
+
+  if (!resource || resource === 'tokens') return null; // tokens route is unprotected
+
+  const mapping = SCOPE_MAP[resource];
+  if (!mapping) return null;
+
+  const isRead = method === 'GET' || method === 'HEAD';
+  return isRead ? mapping.read : mapping.write;
+}
+
+function tokenHasScope(tokenScopes: string[], requiredScope: string): boolean {
+  if (tokenScopes.includes('*')) return true;
+  if (tokenScopes.includes(requiredScope)) return true;
+
+  // Check wildcard: 'collections:*' matches 'collections:read'
+  const [category] = requiredScope.split(':');
+  if (tokenScopes.includes(`${category}:*`)) return true;
+
+  return false;
+}
+
+export const authMiddleware = createMiddleware(async (c, next) => {
+  const authHeader = c.req.header('Authorization');
+
+  // No auth header = local access, pass through
+  if (!authHeader) return next();
+
+  // Must be Bearer token
+  if (!authHeader.startsWith('Bearer ')) {
+    return c.json({ error: 'Invalid authorization format. Use: Bearer <token>' }, 401);
+  }
+
+  const token = authHeader.slice(7);
+  if (!token) {
+    return c.json({ error: 'Missing token' }, 401);
+  }
+
+  // Hash the presented token and look it up
+  const presentedHash = hashToken(token);
+  const rows = db.prepare('SELECT * FROM api_tokens').all() as ApiTokenRow[];
+
+  let matchedToken: ApiTokenRow | null = null;
+  for (const row of rows) {
+    const storedHash = Buffer.from(row.tokenHash, 'hex');
+    if (storedHash.length === presentedHash.length && timingSafeEqual(presentedHash, storedHash)) {
+      matchedToken = row;
+      break;
+    }
+  }
+
+  if (!matchedToken) {
+    return c.json({ error: 'Invalid token' }, 401);
+  }
+
+  // Check expiry
+  if (matchedToken.expiresAt && new Date(matchedToken.expiresAt) < new Date()) {
+    return c.json({ error: 'Token has expired' }, 401);
+  }
+
+  // Check scope
+  const requiredScope = getRequiredScope(c.req.path, c.req.method);
+  if (requiredScope) {
+    const scopes: string[] = JSON.parse(matchedToken.scopes);
+    if (!tokenHasScope(scopes, requiredScope)) {
+      return c.json({ error: `Insufficient scope. Required: ${requiredScope}` }, 403);
+    }
+  }
+
+  // Store token info in context for routes that need it
+  c.set('tokenId', matchedToken.id);
+  c.set('tokenName', matchedToken.name);
+  c.set('tokenScopes', JSON.parse(matchedToken.scopes));
+
+  // Update lastUsedAt (non-blocking)
+  db.prepare('UPDATE api_tokens SET lastUsedAt = ? WHERE id = ?')
+    .run(new Date().toISOString(), matchedToken.id);
+
+  return next();
+});

--- a/api/src/lib/crypto.ts
+++ b/api/src/lib/crypto.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'crypto';
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -1,12 +1,18 @@
 import { Hono } from 'hono';
-import { randomUUID, randomBytes, createHash } from 'crypto';
+import { randomUUID, randomBytes } from 'crypto';
 import { db, ApiTokenRow } from '../db';
+import { hashToken } from '../lib/crypto';
+
+const VALID_SCOPES = new Set([
+  '*',
+  'collections:read', 'collections:write', 'collections:*',
+  'vocab:read', 'vocab:write', 'vocab:*',
+  'stats:read', 'stats:write', 'stats:*',
+  'settings:read', 'settings:write', 'settings:*',
+  'data:export', 'data:import', 'data:*',
+]);
 
 const app = new Hono();
-
-function hashToken(token: string): string {
-  return createHash('sha256').update(token).digest('hex');
-}
 
 function generateToken(): string {
   const bytes = randomBytes(32);
@@ -25,6 +31,11 @@ app.post('/', async (c) => {
 
   if (!Array.isArray(scopes) || scopes.length === 0) {
     return c.json({ error: 'Scopes must be a non-empty array' }, 400);
+  }
+
+  const invalid = scopes.filter((s: string) => !VALID_SCOPES.has(s));
+  if (invalid.length > 0) {
+    return c.json({ error: `Invalid scopes: ${invalid.join(', ')}` }, 400);
   }
 
   const token = generateToken();

--- a/api/src/routes/tokens.ts
+++ b/api/src/routes/tokens.ts
@@ -1,0 +1,89 @@
+import { Hono } from 'hono';
+import { randomUUID, randomBytes, createHash } from 'crypto';
+import { db, ApiTokenRow } from '../db';
+
+const app = new Hono();
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function generateToken(): string {
+  const bytes = randomBytes(32);
+  const encoded = bytes.toString('base64url');
+  return `ltr_${encoded}`;
+}
+
+// POST /api/tokens - Create a new token
+app.post('/', async (c) => {
+  const body = await c.req.json();
+  const { name, scopes = ['*'], expiresAt } = body;
+
+  if (!name || typeof name !== 'string') {
+    return c.json({ error: 'Name is required' }, 400);
+  }
+
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    return c.json({ error: 'Scopes must be a non-empty array' }, 400);
+  }
+
+  const token = generateToken();
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  db.prepare(`
+    INSERT INTO api_tokens (id, name, tokenHash, scopes, createdAt, expiresAt)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(id, name, hashToken(token), JSON.stringify(scopes), now, expiresAt || null);
+
+  return c.json({
+    id,
+    name,
+    token, // Plain token - returned ONCE
+    scopes,
+    createdAt: now,
+    expiresAt: expiresAt || null,
+  }, 201);
+});
+
+// GET /api/tokens - List all tokens (metadata only)
+app.get('/', (c) => {
+  const rows = db.prepare('SELECT id, name, scopes, createdAt, lastUsedAt, expiresAt FROM api_tokens ORDER BY createdAt DESC').all() as Omit<ApiTokenRow, 'tokenHash'>[];
+
+  return c.json(rows.map(row => ({
+    ...row,
+    scopes: JSON.parse(row.scopes as string),
+  })));
+});
+
+// POST /api/tokens/verify - Verify the current token
+app.post('/verify', (c) => {
+  const tokenId = c.get('tokenId');
+  const tokenName = c.get('tokenName');
+  const tokenScopes = c.get('tokenScopes');
+
+  if (!tokenId) {
+    return c.json({ valid: false, error: 'No token provided' }, 401);
+  }
+
+  return c.json({
+    valid: true,
+    id: tokenId,
+    name: tokenName,
+    scopes: tokenScopes,
+  });
+});
+
+// DELETE /api/tokens/:id - Revoke a token
+app.delete('/:id', (c) => {
+  const id = c.req.param('id');
+  const result = db.prepare('DELETE FROM api_tokens WHERE id = ?').run(id);
+
+  if (result.changes === 0) {
+    return c.json({ error: 'Token not found' }, 404);
+  }
+
+  return c.json({ success: true });
+});
+
+export default app;

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -30,7 +30,11 @@ export class ApiClient {
 
     const text = await res.text();
     if (!text) return {};
-    return JSON.parse(text);
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`Unexpected response from server: ${text.slice(0, 200)}`);
+    }
   }
 
   get(path: string) { return this.request('GET', path); }

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,0 +1,40 @@
+export class ApiClient {
+  constructor(
+    private baseUrl: string,
+    private token?: string,
+  ) {}
+
+  private headers(hasBody: boolean = false): Record<string, string> {
+    const h: Record<string, string> = {};
+    if (this.token) h['Authorization'] = `Bearer ${this.token}`;
+    if (hasBody) h['Content-Type'] = 'application/json';
+    return h;
+  }
+
+  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await fetch(url, {
+      method,
+      headers: this.headers(!!body),
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!res.ok) {
+      let msg = `${res.status} ${res.statusText}`;
+      try {
+        const err = await res.json() as { error?: string };
+        if (err.error) msg = err.error;
+      } catch {}
+      throw new Error(msg);
+    }
+
+    const text = await res.text();
+    if (!text) return {};
+    return JSON.parse(text);
+  }
+
+  get(path: string) { return this.request('GET', path); }
+  post(path: string, body?: unknown) { return this.request('POST', path, body); }
+  put(path: string, body: unknown) { return this.request('PUT', path, body); }
+  delete(path: string) { return this.request('DELETE', path); }
+}

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,0 +1,71 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { loadConfig, saveConfig, maskToken } from '../config';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  _id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'login': {
+      const config = loadConfig();
+      const apiUrl = flags.url || flags['api-url'] || config.apiUrl;
+      const token = flags.token;
+
+      if (!token) {
+        console.error('Usage: lector auth login --token <token> [--url <api-url>]');
+        console.error('\nGenerate a token in Settings > API Tokens, then run:');
+        console.error('  lector auth login --token ltr_...');
+        process.exit(1);
+      }
+
+      saveConfig({ ...config, apiUrl, token });
+      console.log(`Saved config. API: ${apiUrl}`);
+      console.log(`Token: ${maskToken(token)}`);
+      break;
+    }
+
+    case 'logout': {
+      const config = loadConfig();
+      delete config.token;
+      saveConfig(config);
+      console.log('Token removed from config.');
+      break;
+    }
+
+    case 'status': {
+      const config = loadConfig();
+      output({
+        apiUrl: config.apiUrl,
+        token: config.token ? maskToken(config.token) : '(none)',
+        format: config.format || 'table',
+      }, format);
+      break;
+    }
+
+    case 'verify': {
+      try {
+        const result = await client.post('/api/tokens/verify') as { valid: boolean; name?: string; scopes?: string[] };
+        if (result.valid) {
+          console.log(`Token valid: "${result.name}" — scopes: ${result.scopes?.join(', ')}`);
+        } else {
+          console.error('Token is invalid.');
+          process.exit(1);
+        }
+      } catch (err) {
+        console.error(`Verification failed: ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    default:
+      console.error(`Unknown auth action: ${action}`);
+      console.error('Available: login, logout, status, verify');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/cloze.ts
+++ b/cli/src/commands/cloze.ts
@@ -1,0 +1,71 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'list': {
+      const params = new URLSearchParams();
+      if (flags.collection) params.set('collection', flags.collection);
+      if (flags.word) params.set('word', flags.word);
+      if (flags.limit) params.set('limit', flags.limit);
+      const query = params.toString() ? `?${params}` : '';
+      const data = await client.get(`/api/cloze${query}`);
+      output(data, format);
+      break;
+    }
+
+    case 'due': {
+      const params = new URLSearchParams();
+      if (flags.mode) params.set('mode', flags.mode);
+      if (flags.collection) params.set('collection', flags.collection);
+      if (flags.limit) params.set('limit', flags.limit);
+      const query = params.toString() ? `?${params}` : '';
+      const data = await client.get(`/api/cloze/due${query}`);
+      output(data, format);
+      break;
+    }
+
+    case 'counts': {
+      const data = await client.get('/api/cloze/counts');
+      output(data, format);
+      break;
+    }
+
+    case 'get': {
+      if (!id) { console.error('Usage: lector cloze get <id>'); process.exit(1); }
+      const data = await client.get(`/api/cloze/${id}`);
+      output(data, format);
+      break;
+    }
+
+    case 'review': {
+      if (!id) { console.error('Usage: lector cloze review <id> --correct --mastery 50'); process.exit(1); }
+      const data = await client.post(`/api/cloze/${id}/review`, {
+        correct: 'correct' in flags,
+        masteryLevel: flags.mastery ? parseInt(flags.mastery) : undefined,
+        nextReview: flags.next || undefined,
+      });
+      output(data, format);
+      break;
+    }
+
+    case 'delete': {
+      if (!id) { console.error('Usage: lector cloze delete <id>'); process.exit(1); }
+      await client.delete(`/api/cloze/${id}`);
+      console.log('Deleted.');
+      break;
+    }
+
+    default:
+      console.error(`Unknown cloze action: ${action}`);
+      console.error('Available: list, due, counts, get, review, delete');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/collections.ts
+++ b/cli/src/commands/collections.ts
@@ -1,0 +1,80 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'list': {
+      const data = await client.get('/api/collections');
+      output(data, format);
+      break;
+    }
+
+    case 'get': {
+      if (!id) { console.error('Usage: lector collections get <id>'); process.exit(1); }
+      const data = await client.get(`/api/collections/${id}`);
+      output(data, format);
+      break;
+    }
+
+    case 'create': {
+      const title = flags.title;
+      if (!title) { console.error('Usage: lector collections create --title "..."'); process.exit(1); }
+      const data = await client.post('/api/collections', {
+        title,
+        author: flags.author || 'Unknown',
+        coverUrl: flags.cover || undefined,
+      });
+      output(data, format);
+      break;
+    }
+
+    case 'update': {
+      if (!id) { console.error('Usage: lector collections update <id> --title "..."'); process.exit(1); }
+      const body: Record<string, string> = {};
+      if (flags.title) body.title = flags.title;
+      if (flags.author) body.author = flags.author;
+      if (flags.cover) body.coverUrl = flags.cover;
+      const data = await client.put(`/api/collections/${id}`, body);
+      output(data, format);
+      break;
+    }
+
+    case 'delete': {
+      if (!id) { console.error('Usage: lector collections delete <id>'); process.exit(1); }
+      await client.delete(`/api/collections/${id}`);
+      console.log('Deleted.');
+      break;
+    }
+
+    case 'lessons': {
+      if (!id) { console.error('Usage: lector collections lessons <id>'); process.exit(1); }
+      const data = await client.get(`/api/collections/${id}/lessons`);
+      output(data, format);
+      break;
+    }
+
+    case 'add-lesson': {
+      if (!id) { console.error('Usage: lector collections add-lesson <id> --title "..."'); process.exit(1); }
+      const title = flags.title;
+      if (!title) { console.error('--title is required'); process.exit(1); }
+      const data = await client.post(`/api/collections/${id}/lessons`, {
+        title,
+        textContent: flags.text || '',
+      });
+      output(data, format);
+      break;
+    }
+
+    default:
+      console.error(`Unknown collections action: ${action}`);
+      console.error('Available: list, get, create, update, delete, lessons, add-lesson');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/data.ts
+++ b/cli/src/commands/data.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  _id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'export': {
+      const data = await client.get('/api/data');
+      if (flags.file) {
+        fs.writeFileSync(flags.file, JSON.stringify(data, null, 2));
+        console.log(`Exported to ${flags.file}`);
+      } else {
+        output(data, 'json'); // Always JSON for export
+      }
+      break;
+    }
+
+    case 'import': {
+      const file = flags.file;
+      if (!file) { console.error('Usage: lector data import --file backup.json'); process.exit(1); }
+      if (!fs.existsSync(file)) { console.error(`File not found: ${file}`); process.exit(1); }
+      const content = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const data = await client.post('/api/data', content);
+      output(data, format);
+      break;
+    }
+
+    default:
+      console.error(`Unknown data action: ${action}`);
+      console.error('Available: export, import');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/lessons.ts
+++ b/cli/src/commands/lessons.ts
@@ -1,0 +1,53 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'get': {
+      if (!id) { console.error('Usage: lector lessons get <id>'); process.exit(1); }
+      const data = await client.get(`/api/lessons/${id}`);
+      output(data, format);
+      break;
+    }
+
+    case 'update': {
+      if (!id) { console.error('Usage: lector lessons update <id> --title "..."'); process.exit(1); }
+      const body: Record<string, unknown> = {};
+      if (flags.title) body.title = flags.title;
+      if (flags.text) body.textContent = flags.text;
+      if (flags.order) body.sortOrder = parseInt(flags.order);
+      const data = await client.put(`/api/lessons/${id}`, body);
+      output(data, format);
+      break;
+    }
+
+    case 'delete': {
+      if (!id) { console.error('Usage: lector lessons delete <id>'); process.exit(1); }
+      await client.delete(`/api/lessons/${id}`);
+      console.log('Deleted.');
+      break;
+    }
+
+    case 'progress': {
+      if (!id) { console.error('Usage: lector lessons progress <id> --scroll 100 --percent 50'); process.exit(1); }
+      const body: Record<string, number> = {};
+      if (flags.scroll) body.scrollPosition = parseInt(flags.scroll);
+      if (flags.percent) body.percentComplete = parseFloat(flags.percent);
+      const data = await client.put(`/api/lessons/${id}/progress`, body);
+      output(data, format);
+      break;
+    }
+
+    default:
+      console.error(`Unknown lessons action: ${action}`);
+      console.error('Available: get, update, delete, progress');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -1,0 +1,50 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  key: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'list': {
+      const data = await client.get('/api/settings');
+      output(data, format);
+      break;
+    }
+
+    case 'get': {
+      if (!key) { console.error('Usage: lector settings get <key>'); process.exit(1); }
+      const data = await client.get(`/api/settings/${key}`);
+      output(data, format);
+      break;
+    }
+
+    case 'set': {
+      if (!key) { console.error('Usage: lector settings set <key> --value "..."'); process.exit(1); }
+      const value = flags.value;
+      if (value === undefined) { console.error('--value is required'); process.exit(1); }
+      // Try to parse as JSON, fall back to string
+      let parsed: unknown;
+      try { parsed = JSON.parse(value); } catch { parsed = value; }
+      await client.put(`/api/settings/${key}`, { value: parsed });
+      console.log(`Set ${key}.`);
+      break;
+    }
+
+    case 'delete': {
+      if (!key) { console.error('Usage: lector settings delete <key>'); process.exit(1); }
+      await client.delete(`/api/settings/${key}`);
+      console.log(`Deleted ${key}.`);
+      break;
+    }
+
+    default:
+      console.error(`Unknown settings action: ${action}`);
+      console.error('Available: list, get, set, delete');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -1,0 +1,52 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  _id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'today': {
+      const data = await client.get('/api/stats/today');
+      output(data, format);
+      break;
+    }
+
+    case 'range': {
+      const params = new URLSearchParams();
+      if (flags.start) params.set('startDate', flags.start);
+      if (flags.end) params.set('endDate', flags.end);
+      if (flags.days) params.set('days', flags.days);
+      const query = params.toString() ? `?${params}` : '';
+      const data = await client.get(`/api/stats${query}`);
+      output(data, format);
+      break;
+    }
+
+    case 'streak': {
+      const data = await client.get('/api/stats/streak');
+      output(data, format);
+      break;
+    }
+
+    case 'increment': {
+      const field = flags.field;
+      if (!field) { console.error('Usage: lector stats increment --field wordsRead [--amount 1]'); process.exit(1); }
+      const data = await client.put('/api/stats/today', {
+        field,
+        amount: flags.amount ? parseInt(flags.amount) : 1,
+      });
+      output(data, format);
+      break;
+    }
+
+    default:
+      console.error(`Unknown stats action: ${action}`);
+      console.error('Available: today, range, streak, increment');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/tokens.ts
+++ b/cli/src/commands/tokens.ts
@@ -1,0 +1,53 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'list': {
+      const data = await client.get('/api/tokens');
+      output(data, format);
+      break;
+    }
+
+    case 'create': {
+      const name = flags.name;
+      if (!name) { console.error('Usage: lector tokens create --name "CLI" [--scopes "*"]'); process.exit(1); }
+      const scopes = flags.scopes ? flags.scopes.split(',').map(s => s.trim()) : ['*'];
+      const data = await client.post('/api/tokens', {
+        name,
+        scopes,
+        expiresAt: flags.expires || undefined,
+      }) as { token: string; id: string; name: string; scopes: string[] };
+
+      if (format === 'json') {
+        output(data, format);
+      } else {
+        console.log(`Token created: ${data.name}`);
+        console.log(`Scopes: ${data.scopes.join(', ')}`);
+        console.log(`\nToken (save this — it won't be shown again):\n`);
+        console.log(`  ${data.token}`);
+        console.log(`\nTo configure the CLI:\n  lector auth login --token ${data.token}`);
+      }
+      break;
+    }
+
+    case 'revoke': {
+      if (!id) { console.error('Usage: lector tokens revoke <id>'); process.exit(1); }
+      await client.delete(`/api/tokens/${id}`);
+      console.log('Token revoked.');
+      break;
+    }
+
+    default:
+      console.error(`Unknown tokens action: ${action}`);
+      console.error('Available: list, create, revoke');
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/vocab.ts
+++ b/cli/src/commands/vocab.ts
@@ -1,0 +1,68 @@
+import type { ApiClient } from '../client';
+import type { Format } from '../format';
+import { output } from '../format';
+
+export async function handle(
+  client: ApiClient,
+  action: string,
+  id: string | undefined,
+  flags: Record<string, string>,
+  format: Format,
+): Promise<void> {
+  switch (action) {
+    case 'list': {
+      const params = new URLSearchParams();
+      if (flags.state) params.set('state', flags.state);
+      if (flags.bookId) params.set('bookId', flags.bookId);
+      if (flags.unpushed) params.set('unpushed', 'true');
+      const query = params.toString() ? `?${params}` : '';
+      const data = await client.get(`/api/vocab${query}`);
+      output(data, format);
+      break;
+    }
+
+    case 'get': {
+      if (!id) { console.error('Usage: lector vocab get <id>'); process.exit(1); }
+      const data = await client.get(`/api/vocab/${id}`);
+      output(data, format);
+      break;
+    }
+
+    case 'create': {
+      const text = flags.text;
+      if (!text) { console.error('Usage: lector vocab create --text "word" --translation "meaning"'); process.exit(1); }
+      const data = await client.post('/api/vocab', {
+        text,
+        type: flags.type || 'word',
+        sentence: flags.sentence || '',
+        translation: flags.translation || '',
+        state: flags.state || 'new',
+      });
+      output(data, format);
+      break;
+    }
+
+    case 'update': {
+      if (!id) { console.error('Usage: lector vocab update <id> --state known'); process.exit(1); }
+      const body: Record<string, unknown> = {};
+      if (flags.state) body.state = flags.state;
+      if (flags.translation) body.translation = flags.translation;
+      if (flags.sentence) body.sentence = flags.sentence;
+      const data = await client.put(`/api/vocab/${id}`, body);
+      output(data, format);
+      break;
+    }
+
+    case 'delete': {
+      if (!id) { console.error('Usage: lector vocab delete <id>'); process.exit(1); }
+      await client.delete(`/api/vocab/${id}`);
+      console.log('Deleted.');
+      break;
+    }
+
+    default:
+      console.error(`Unknown vocab action: ${action}`);
+      console.error('Available: list, get, create, update, delete');
+      process.exit(1);
+  }
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -34,7 +34,9 @@ export function loadConfig(): LectorConfig {
 export function saveConfig(config: LectorConfig): void {
   const dir = getConfigDir();
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + '\n');
+  const configPath = getConfigPath();
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+  fs.chmodSync(configPath, 0o600);
 }
 
 export function maskToken(token: string): string {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+export interface LectorConfig {
+  apiUrl: string;
+  token?: string;
+  format?: 'json' | 'table';
+}
+
+const DEFAULT_CONFIG: LectorConfig = {
+  apiUrl: 'http://localhost:3457',
+  format: 'table',
+};
+
+function getConfigDir(): string {
+  return path.join(os.homedir(), '.config', 'lector');
+}
+
+function getConfigPath(): string {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+export function loadConfig(): LectorConfig {
+  const configPath = getConfigPath();
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    return { ...DEFAULT_CONFIG, ...JSON.parse(content) };
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function saveConfig(config: LectorConfig): void {
+  const dir = getConfigDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + '\n');
+}
+
+export function maskToken(token: string): string {
+  if (token.length <= 8) return '****';
+  return token.slice(0, 8) + '...' + token.slice(-4);
+}

--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -1,0 +1,86 @@
+export type Format = 'json' | 'table';
+
+export function output(data: unknown, format: Format): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      console.log('(no results)');
+      return;
+    }
+    printTable(data);
+  } else if (typeof data === 'object' && data !== null) {
+    printKeyValue(data as Record<string, unknown>);
+  } else {
+    console.log(String(data));
+  }
+}
+
+function printTable(rows: Record<string, unknown>[]): void {
+  const keys = Object.keys(rows[0]);
+  const maxWidth = process.stdout.columns || 120;
+
+  // Filter out very long fields
+  const displayKeys = keys.filter(k => {
+    const sample = String(rows[0][k] ?? '');
+    return k !== 'textContent' && sample.length < 500;
+  });
+
+  // Calculate column widths
+  const widths: Record<string, number> = {};
+  for (const key of displayKeys) {
+    widths[key] = key.length;
+    for (const row of rows) {
+      const val = formatValue(row[key]);
+      widths[key] = Math.max(widths[key], Math.min(val.length, 40));
+    }
+  }
+
+  // Truncate columns to fit terminal
+  const totalPadding = (displayKeys.length - 1) * 3; // ' | ' separators
+  let totalWidth = displayKeys.reduce((sum, k) => sum + widths[k], 0) + totalPadding;
+  while (totalWidth > maxWidth && displayKeys.length > 1) {
+    // Shrink widest column
+    const widest = displayKeys.reduce((a, b) => widths[a] > widths[b] ? a : b);
+    widths[widest] = Math.max(widths[widest] - 5, 8);
+    totalWidth = displayKeys.reduce((sum, k) => sum + widths[k], 0) + totalPadding;
+  }
+
+  // Header
+  const header = displayKeys.map(k => pad(k, widths[k])).join(' | ');
+  console.log(header);
+  console.log(displayKeys.map(k => '-'.repeat(widths[k])).join('-+-'));
+
+  // Rows
+  for (const row of rows) {
+    const line = displayKeys.map(k => pad(formatValue(row[k]), widths[k])).join(' | ');
+    console.log(line);
+  }
+
+  console.log(`\n${rows.length} result${rows.length === 1 ? '' : 's'}`);
+}
+
+function printKeyValue(obj: Record<string, unknown>): void {
+  const maxKeyLen = Math.max(...Object.keys(obj).map(k => k.length));
+  for (const [key, value] of Object.entries(obj)) {
+    const val = formatValue(value);
+    const display = val.length > 200 ? val.slice(0, 200) + '...' : val;
+    console.log(`${key.padEnd(maxKeyLen)}  ${display}`);
+  }
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function pad(str: string, width: number): string {
+  if (str.length > width) return str.slice(0, width - 1) + '…';
+  return str.padEnd(width);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -34,17 +34,13 @@ function parseArgs(args: string[]): {
   const flags: Record<string, string> = {};
   const positional: string[] = [];
 
-  let i = 0;
-  // First two positional args are resource and action
-  const resource = args[i++] || '';
-  const action = args[i++] || '';
-
-  while (i < args.length) {
+  // First pass: extract all --flags from anywhere in the args
+  const remaining: string[] = [];
+  for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg.startsWith('--')) {
       const key = arg.slice(2);
       const next = args[i + 1];
-      // Boolean flags (no value following, or next arg is also a flag)
       if (!next || next.startsWith('--')) {
         flags[key] = 'true';
       } else {
@@ -52,10 +48,14 @@ function parseArgs(args: string[]): {
         i++;
       }
     } else {
-      positional.push(arg);
+      remaining.push(arg);
     }
-    i++;
   }
+
+  // First two remaining positional args are resource and action
+  const resource = remaining[0] || '';
+  const action = remaining[1] || '';
+  positional.push(...remaining.slice(2));
 
   return { resource, action, positional, flags };
 }
@@ -82,6 +82,11 @@ async function main(): Promise<void> {
 
   if (args.length === 0 || args[0] === 'help' || args[0] === '--help' || args[0] === '-h') {
     printHelp();
+    return;
+  }
+
+  if (args[0] === '--version' || args[0] === '-v') {
+    console.log('lector-cli 0.1.0');
     return;
   }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+import { loadConfig } from './config';
+import { ApiClient } from './client';
+import { output, type Format } from './format';
+
+import * as auth from './commands/auth';
+import * as collections from './commands/collections';
+import * as lessons from './commands/lessons';
+import * as vocab from './commands/vocab';
+import * as cloze from './commands/cloze';
+import * as stats from './commands/stats';
+import * as settings from './commands/settings';
+import * as data from './commands/data';
+import * as tokens from './commands/tokens';
+
+const COMMANDS: Record<string, { handle: typeof auth.handle; description: string }> = {
+  auth:        { handle: auth.handle,        description: 'Configure API access (login, logout, status, verify)' },
+  collections: { handle: collections.handle, description: 'Manage collections (list, get, create, update, delete, lessons, add-lesson)' },
+  lessons:     { handle: lessons.handle,     description: 'Manage lessons (get, update, delete, progress)' },
+  vocab:       { handle: vocab.handle,       description: 'Manage vocabulary (list, get, create, update, delete)' },
+  cloze:       { handle: cloze.handle,       description: 'Manage cloze sentences (list, due, counts, get, review, delete)' },
+  stats:       { handle: stats.handle,       description: 'View and update stats (today, range, streak, increment)' },
+  settings:    { handle: settings.handle,    description: 'Manage settings (list, get, set, delete)' },
+  data:        { handle: data.handle,        description: 'Export and import data (export, import)' },
+  tokens:      { handle: tokens.handle,      description: 'Manage API tokens (list, create, revoke)' },
+};
+
+function parseArgs(args: string[]): {
+  resource: string;
+  action: string;
+  positional: string[];
+  flags: Record<string, string>;
+} {
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+
+  let i = 0;
+  // First two positional args are resource and action
+  const resource = args[i++] || '';
+  const action = args[i++] || '';
+
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = args[i + 1];
+      // Boolean flags (no value following, or next arg is also a flag)
+      if (!next || next.startsWith('--')) {
+        flags[key] = 'true';
+      } else {
+        flags[key] = next;
+        i++;
+      }
+    } else {
+      positional.push(arg);
+    }
+    i++;
+  }
+
+  return { resource, action, positional, flags };
+}
+
+function printHelp(): void {
+  console.log('Usage: lector <resource> <action> [id] [--flags]');
+  console.log('\nResources:');
+  for (const [name, { description }] of Object.entries(COMMANDS)) {
+    console.log(`  ${name.padEnd(14)} ${description}`);
+  }
+  console.log('\nGlobal flags:');
+  console.log('  --format     json | table (default: table)');
+  console.log('  --api-url    Override API URL');
+  console.log('  --token      Override auth token');
+  console.log('\nExamples:');
+  console.log('  lector collections list');
+  console.log('  lector vocab list --state known --format json');
+  console.log('  lector tokens create --name "CLI" --scopes "*"');
+  console.log('  lector auth login --token ltr_...');
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === 'help' || args[0] === '--help' || args[0] === '-h') {
+    printHelp();
+    return;
+  }
+
+  const { resource, action, positional, flags } = parseArgs(args);
+
+  if (resource === 'help' || action === 'help') {
+    printHelp();
+    return;
+  }
+
+  const command = COMMANDS[resource];
+  if (!command) {
+    console.error(`Unknown resource: ${resource}`);
+    console.error(`Run 'lector help' for available commands.`);
+    process.exit(1);
+  }
+
+  if (!action) {
+    console.error(`Missing action for ${resource}.`);
+    console.error(`Run 'lector ${resource} help' for available actions.`);
+    process.exit(1);
+  }
+
+  // Build config with flag overrides
+  const config = loadConfig();
+  const apiUrl = flags['api-url'] || config.apiUrl;
+  const token = flags.token || config.token;
+  const format: Format = (flags.format as Format) || config.format || 'table';
+
+  const client = new ApiClient(apiUrl, token);
+  const id = positional[0];
+
+  try {
+    await command.handle(client, action, id, flags, format);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/e2e/tokens.spec.ts
+++ b/e2e/tokens.spec.ts
@@ -97,7 +97,8 @@ test.describe("API Tokens", () => {
     // Token should be listed
     await expect(page.getByText("Test Revoke")).toBeVisible();
 
-    // Click Revoke
+    // Click Revoke and accept confirmation dialog
+    page.on("dialog", (dialog) => dialog.accept());
     const tokenRow = page.locator("div").filter({ hasText: "Test Revoke" }).first();
     await tokenRow.getByRole("button", { name: "Revoke" }).click();
 

--- a/e2e/tokens.spec.ts
+++ b/e2e/tokens.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("API Tokens", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    // Clean up any existing test tokens via API
+    const res = await page.request.get("/api/tokens");
+    const tokens = await res.json();
+    for (const t of tokens) {
+      if (t.name.startsWith("Test") || t.name.startsWith("E2E")) {
+        await page.request.delete(`/api/tokens/${t.id}`);
+      }
+    }
+  });
+
+  test("should create a token, show it once, and list it", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Scroll to API Tokens section
+    const section = page.getByText("API Tokens");
+    await expect(section.first()).toBeVisible();
+
+    // Click Generate Token
+    await page.getByRole("button", { name: "Generate Token" }).click();
+
+    // Fill in name
+    await page.getByPlaceholder("e.g. CLI, Automation, Backup script").fill("Test Token");
+
+    // Full Access should be checked by default
+    const fullAccessCheckbox = page.locator("label").filter({ hasText: "Full Access" }).locator("input[type='checkbox']");
+    await expect(fullAccessCheckbox).toBeChecked();
+
+    // Click Create Token
+    await page.getByRole("button", { name: "Create Token" }).click();
+
+    // Should show the one-time token display
+    await expect(
+      page.getByText("Copy this token now")
+    ).toBeVisible();
+
+    // Token should start with ltr_
+    const tokenCode = page.locator("code");
+    const tokenText = await tokenCode.textContent();
+    expect(tokenText).toMatch(/^ltr_/);
+
+    // Click "I've saved this token"
+    await page.getByText("I've saved this token").click();
+
+    // One-time display should be gone
+    await expect(
+      page.getByText("Copy this token now")
+    ).not.toBeVisible();
+
+    // Token should appear in the list
+    await expect(page.getByText("Test Token")).toBeVisible();
+    await expect(page.getByText("Full Access")).toBeVisible();
+  });
+
+  test("should create a scoped token", async ({ page }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: "Generate Token" }).click();
+    await page.getByPlaceholder("e.g. CLI, Automation, Backup script").fill("E2E Scoped");
+
+    // Uncheck Full Access
+    const fullAccessLabel = page.locator("label").filter({ hasText: "Full Access" });
+    await fullAccessLabel.click();
+
+    // Check specific scopes
+    await page.locator("label").filter({ hasText: "Collections (read)" }).click();
+    await page.locator("label").filter({ hasText: "Stats (read)" }).click();
+
+    await page.getByRole("button", { name: "Create Token" }).click();
+
+    // Verify token is shown
+    await expect(page.getByText("Copy this token now")).toBeVisible();
+    await page.getByText("I've saved this token").click();
+
+    // Verify scope badges
+    await expect(page.getByText("collections:read")).toBeVisible();
+    await expect(page.getByText("stats:read")).toBeVisible();
+  });
+
+  test("should revoke a token", async ({ page }) => {
+    // Create a token via API first
+    await page.request.post("/api/tokens", {
+      data: { name: "Test Revoke", scopes: ["*"] },
+    });
+
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Token should be listed
+    await expect(page.getByText("Test Revoke")).toBeVisible();
+
+    // Click Revoke
+    const tokenRow = page.locator("div").filter({ hasText: "Test Revoke" }).first();
+    await tokenRow.getByRole("button", { name: "Revoke" }).click();
+
+    // Token should be gone
+    await expect(page.getByText("Test Revoke")).not.toBeVisible();
+  });
+
+  test("should disable Create button when name is empty", async ({ page }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: "Generate Token" }).click();
+
+    // Create Token button should be disabled when name is empty
+    const createBtn = page.getByRole("button", { name: "Create Token" });
+    await expect(createBtn).toBeDisabled();
+
+    // Fill in name - button should become enabled
+    await page.getByPlaceholder("e.g. CLI, Automation, Backup script").fill("Test");
+    await expect(createBtn).toBeEnabled();
+
+    // Clear name - button should be disabled again
+    await page.getByPlaceholder("e.g. CLI, Automation, Backup script").fill("");
+    await expect(createBtn).toBeDisabled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "fetch-sentences": "npx tsx scripts/fetch-sentences.ts"
+    "fetch-sentences": "npx tsx scripts/fetch-sentences.ts",
+    "cli": "bun run cli/src/index.ts"
   },
   "dependencies": {
     "@mozilla/readability": "^0.6.0",

--- a/src/app/api/tokens/[id]/route.ts
+++ b/src/app/api/tokens/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+
+// DELETE /api/tokens/:id - Revoke a token
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const result = db.prepare('DELETE FROM api_tokens WHERE id = ?').run(id);
+
+  if (result.changes === 0) {
+    return NextResponse.json({ error: 'Token not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, ApiTokenRow } from '@/lib/server/database';
-import { randomUUID, randomBytes, createHash } from 'crypto';
-
-function hashToken(token: string): string {
-  return createHash('sha256').update(token).digest('hex');
-}
+import { randomUUID, randomBytes } from 'crypto';
+import { hashToken } from '@/lib/server/crypto';
 
 // GET /api/tokens - List all tokens (metadata only)
 export async function GET() {

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, ApiTokenRow } from '@/lib/server/database';
+import { randomUUID, randomBytes, createHash } from 'crypto';
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// GET /api/tokens - List all tokens (metadata only)
+export async function GET() {
+  const rows = db.prepare(
+    'SELECT id, name, scopes, createdAt, lastUsedAt, expiresAt FROM api_tokens ORDER BY createdAt DESC'
+  ).all() as Omit<ApiTokenRow, 'tokenHash'>[];
+
+  return NextResponse.json(rows.map(row => ({
+    ...row,
+    scopes: JSON.parse(row.scopes as string),
+  })));
+}
+
+// POST /api/tokens - Create a new token
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { name, scopes = ['*'], expiresAt } = body;
+
+  if (!name || typeof name !== 'string') {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+  }
+
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    return NextResponse.json({ error: 'Scopes must be a non-empty array' }, { status: 400 });
+  }
+
+  const bytes = randomBytes(32);
+  const token = `ltr_${bytes.toString('base64url')}`;
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  db.prepare(`
+    INSERT INTO api_tokens (id, name, tokenHash, scopes, createdAt, expiresAt)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(id, name, hashToken(token), JSON.stringify(scopes), now, expiresAt || null);
+
+  return NextResponse.json({
+    id,
+    name,
+    token,
+    scopes,
+    createdAt: now,
+    expiresAt: expiresAt || null,
+  }, { status: 201 });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -17,6 +17,10 @@ import {
   getVocabByText,
   saveVocab,
   updateVocabState,
+  getApiTokens,
+  createApiToken,
+  revokeApiToken,
+  type ApiTokenMeta,
   type VocabEntry,
   type KnownWord,
   type WordState,
@@ -104,6 +108,15 @@ export default function SettingsPage() {
   const [googleTTSAvailable, setGoogleTTSAvailable] = useState<boolean | null>(null);
   const [showGoogleApiKey, setShowGoogleApiKey] = useState(false);
 
+  // API Token state
+  const [apiTokens, setApiTokens] = useState<ApiTokenMeta[]>([]);
+  const [showTokenForm, setShowTokenForm] = useState(false);
+  const [newTokenName, setNewTokenName] = useState("");
+  const [newTokenScopes, setNewTokenScopes] = useState<string[]>(["*"]);
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
   // Load settings from localStorage on mount
   useEffect(() => {
     const loadedSettings: AppSettings = {
@@ -145,6 +158,9 @@ export default function SettingsPage() {
 
     // Check LLM status
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+
+    // Load API tokens
+    getApiTokens().then(setApiTokens).catch(() => {});
   }, []);
 
   // Check Anki connection
@@ -994,6 +1010,233 @@ export default function SettingsPage() {
                 ))}
               </div>
             </div>
+          </section>
+
+          {/* API Tokens Section */}
+          <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                API Tokens
+              </h2>
+              {!showTokenForm && !createdToken && (
+                <button
+                  onClick={() => { setShowTokenForm(true); setTokenError(null); }}
+                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                >
+                  Generate Token
+                </button>
+              )}
+            </div>
+
+            <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+              Create personal access tokens for CLI or API access. Tokens are scoped to specific permissions.
+            </p>
+
+            {tokenError && (
+              <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+                {tokenError}
+              </div>
+            )}
+
+            {/* One-time token display */}
+            {createdToken && (
+              <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-900/20">
+                <p className="mb-2 text-sm font-medium text-amber-800 dark:text-amber-300">
+                  Copy this token now — it won&apos;t be shown again.
+                </p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 rounded bg-white px-3 py-2 font-mono text-sm text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100 select-all break-all border border-amber-200 dark:border-amber-800">
+                    {createdToken}
+                  </code>
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(createdToken);
+                      setTokenCopied(true);
+                      setTimeout(() => setTokenCopied(false), 2000);
+                    }}
+                    className="shrink-0 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                  >
+                    {tokenCopied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
+                <button
+                  onClick={() => setCreatedToken(null)}
+                  className="mt-3 text-sm text-amber-700 underline hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-300"
+                >
+                  I&apos;ve saved this token
+                </button>
+              </div>
+            )}
+
+            {/* Create token form */}
+            {showTokenForm && (
+              <div className="mb-4 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+                <div className="mb-3">
+                  <label className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Token Name
+                  </label>
+                  <input
+                    type="text"
+                    value={newTokenName}
+                    onChange={(e) => setNewTokenName(e.target.value)}
+                    placeholder="e.g. CLI, Automation, Backup script"
+                    className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  />
+                </div>
+
+                <div className="mb-3">
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Scopes
+                  </label>
+                  <div className="grid grid-cols-2 gap-2">
+                    {[
+                      { value: "*", label: "Full Access" },
+                      { value: "collections:read", label: "Collections (read)" },
+                      { value: "collections:write", label: "Collections (write)" },
+                      { value: "vocab:read", label: "Vocabulary (read)" },
+                      { value: "vocab:write", label: "Vocabulary (write)" },
+                      { value: "stats:read", label: "Stats (read)" },
+                      { value: "stats:write", label: "Stats (write)" },
+                      { value: "settings:read", label: "Settings (read)" },
+                      { value: "settings:write", label: "Settings (write)" },
+                      { value: "data:export", label: "Data Export" },
+                      { value: "data:import", label: "Data Import" },
+                    ].map(({ value, label }) => (
+                      <label
+                        key={value}
+                        className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
+                          newTokenScopes.includes(value)
+                            ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400"
+                            : "border-zinc-300 bg-white text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                        } ${
+                          newTokenScopes.includes("*") && value !== "*"
+                            ? "opacity-50 cursor-not-allowed"
+                            : "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={newTokenScopes.includes("*") || newTokenScopes.includes(value)}
+                          disabled={newTokenScopes.includes("*") && value !== "*"}
+                          onChange={(e) => {
+                            if (value === "*") {
+                              setNewTokenScopes(e.target.checked ? ["*"] : []);
+                            } else {
+                              setNewTokenScopes((prev) =>
+                                e.target.checked
+                                  ? [...prev.filter((s) => s !== "*"), value]
+                                  : prev.filter((s) => s !== value)
+                              );
+                            }
+                          }}
+                          className="rounded"
+                        />
+                        {label}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={async () => {
+                      if (!newTokenName.trim()) {
+                        setTokenError("Token name is required");
+                        return;
+                      }
+                      if (newTokenScopes.length === 0) {
+                        setTokenError("Select at least one scope");
+                        return;
+                      }
+                      try {
+                        setTokenError(null);
+                        const result = await createApiToken({
+                          name: newTokenName.trim(),
+                          scopes: newTokenScopes,
+                        });
+                        setCreatedToken(result.token);
+                        setShowTokenForm(false);
+                        setNewTokenName("");
+                        setNewTokenScopes(["*"]);
+                        const tokens = await getApiTokens();
+                        setApiTokens(tokens);
+                      } catch (err) {
+                        setTokenError(err instanceof Error ? err.message : "Failed to create token");
+                      }
+                    }}
+                    disabled={!newTokenName.trim() || newTokenScopes.length === 0}
+                    className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Create Token
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowTokenForm(false);
+                      setNewTokenName("");
+                      setNewTokenScopes(["*"]);
+                      setTokenError(null);
+                    }}
+                    className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Token list */}
+            {apiTokens.length > 0 ? (
+              <div className="space-y-2">
+                {apiTokens.map((token) => (
+                  <div
+                    key={token.id}
+                    className="flex items-center justify-between rounded-md border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-700 dark:bg-zinc-800/50"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-sm text-zinc-900 dark:text-zinc-100">
+                          {token.name}
+                        </span>
+                        <div className="flex flex-wrap gap-1">
+                          {(token.scopes.includes("*")
+                            ? ["Full Access"]
+                            : token.scopes
+                          ).map((scope) => (
+                            <span
+                              key={scope}
+                              className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                            >
+                              {scope}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                        Created {new Date(token.createdAt).toLocaleDateString()}
+                        {token.lastUsedAt
+                          ? ` · Last used ${new Date(token.lastUsedAt).toLocaleDateString()}`
+                          : " · Never used"}
+                      </div>
+                    </div>
+                    <button
+                      onClick={async () => {
+                        await revokeApiToken(token.id);
+                        setApiTokens((prev) => prev.filter((t) => t.id !== token.id));
+                      }}
+                      className="ml-3 shrink-0 rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700"
+                    >
+                      Revoke
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              !showTokenForm && (
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  No tokens created yet. Generate one to use the CLI or access the API remotely.
+                </p>
+              )
+            )}
           </section>
 
           {/* Known Words Import Section */}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1220,6 +1220,7 @@ export default function SettingsPage() {
                     </div>
                     <button
                       onClick={async () => {
+                        if (!confirm(`Revoke token "${token.name}"? This cannot be undone.`)) return;
                         await revokeApiToken(token.id);
                         setApiTokens((prev) => prev.filter((t) => t.id !== token.id));
                       }}

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -584,6 +584,49 @@ export async function getAllSettings(): Promise<Record<string, unknown>> {
 }
 
 // ============================================================================
+// Helper Functions - API Tokens
+// ============================================================================
+
+export interface ApiTokenMeta {
+  id: string;
+  name: string;
+  scopes: string[];
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+}
+
+export interface ApiTokenCreateResponse extends ApiTokenMeta {
+  token: string;
+}
+
+export async function getApiTokens(): Promise<ApiTokenMeta[]> {
+  const res = await fetch('/api/tokens');
+  return res.json();
+}
+
+export async function createApiToken(data: {
+  name: string;
+  scopes: string[];
+  expiresAt?: string;
+}): Promise<ApiTokenCreateResponse> {
+  const res = await fetch('/api/tokens', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to create token');
+  }
+  return res.json();
+}
+
+export async function revokeApiToken(id: string): Promise<void> {
+  await fetch(`/api/tokens/${id}`, { method: 'DELETE' });
+}
+
+// ============================================================================
 // Utility Functions
 // ============================================================================
 

--- a/src/lib/server/crypto.ts
+++ b/src/lib/server/crypto.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'crypto';
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -115,6 +115,16 @@ function getDb(): DatabaseType {
       value TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      tokenHash TEXT NOT NULL UNIQUE,
+      scopes TEXT NOT NULL DEFAULT '["*"]',
+      createdAt TEXT NOT NULL,
+      lastUsedAt TEXT,
+      expiresAt TEXT
+    );
+
     CREATE TABLE IF NOT EXISTS journal_entries (
       id TEXT PRIMARY KEY,
       body TEXT NOT NULL DEFAULT '',
@@ -423,6 +433,16 @@ export interface SettingRow {
 }
 
 export type JournalStatus = 'draft' | 'submitted';
+
+export interface ApiTokenRow {
+  id: string;
+  name: string;
+  tokenHash: string;
+  scopes: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+}
 
 export interface JournalEntryRow {
   id: string;


### PR DESCRIPTION
## Summary
- Add a **Personal Access Token (PAT) system** with scoped permissions for API authentication
- Add a **CLI tool** (`lector`) for all CRUD operations against the API
- Auth is **opt-in**: no Bearer token = full local access (browser, curl). Tokens gate remote/CLI access with granular scopes.

### PAT System
- `api_tokens` table with SHA-256 hashed token storage (plain token returned once on creation)
- Hono middleware validates `Authorization: Bearer <token>` header, checks scopes, rejects with 401/403
- Timing-safe hash comparison via `crypto.timingSafeEqual`
- Scopes: `collections:read/write`, `vocab:read/write`, `stats:read/write`, `settings:read/write`, `data:export/import`, `*` (full access)
- Token CRUD endpoints: `POST /api/tokens`, `GET /api/tokens`, `DELETE /api/tokens/:id`, `POST /api/tokens/verify`
- Token management routes blocked for PAT access (prevents privilege escalation)

### Settings UI
- New "API Tokens" section with Generate Token button, scope selection checkboxes, one-time token display with copy, and token list with Revoke (with confirmation dialog)

### CLI Tool (`cli/src/`)
- Commands: `collections`, `lessons`, `vocab`, `cloze`, `stats`, `settings`, `data`, `tokens`, `auth`
- Output formats: `--format table` (default) or `--format json`
- Config at `~/.config/lector/config.json` (API URL + token, 0600 permissions)
- Zero external dependencies — Bun built-ins only

## Test plan
- [x] Unit tests: 14 auth middleware tests (valid/invalid/expired tokens, scope checking, wildcard scopes, PAT-blocked token routes)
- [x] E2E tests: 4 Playwright tests (create token, scoped token, revoke with confirmation, disabled button validation)
- [x] Full suite: 58 passed, 1 skipped, 0 failed
- [x] Manual: create token in Settings UI, copy it, use in CLI (`lector auth login --token ...`), run `lector collections list` - [proof](https://github.com/heuwels/lector/pull/44#issuecomment-4276008077)
- [x] Manual: create scoped token (stats:read only), verify it can read stats but not collections - [proof](https://github.com/heuwels/lector/pull/44#issuecomment-4276008077)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
