### PR TITLE
feat: inline per-word definitions in Cloze practice

### DIFF
--- a/e2e/cloze-definitions.spec.ts
+++ b/e2e/cloze-definitions.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect, Page } from "@playwright/test";
+
+const TEST_COLLECTION = "top500";
+const TEST_SENTENCE_ID = "test-inline-def-1";
+
+// Seed a cloze sentence where the non-cloze words are in the dictionary
+// "die" -> "the" (rank 1 in dictionary)
+// "kat" is the cloze word (blanked out)
+// "is" -> "is" (rank 4 in dictionary)
+const testSentence = {
+  id: TEST_SENTENCE_ID,
+  sentence: "Die kat is groot.",
+  clozeWord: "kat",
+  clozeIndex: 1,
+  translation: "The cat is big.",
+  source: "tatoeba",
+  collection: TEST_COLLECTION,
+  masteryLevel: 0,
+  nextReview: new Date().toISOString(),
+  reviewCount: 0,
+  timesCorrect: 0,
+  timesIncorrect: 0,
+};
+
+// Helper: navigate to practice and start a type-mode round
+async function startTypeRound(page: Page) {
+  await page.goto("/practice");
+  await expect(page.getByRole("button", { name: "Start" })).toBeVisible({
+    timeout: 30000,
+  });
+
+  // Scope to Learn New section to avoid clicking Review Due buttons
+  const learnNewSection = page.getByText("Learn New").locator("..");
+  await learnNewSection
+    .getByRole("button", { name: /Top 500/ })
+    .first()
+    .click();
+  await page.getByRole("button", { name: "10", exact: true }).click();
+  await page.getByRole("button", { name: "Type" }).click();
+  await page.getByRole("button", { name: "Start" }).click();
+
+  await expect(page.getByText("Fill in the blank")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+test.describe("Cloze Inline Definitions", () => {
+  test.beforeEach(async ({ page }) => {
+    // Seed the test sentence
+    const res = await page.request.post("http://localhost:3456/api/cloze", {
+      data: [testSentence],
+    });
+    expect(res.ok()).toBeTruthy();
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Clean up
+    await page.request.delete(
+      `http://localhost:3456/api/cloze/${TEST_SENTENCE_ID}`
+    );
+  });
+
+  test("should show translation popup when tapping a word in practicing state", async ({
+    page,
+  }) => {
+    await startTypeRound(page);
+
+    // Find a clickable word (non-cloze word) and click it
+    const clozeWords = page.locator('[data-testid="cloze-word"]');
+    await expect(clozeWords.first()).toBeVisible();
+
+    // Click the first clickable word
+    await clozeWords.first().click();
+
+    // The word definition popup should appear
+    const popup = page.locator('[data-testid="word-definition-popup"]');
+    await expect(popup).toBeVisible({ timeout: 5000 });
+
+    // Should show an arrow (translation separator)
+    await expect(popup.locator("text=\u2192")).toBeVisible();
+  });
+
+  test("should show dictionary translation for known words", async ({
+    page,
+  }) => {
+    await startTypeRound(page);
+
+    const clozeWords = page.locator('[data-testid="cloze-word"]');
+    await expect(clozeWords.first()).toBeVisible();
+
+    // Click a word
+    const wordText = await clozeWords.first().textContent();
+    await clozeWords.first().click();
+
+    // Popup should appear with the word we clicked
+    const popup = page.locator('[data-testid="word-definition-popup"]');
+    await expect(popup).toBeVisible({ timeout: 5000 });
+
+    // The word text should appear in the popup (stripped of punctuation)
+    if (wordText) {
+      const cleanWord = wordText.replace(/[.,!?;:'")\]]+$/, "");
+      await expect(
+        popup.getByText(cleanWord, { exact: false })
+      ).toBeVisible();
+    }
+  });
+
+  test("should close the popup when clicking the close button", async ({
+    page,
+  }) => {
+    await startTypeRound(page);
+
+    const clozeWords = page.locator('[data-testid="cloze-word"]');
+    await expect(clozeWords.first()).toBeVisible();
+    await clozeWords.first().click();
+
+    const popup = page.locator('[data-testid="word-definition-popup"]');
+    await expect(popup).toBeVisible({ timeout: 5000 });
+
+    // Close the popup
+    await popup.locator('button[title="Close"]').click();
+    await expect(popup).not.toBeVisible();
+  });
+
+  test("should clear popup when advancing to next sentence", async ({
+    page,
+  }) => {
+    await startTypeRound(page);
+
+    // Click a word to open popup
+    const clozeWords = page.locator('[data-testid="cloze-word"]');
+    await expect(clozeWords.first()).toBeVisible();
+    await clozeWords.first().click();
+
+    const popup = page.locator('[data-testid="word-definition-popup"]');
+    await expect(popup).toBeVisible({ timeout: 5000 });
+
+    // Type a wrong answer and submit to get feedback
+    const input = page.locator('input[placeholder="..."]');
+    await input.fill("zzzzz");
+    await input.press("Enter");
+
+    // Wait for feedback
+    await expect(
+      page.getByRole("heading", { name: "Incorrect" })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Click Next Sentence
+    await page.getByRole("button", { name: "Next Sentence" }).click();
+
+    // Popup should be cleared on the new sentence
+    await page.waitForTimeout(500);
+    await expect(popup).not.toBeVisible();
+  });
+
+  test("should show clickable words in feedback state too", async ({
+    page,
+  }) => {
+    await startTypeRound(page);
+
+    // Submit a wrong answer to get to feedback state
+    const input = page.locator('input[placeholder="..."]');
+    await input.fill("zzzzz");
+    await input.press("Enter");
+
+    await expect(
+      page.getByRole("heading", { name: "Incorrect" })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Words in the feedback sentence should be clickable
+    const clozeWords = page.locator('[data-testid="cloze-word"]');
+    await expect(clozeWords.first()).toBeVisible();
+
+    // Click a word
+    await clozeWords.first().click();
+
+    // Popup should appear
+    const popup = page.locator('[data-testid="word-definition-popup"]');
+    await expect(popup).toBeVisible({ timeout: 5000 });
+  });
+
+  test("cloze blank word should not be clickable", async ({ page }) => {
+    await startTypeRound(page);
+
+    // The input field (cloze word) should NOT have data-testid="cloze-word"
+    const inputField = page.locator('input[placeholder="..."]');
+    await expect(inputField).toBeVisible();
+
+    // Verify the input is NOT wrapped in a cloze-word testid
+    const clozeWordInput = page.locator(
+      '[data-testid="cloze-word"] input[placeholder="..."]'
+    );
+    await expect(clozeWordInput).not.toBeVisible();
+  });
+});

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -21,6 +21,8 @@ import {
 import { speak, isTTSAvailable } from '@/lib/tts';
 import { playCorrectSound, playIncorrectSound } from '@/lib/sounds';
 import { addClozeCard, isAnkiConnected } from '@/lib/anki';
+import { translateWord } from '@/lib/claude';
+import { lookupWord } from '@/lib/dictionary';
 
 const ANKI_CLOZE_DECK_SETTING_KEY = 'lector-anki-cloze-deck';
 const DEFAULT_ANKI_CLOZE_DECK = 'Afrikaans::Cloze';
@@ -206,6 +208,14 @@ export default function PracticePage() {
   const [retryQueue, setRetryQueue] = useState<ClozeSentence[]>([]);
   const [blacklistToast, setBlacklistToast] = useState(false);
 
+  // Word definition tooltip state
+  const [wordTooltip, setWordTooltip] = useState<{
+    word: string;
+    translation: string | null;
+    partOfSpeech: string | null;
+    isLoading: boolean;
+  } | null>(null);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const submittingRef = useRef(false);
 
@@ -240,6 +250,46 @@ export default function PracticePage() {
     setPracticeMode(mode);
     localStorage.setItem('cloze-practice-mode', mode);
   }, []);
+
+  // Handle word click for inline definitions
+  const handleWordClick = useCallback(async (word: string) => {
+    if (!current) return;
+    const [cleanWord] = splitTrailingPunctuation(word);
+    if (!cleanWord) return;
+
+    // Show loading state
+    setWordTooltip({ word: cleanWord, translation: null, partOfSpeech: null, isLoading: true });
+
+    // Try local dictionary first (instant, no network)
+    const dictEntry = lookupWord(cleanWord);
+    if (dictEntry) {
+      setWordTooltip({
+        word: cleanWord,
+        translation: dictEntry.translation,
+        partOfSpeech: dictEntry.partOfSpeech || null,
+        isLoading: false,
+      });
+      return;
+    }
+
+    // Fall back to translate API
+    try {
+      const result = await translateWord(cleanWord, current.sentence.sentence);
+      setWordTooltip({
+        word: cleanWord,
+        translation: result.translation,
+        partOfSpeech: result.partOfSpeech || null,
+        isLoading: false,
+      });
+    } catch {
+      setWordTooltip({
+        word: cleanWord,
+        translation: null,
+        partOfSpeech: null,
+        isLoading: false,
+      });
+    }
+  }, [current]);
 
   // Generate MC options when current sentence or queue changes
   const generateMcOptionsForSentence = useCallback((sentence: ClozeSentence, sentenceQueue: ClozeSentence[]) => {
@@ -279,6 +329,7 @@ export default function PracticePage() {
     setAnkiError(null);
     setHintLetters(0);
     setMcFallback(false);
+    setWordTooltip(null);
     submittingRef.current = false;
     setState('practicing');
 
@@ -867,7 +918,13 @@ export default function PracticePage() {
                             </span>
                           )
                         ) : (
-                          word
+                          <span
+                            data-testid="cloze-word"
+                            onClick={() => handleWordClick(word)}
+                            className="cursor-pointer rounded px-0.5 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:hover:bg-blue-900/40 dark:hover:text-blue-300"
+                          >
+                            {word}
+                          </span>
                         )}
                       </span>
                     ))}
@@ -1015,7 +1072,13 @@ export default function PracticePage() {
                           {word}
                         </span>
                       ) : (
-                        word
+                        <span
+                          data-testid="cloze-word"
+                          onClick={() => handleWordClick(word)}
+                          className="cursor-pointer rounded px-0.5 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:hover:bg-blue-900/40 dark:hover:text-blue-300"
+                        >
+                          {word}
+                        </span>
                       )}
                     </span>
                   ))}
@@ -1125,6 +1188,49 @@ export default function PracticePage() {
         )}
 
       </main>
+
+      {/* Word definition tooltip bar */}
+      {wordTooltip && (
+        <div
+          data-testid="word-definition-popup"
+          className="fixed bottom-0 left-0 right-0 z-50 border-t border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
+        >
+          <div className="mx-auto flex max-w-2xl items-center gap-3 px-4 py-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline gap-2 flex-wrap">
+                <span className="text-lg font-bold text-zinc-900 dark:text-zinc-100">
+                  {wordTooltip.word}
+                </span>
+                {wordTooltip.partOfSpeech && (
+                  <span className="text-xs italic text-zinc-500 dark:text-zinc-400">
+                    {wordTooltip.partOfSpeech}
+                  </span>
+                )}
+                <span className="text-zinc-400 dark:text-zinc-500">&rarr;</span>
+                {wordTooltip.isLoading ? (
+                  <span className="flex items-center gap-1 text-zinc-500 dark:text-zinc-400">
+                    <span className="h-3 w-3 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+                  </span>
+                ) : (
+                  <span className="text-zinc-700 dark:text-zinc-300">
+                    {wordTooltip.translation || 'No translation found'}
+                  </span>
+                )}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setWordTooltip(null)}
+              className="rounded p-1.5 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700"
+              title="Close"
+            >
+              <svg className="h-4 w-4 text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds tap-to-translate to cloze practice sentences, matching the reader's word panel pattern
- Tapping any non-blank word shows a fixed bottom bar with the word's translation and part of speech
- Uses the local dictionary for instant offline lookups; falls back to the `/api/translate` endpoint for unknown words
- Works in both the practicing state (while answering) and the feedback state (after submitting)
- The blanked cloze word is not clickable (it remains the answer input)
- Tooltip clears automatically when advancing to the next sentence

## Test plan
- [x] E2E: `e2e/cloze-definitions.spec.ts` with 6 tests covering:
  - Popup appears when tapping a word in practicing state
  - Dictionary translation shown for known words
  - Close button dismisses the popup
  - Popup clears when advancing to next sentence
  - Clickable words in feedback state
  - Cloze blank word is not clickable
- [x] Full e2e suite passes locally (60 passed, 1 skipped, 0 failures)

Closes #40
