### PR TITLE
feat: fluency benchmarks with CEFR level estimation

### DIFF
--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -74,6 +74,88 @@ app.put('/today', async (c) => {
   return c.json({ success: true });
 });
 
+// GET /api/stats/fluency
+app.get('/fluency', (c) => {
+  // Count words by state from knownWords table
+  const stateCounts = db.prepare(
+    'SELECT state, COUNT(*) as count FROM knownWords GROUP BY state'
+  ).all() as { state: string; count: number }[];
+
+  const countMap: Record<string, number> = {};
+  for (const row of stateCounts) {
+    countMap[row.state] = row.count;
+  }
+
+  const totalKnownWords = countMap['known'] || 0;
+  const totalLearning =
+    (countMap['level1'] || 0) +
+    (countMap['level2'] || 0) +
+    (countMap['level3'] || 0) +
+    (countMap['level4'] || 0);
+  const totalNew = countMap['new'] || 0;
+
+  // Determine CEFR-style level
+  const levels = [
+    { min: 0, max: 500, code: 'A1', label: 'Beginner' },
+    { min: 500, max: 1500, code: 'A2', label: 'Elementary' },
+    { min: 1500, max: 3000, code: 'B1', label: 'Intermediate' },
+    { min: 3000, max: 5000, code: 'B2', label: 'Upper Intermediate' },
+    { min: 5000, max: 8000, code: 'C1', label: 'Advanced' },
+    { min: 8000, max: Infinity, code: 'C2', label: 'Proficiency' },
+  ];
+
+  const currentLevel = levels.find(
+    (l) => totalKnownWords >= l.min && totalKnownWords < l.max
+  ) || levels[levels.length - 1];
+
+  const progressToNextLevel =
+    currentLevel.max === Infinity
+      ? 100
+      : Math.round(
+          ((totalKnownWords - currentLevel.min) /
+            (currentLevel.max - currentLevel.min)) *
+            100
+        );
+
+  // Weekly growth: words marked known in last 7 days vs previous 7 days
+  const today = getTodayDate();
+  const d7 = new Date();
+  d7.setDate(d7.getDate() - 6);
+  const weekStart = d7.toISOString().split('T')[0];
+
+  const d14 = new Date();
+  d14.setDate(d14.getDate() - 13);
+  const prevWeekStart = d14.toISOString().split('T')[0];
+
+  const d8 = new Date();
+  d8.setDate(d8.getDate() - 7);
+  const prevWeekEnd = d8.toISOString().split('T')[0];
+
+  const thisWeekRow = db.prepare(
+    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ?'
+  ).get(weekStart, today) as { total: number };
+
+  const prevWeekRow = db.prepare(
+    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ?'
+  ).get(prevWeekStart, prevWeekEnd) as { total: number };
+
+  return c.json({
+    totalKnownWords,
+    totalLearning,
+    totalNew,
+    estimatedLevel: {
+      code: currentLevel.code,
+      label: currentLevel.label,
+    },
+    progressToNextLevel,
+    weeklyGrowth: {
+      thisWeek: thisWeekRow.total,
+      lastWeek: prevWeekRow.total,
+      delta: thisWeekRow.total - prevWeekRow.total,
+    },
+  });
+});
+
 // GET /api/stats/streak
 app.get('/streak', (c) => {
   const today = getTodayDate();

--- a/e2e/fluency.spec.ts
+++ b/e2e/fluency.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Fluency Benchmarks", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+  });
+
+  test("should display fluency section on stats page with level badge", async ({
+    page,
+  }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    // Fluency section should be visible
+    const section = page.locator('[data-testid="fluency-section"]');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // Level badge should show A1 for empty/fresh database
+    const badge = page.locator('[data-testid="fluency-level-badge"]');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText("A1");
+
+    // Should display the level description
+    await expect(section.getByText("Beginner")).toBeVisible();
+
+    // Progress bar should exist
+    const progressBar = page.locator('[data-testid="fluency-progress-bar"]');
+    await expect(progressBar).toBeVisible();
+
+    // Known and learning counts should be visible
+    const knownCount = page.locator('[data-testid="fluency-known-count"]');
+    await expect(knownCount).toBeVisible();
+    await expect(knownCount).toHaveText("0");
+
+    const learningCount = page.locator('[data-testid="fluency-learning-count"]');
+    await expect(learningCount).toBeVisible();
+    await expect(learningCount).toHaveText("0");
+  });
+
+  test("should show CEFR level label with description", async ({ page }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const section = page.locator('[data-testid="fluency-section"]');
+    await expect(section).toBeVisible({ timeout: 10000 });
+
+    // Should show "A1 — Beginner" text
+    await expect(section.getByText(/A1\s*—\s*Beginner/)).toBeVisible();
+
+    // Should show "Estimated CEFR Level" subtitle
+    await expect(section.getByText("Estimated CEFR Level")).toBeVisible();
+  });
+
+  test("fluency API endpoint should return valid data", async ({ page }) => {
+    const response = await page.request.get("/api/stats/fluency");
+    expect(response.ok()).toBeTruthy();
+
+    const data = await response.json();
+    expect(data).toHaveProperty("totalKnownWords");
+    expect(data).toHaveProperty("totalLearning");
+    expect(data).toHaveProperty("totalNew");
+    expect(data).toHaveProperty("estimatedLevel");
+    expect(data.estimatedLevel).toHaveProperty("code");
+    expect(data.estimatedLevel).toHaveProperty("label");
+    expect(data).toHaveProperty("progressToNextLevel");
+    expect(data).toHaveProperty("weeklyGrowth");
+    expect(data.weeklyGrowth).toHaveProperty("thisWeek");
+    expect(data.weeklyGrowth).toHaveProperty("lastWeek");
+    expect(data.weeklyGrowth).toHaveProperty("delta");
+
+    // With empty DB, should be A1
+    expect(data.estimatedLevel.code).toBe("A1");
+    expect(data.totalKnownWords).toBe(0);
+    expect(typeof data.progressToNextLevel).toBe("number");
+  });
+});

--- a/src/app/api/stats/fluency/route.ts
+++ b/src/app/api/stats/fluency/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+
+function getTodayDate(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+// GET /api/stats/fluency - Get fluency benchmarks (word counts, CEFR level, growth)
+export async function GET() {
+  // Count words by state from knownWords table
+  const stateCounts = db.prepare(
+    'SELECT state, COUNT(*) as count FROM knownWords GROUP BY state'
+  ).all() as { state: string; count: number }[];
+
+  const countMap: Record<string, number> = {};
+  for (const row of stateCounts) {
+    countMap[row.state] = row.count;
+  }
+
+  const totalKnownWords = countMap['known'] || 0;
+  const totalLearning =
+    (countMap['level1'] || 0) +
+    (countMap['level2'] || 0) +
+    (countMap['level3'] || 0) +
+    (countMap['level4'] || 0);
+  const totalNew = countMap['new'] || 0;
+
+  // Determine CEFR-style level
+  const levels = [
+    { min: 0, max: 500, code: 'A1', label: 'Beginner' },
+    { min: 500, max: 1500, code: 'A2', label: 'Elementary' },
+    { min: 1500, max: 3000, code: 'B1', label: 'Intermediate' },
+    { min: 3000, max: 5000, code: 'B2', label: 'Upper Intermediate' },
+    { min: 5000, max: 8000, code: 'C1', label: 'Advanced' },
+    { min: 8000, max: Infinity, code: 'C2', label: 'Proficiency' },
+  ];
+
+  const currentLevel = levels.find(
+    (l) => totalKnownWords >= l.min && totalKnownWords < l.max
+  ) || levels[levels.length - 1];
+
+  const progressToNextLevel =
+    currentLevel.max === Infinity
+      ? 100
+      : Math.round(
+          ((totalKnownWords - currentLevel.min) /
+            (currentLevel.max - currentLevel.min)) *
+            100
+        );
+
+  // Weekly growth: words marked known in last 7 days vs previous 7 days
+  const today = getTodayDate();
+  const d7 = new Date();
+  d7.setDate(d7.getDate() - 6);
+  const weekStart = d7.toISOString().split('T')[0];
+
+  const d14 = new Date();
+  d14.setDate(d14.getDate() - 13);
+  const prevWeekStart = d14.toISOString().split('T')[0];
+
+  const d8 = new Date();
+  d8.setDate(d8.getDate() - 7);
+  const prevWeekEnd = d8.toISOString().split('T')[0];
+
+  const thisWeekRow = db.prepare(
+    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ?'
+  ).get(weekStart, today) as { total: number };
+
+  const prevWeekRow = db.prepare(
+    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ?'
+  ).get(prevWeekStart, prevWeekEnd) as { total: number };
+
+  return NextResponse.json({
+    totalKnownWords,
+    totalLearning,
+    totalNew,
+    estimatedLevel: {
+      code: currentLevel.code,
+      label: currentLevel.label,
+    },
+    progressToNextLevel,
+    weeklyGrowth: {
+      thisWeek: thisWeekRow.total,
+      lastWeek: prevWeekRow.total,
+      delta: thisWeekRow.total - prevWeekRow.total,
+    },
+  });
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -9,9 +9,11 @@ import {
   getStatsForDateRange,
   getAllClozeSentences,
   getCollectionCounts,
+  getFluencyStats,
   type DailyStats,
   type WordState,
   type ClozeCollection,
+  type FluencyStats,
 } from '@/lib/data-layer';
 import ActivityHeatmap from '@/components/ActivityHeatmap';
 import VocabGrowthChart from '@/components/VocabGrowthChart';
@@ -33,6 +35,7 @@ interface StatsData {
   vocabGrowth: Array<{ date: string; known: number; learning: number; total: number }>;
   activityData: Array<{ date: string; count: number }>;
   collectionCounts: Record<ClozeCollection, { total: number; due: number; mastered: number }>;
+  fluency: FluencyStats;
 }
 
 // Stat card component
@@ -229,6 +232,98 @@ function SentenceMastery({
   );
 }
 
+// Fluency badge component
+function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
+  const { estimatedLevel, progressToNextLevel, totalKnownWords, totalLearning, weeklyGrowth } = fluency;
+  const growthDelta = weeklyGrowth.delta;
+
+  return (
+    <div data-testid="fluency-section" className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6 mb-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+        <div className="flex items-center gap-4">
+          <span
+            data-testid="fluency-level-badge"
+            className="inline-flex items-center px-4 py-2 rounded-lg text-lg font-bold bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300"
+          >
+            {estimatedLevel.code}
+          </span>
+          <div>
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              {estimatedLevel.code} &mdash; {estimatedLevel.label}
+            </h3>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              Estimated CEFR Level
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {growthDelta !== 0 && (
+            <span
+              data-testid="fluency-weekly-growth"
+              className={`inline-flex items-center gap-1 text-sm font-medium ${
+                growthDelta > 0
+                  ? 'text-green-600 dark:text-green-400'
+                  : 'text-red-500 dark:text-red-400'
+              }`}
+            >
+              {growthDelta > 0 ? (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                </svg>
+              ) : (
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              )}
+              {Math.abs(growthDelta)} vs last week
+            </span>
+          )}
+          {growthDelta === 0 && weeklyGrowth.thisWeek > 0 && (
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+              {weeklyGrowth.thisWeek} this week (same as last)
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Progress bar toward next level */}
+      <div className="mb-4">
+        <div className="flex justify-between text-sm mb-1">
+          <span className="text-zinc-500 dark:text-zinc-400">
+            Progress to next level
+          </span>
+          <span className="text-zinc-500 dark:text-zinc-400">{progressToNextLevel}%</span>
+        </div>
+        <div
+          data-testid="fluency-progress-bar"
+          className="h-3 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden"
+        >
+          <div
+            className="h-full bg-blue-500 rounded-full transition-all duration-500"
+            style={{ width: `${progressToNextLevel}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Known / Learning counts */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="text-center p-3 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg">
+          <div data-testid="fluency-known-count" className="text-2xl font-bold text-green-600 dark:text-green-400">
+            {totalKnownWords.toLocaleString()}
+          </div>
+          <div className="text-sm text-zinc-500 dark:text-zinc-400">Known</div>
+        </div>
+        <div className="text-center p-3 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg">
+          <div data-testid="fluency-learning-count" className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
+            {totalLearning.toLocaleString()}
+          </div>
+          <div className="text-sm text-zinc-500 dark:text-zinc-400">Learning</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Helper function to calculate streak
 function calculateStreak(dailyStats: DailyStats[]): { current: number; longest: number } {
   if (dailyStats.length === 0) return { current: 0, longest: 0 };
@@ -322,11 +417,12 @@ export default function StatsPage() {
   useEffect(() => {
     async function loadStats() {
       try {
-        // Get vocab stats, collections, and collection counts in parallel
-        const [vocabStats, collections, collectionCounts] = await Promise.all([
+        // Get vocab stats, collections, collection counts, and fluency in parallel
+        const [vocabStats, collections, collectionCounts, fluency] = await Promise.all([
           getVocabStats(),
           getAllCollections(),
           getCollectionCounts(),
+          getFluencyStats(),
         ]);
 
         const completedBooks = collections.filter((c) => (c.avgProgress || 0) >= 100);
@@ -413,6 +509,7 @@ export default function StatsPage() {
           vocabGrowth,
           activityData,
           collectionCounts,
+          fluency,
         });
       } catch (error) {
         console.error('Failed to load stats:', error);
@@ -461,6 +558,9 @@ export default function StatsPage() {
             day: 'numeric',
           })}
         </p>
+
+        {/* Fluency level */}
+        <FluencyBadge fluency={stats.fluency} />
 
         {/* Top stat cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -442,6 +442,27 @@ export async function getStreak(): Promise<{ streak: number; practicedToday: boo
   return res.json();
 }
 
+export interface FluencyStats {
+  totalKnownWords: number;
+  totalLearning: number;
+  totalNew: number;
+  estimatedLevel: {
+    code: string;
+    label: string;
+  };
+  progressToNextLevel: number;
+  weeklyGrowth: {
+    thisWeek: number;
+    lastWeek: number;
+    delta: number;
+  };
+}
+
+export async function getFluencyStats(): Promise<FluencyStats> {
+  const res = await fetch('/api/stats/fluency');
+  return res.json();
+}
+
 // Migration function - no-op for server storage
 export async function migrateClozeSentences(): Promise<number> {
   return 0;


### PR DESCRIPTION
## Summary
- Add `GET /api/stats/fluency` endpoint that returns known/learning/new word counts, CEFR-style level estimation (A1-C2), progress toward next level, and weekly growth delta
- Add `FluencyBadge` component to the stats page showing a prominent level badge, progress bar, known/learning counts, and weekly growth indicator
- Add `getFluencyStats()` to the data layer

## How it works
Queries the `knownWords` table (`GROUP BY state`) for word counts, then maps the "known" count to CEFR thresholds:
| Words Known | Level |
|---|---|
| 0-500 | A1 (Beginner) |
| 500-1500 | A2 (Elementary) |
| 1500-3000 | B1 (Intermediate) |
| 3000-5000 | B2 (Upper Intermediate) |
| 5000-8000 | C1 (Advanced) |
| 8000+ | C2 (Proficiency) |

Weekly growth compares `SUM(wordsMarkedKnown)` from the last 7 days vs the previous 7 days.

## Test plan
- [x] E2E: fluency section renders on stats page with level badge (A1 for empty DB)
- [x] E2E: CEFR level label and description visible
- [x] E2E: API endpoint returns correct shape with all expected fields
- [x] Full e2e suite passes locally (57 passed, 0 failed)

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)
