### PR TITLE
feat: add Apfel as an LLM provider option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ OLLAMA_MODEL=llama3.1:8b
 
 # Apfel settings (used when LLM_PROVIDER=apfel)
 # Apfel is an OpenAI-compatible API — see https://apfel.franzai.com/
-APFEL_URL=http://localhost:8000
+APFEL_URL=http://localhost:11434
 
 # Anthropic API key (only needed when LLM_PROVIDER=anthropic)
 ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,16 @@
 # Lector Configuration
 # Copy to .env.local and adjust as needed
 
-# LLM provider for translations: "ollama" (default, local) or "anthropic" (cloud)
+# LLM provider for translations: "ollama" (local), "anthropic" (cloud), or "apfel" (self-hosted)
 LLM_PROVIDER=anthropic
 
-# Ollama settings (used when LLM_PROVIDER=anthropic)
+# Ollama settings (used when LLM_PROVIDER=ollama)
 OLLAMA_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.1:8b
+
+# Apfel settings (used when LLM_PROVIDER=apfel)
+# Apfel is an OpenAI-compatible API — see https://apfel.franzai.com/
+APFEL_URL=http://localhost:8000
 
 # Anthropic API key (only needed when LLM_PROVIDER=anthropic)
 ANTHROPIC_API_KEY=

--- a/api/src/lib/llm/apfel.test.ts
+++ b/api/src/lib/llm/apfel.test.ts
@@ -28,7 +28,7 @@ describe('ApfelProvider', () => {
   describe('complete', () => {
     test('sends correct request and parses response', async () => {
       globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
-        expect(url).toBe('http://localhost:8000/v1/chat/completions');
+        expect(url).toBe('http://localhost:11434/v1/chat/completions');
         const body = JSON.parse(init?.body as string);
         expect(body.model).toBe('default');
         expect(body.messages).toEqual([{ role: 'user', content: 'Hello' }]);
@@ -81,7 +81,7 @@ describe('ApfelProvider', () => {
   describe('healthCheck', () => {
     test('returns ok when server responds', async () => {
       globalThis.fetch = mock(async (url: string) => {
-        expect(url).toBe('http://localhost:8000/v1/models');
+        expect(url).toBe('http://localhost:11434/v1/models');
         return new Response(JSON.stringify({ data: [{ id: 'default' }] }), { status: 200 });
       }) as typeof fetch;
 
@@ -107,7 +107,7 @@ describe('ApfelProvider', () => {
 
       const provider = new ApfelProvider();
       const result = await provider.healthCheck();
-      expect(result).toEqual({ ok: false, error: 'Cannot reach Apfel at http://localhost:8000' });
+      expect(result).toEqual({ ok: false, error: 'Cannot reach Apfel at http://localhost:11434' });
     });
 
     test('uses custom URL in error message', async () => {

--- a/api/src/lib/llm/apfel.test.ts
+++ b/api/src/lib/llm/apfel.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { ApfelProvider } from './apfel';
+
+describe('ApfelProvider', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('constructor', () => {
+    test('uses provided baseUrl and model', () => {
+      const provider = new ApfelProvider('http://custom:9000', 'my-model');
+      expect(provider.name).toBe('apfel');
+    });
+
+    test('strips trailing slash from baseUrl', () => {
+      const provider = new ApfelProvider('http://custom:9000/');
+      // Verify by checking healthCheck calls the right URL
+      globalThis.fetch = mock(async (url: string) => {
+        expect(url).toBe('http://custom:9000/v1/models');
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }) as typeof fetch;
+      provider.healthCheck();
+    });
+  });
+
+  describe('complete', () => {
+    test('sends correct request and parses response', async () => {
+      globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+        expect(url).toBe('http://localhost:8000/v1/chat/completions');
+        const body = JSON.parse(init?.body as string);
+        expect(body.model).toBe('default');
+        expect(body.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+        expect(body.max_tokens).toBe(100);
+        expect(body.response_format).toEqual({ type: 'json_object' });
+
+        return new Response(JSON.stringify({
+          choices: [{ message: { content: '{"translation": "Hallo"}' } }],
+        }), { status: 200 });
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider();
+      const result = await provider.complete({
+        messages: [{ role: 'user', content: 'Hello' }],
+        maxTokens: 100,
+      });
+
+      expect(result).toBe('{"translation": "Hallo"}');
+    });
+
+    test('returns empty string when response has no choices', async () => {
+      globalThis.fetch = mock(async () => {
+        return new Response(JSON.stringify({ choices: [] }), { status: 200 });
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider();
+      const result = await provider.complete({
+        messages: [{ role: 'user', content: 'Hello' }],
+        maxTokens: 100,
+      });
+
+      expect(result).toBe('');
+    });
+
+    test('throws on non-OK response', async () => {
+      globalThis.fetch = mock(async () => {
+        return new Response('Internal Server Error', { status: 500 });
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider();
+      await expect(
+        provider.complete({
+          messages: [{ role: 'user', content: 'Hello' }],
+          maxTokens: 100,
+        })
+      ).rejects.toThrow('Apfel error: Internal Server Error');
+    });
+  });
+
+  describe('healthCheck', () => {
+    test('returns ok when server responds', async () => {
+      globalThis.fetch = mock(async (url: string) => {
+        expect(url).toBe('http://localhost:8000/v1/models');
+        return new Response(JSON.stringify({ data: [{ id: 'default' }] }), { status: 200 });
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider();
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: true });
+    });
+
+    test('returns error on non-OK response', async () => {
+      globalThis.fetch = mock(async () => {
+        return new Response('Unauthorized', { status: 401 });
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider();
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: false, error: 'Apfel returned 401' });
+    });
+
+    test('returns error when server is unreachable', async () => {
+      globalThis.fetch = mock(async () => {
+        throw new Error('ECONNREFUSED');
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider();
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: false, error: 'Cannot reach Apfel at http://localhost:8000' });
+    });
+
+    test('uses custom URL in error message', async () => {
+      globalThis.fetch = mock(async () => {
+        throw new Error('ECONNREFUSED');
+      }) as typeof fetch;
+
+      const provider = new ApfelProvider('http://my-apfel:3000');
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: false, error: 'Cannot reach Apfel at http://my-apfel:3000' });
+    });
+  });
+});

--- a/api/src/lib/llm/apfel.ts
+++ b/api/src/lib/llm/apfel.ts
@@ -1,6 +1,6 @@
 import type { LLMProvider, CompletionOptions } from './types';
 
-const DEFAULT_URL = 'http://localhost:8000';
+const DEFAULT_URL = 'http://localhost:11434';
 const DEFAULT_MODEL = 'default';
 
 export class ApfelProvider implements LLMProvider {

--- a/api/src/lib/llm/apfel.ts
+++ b/api/src/lib/llm/apfel.ts
@@ -1,0 +1,50 @@
+import type { LLMProvider, CompletionOptions } from './types';
+
+const DEFAULT_URL = 'http://localhost:8000';
+const DEFAULT_MODEL = 'default';
+
+export class ApfelProvider implements LLMProvider {
+  name = 'apfel';
+  private baseUrl: string;
+  private model: string;
+
+  constructor(baseUrl?: string, model?: string) {
+    this.baseUrl = (baseUrl || process.env.APFEL_URL || DEFAULT_URL).replace(/\/$/, '');
+    this.model = model || process.env.APFEL_MODEL || DEFAULT_MODEL;
+  }
+
+  async complete(options: CompletionOptions): Promise<string> {
+    const body = {
+      model: this.model,
+      messages: options.messages,
+      max_tokens: options.maxTokens,
+      response_format: { type: 'json_object' },
+    };
+
+    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Apfel error: ${error}`);
+    }
+
+    const data = await response.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const response = await fetch(`${this.baseUrl}/v1/models`);
+      if (!response.ok) {
+        return { ok: false, error: `Apfel returned ${response.status}` };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: `Cannot reach Apfel at ${this.baseUrl}` };
+    }
+  }
+}

--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -1,6 +1,7 @@
 import type { LLMProvider } from './types';
 import { OllamaProvider } from './ollama';
 import { AnthropicProvider } from './anthropic';
+import { ApfelProvider } from './apfel';
 import { db } from '../../db';
 
 export type { LLMProvider, ChatMessage, CompletionOptions } from './types';
@@ -20,11 +21,19 @@ function getSetting(key: string): string | null {
 
 export function getProvider(): LLMProvider {
   const name = getSetting('llmProvider') || process.env.LLM_PROVIDER || 'anthropic';
-  const model = name === 'ollama'
-    ? (getSetting('ollamaModel') || process.env.OLLAMA_MODEL || undefined)
-    : (process.env.ANTHROPIC_MODEL || undefined);
 
-  const cacheKey = `${name}:${model || 'default'}`;
+  let model: string | undefined;
+  let url: string | undefined;
+  if (name === 'ollama') {
+    model = getSetting('ollamaModel') || process.env.OLLAMA_MODEL || undefined;
+  } else if (name === 'apfel') {
+    model = getSetting('apfelModel') || process.env.APFEL_MODEL || undefined;
+    url = getSetting('apfelUrl') || process.env.APFEL_URL || undefined;
+  } else {
+    model = process.env.ANTHROPIC_MODEL || undefined;
+  }
+
+  const cacheKey = `${name}:${model || 'default'}:${url || 'default'}`;
 
   if (cachedProvider && cachedProviderKey === cacheKey) {
     return cachedProvider;
@@ -33,6 +42,9 @@ export function getProvider(): LLMProvider {
   switch (name) {
     case 'anthropic':
       cachedProvider = new AnthropicProvider(undefined, model);
+      break;
+    case 'apfel':
+      cachedProvider = new ApfelProvider(url, model);
       break;
     case 'ollama':
     default:

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:api": "cd api && bun run --watch src/index.ts",
+    "dev": "next dev --port 3456",
+    "dev:api": "cd api && bun run --env-file=../.env.local --watch src/index.ts",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev -- --port 3456",
+    command: "npm run dev",
     url: "http://localhost:3456",
     reuseExistingServer: !process.env.CI,
   },

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -97,7 +97,7 @@ export default function SettingsPage() {
   // LLM provider state
   const [llmProvider, setLlmProvider] = useState<LLMProvider>("ollama");
   const [ollamaModel, setOllamaModel] = useState("llama3.1:8b");
-  const [apfelUrl, setApfelUrl] = useState("http://localhost:8000");
+  const [apfelUrl, setApfelUrl] = useState("http://localhost:11434");
   const [apfelModel, setApfelModel] = useState("default");
   const [llmStatus, setLlmStatus] = useState<LLMStatus | null>(null);
   const [llmTesting, setLlmTesting] = useState(false);
@@ -718,7 +718,7 @@ export default function SettingsPage() {
                     type="text"
                     value={apfelUrl}
                     onChange={(e) => saveApfelUrl(e.target.value)}
-                    placeholder="http://localhost:8000"
+                    placeholder="http://localhost:11434"
                     className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
                   />
                   <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -35,7 +35,7 @@ const SETTINGS_KEYS = {
 
 type CardType = "basic" | "cloze";
 type Theme = "light" | "dark" | "system";
-type LLMProvider = "ollama" | "anthropic";
+type LLMProvider = "ollama" | "anthropic" | "apfel";
 
 const OLLAMA_MODELS = [
   { value: "llama3.2:3b", label: "Llama 3.2 3B (fastest, lower quality)" },
@@ -97,6 +97,8 @@ export default function SettingsPage() {
   // LLM provider state
   const [llmProvider, setLlmProvider] = useState<LLMProvider>("ollama");
   const [ollamaModel, setOllamaModel] = useState("llama3.1:8b");
+  const [apfelUrl, setApfelUrl] = useState("http://localhost:8000");
+  const [apfelModel, setApfelModel] = useState("default");
   const [llmStatus, setLlmStatus] = useState<LLMStatus | null>(null);
   const [llmTesting, setLlmTesting] = useState(false);
 
@@ -137,10 +139,16 @@ export default function SettingsPage() {
 
     // Load LLM provider settings from server
     getSetting<string>('llmProvider').then((p) => {
-      if (p === 'ollama' || p === 'anthropic') setLlmProvider(p);
+      if (p === 'ollama' || p === 'anthropic' || p === 'apfel') setLlmProvider(p);
     });
     getSetting<string>('ollamaModel').then((m) => {
       if (m) setOllamaModel(m);
+    });
+    getSetting<string>('apfelUrl').then((u) => {
+      if (u) setApfelUrl(u);
+    });
+    getSetting<string>('apfelModel').then((m) => {
+      if (m) setApfelModel(m);
     });
 
     // Check LLM status
@@ -238,6 +246,20 @@ export default function SettingsPage() {
   const saveOllamaModel = async (model: string) => {
     setOllamaModel(model);
     await setSetting('ollamaModel', model);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveApfelUrl = async (url: string) => {
+    setApfelUrl(url);
+    await setSetting('apfelUrl', url);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveApfelModel = async (model: string) => {
+    setApfelModel(model);
+    await setSetting('apfelModel', model);
     await fetch('/api/llm-status/reset', { method: 'POST' });
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
   };
@@ -605,7 +627,7 @@ export default function SettingsPage() {
               )}
             </div>
             <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
-              Choose how translations are powered. Ollama runs locally (no API key needed). Anthropic uses cloud AI for higher quality.
+              Choose how translations are powered. Ollama runs locally (no API key needed). Anthropic uses cloud AI for higher quality. Apfel is an OpenAI-compatible API you can self-host.
             </p>
 
             {/* Provider selector */}
@@ -620,6 +642,7 @@ export default function SettingsPage() {
               >
                 <option value="ollama">Ollama (local)</option>
                 <option value="anthropic">Anthropic (cloud)</option>
+                <option value="apfel">Apfel (self-hosted)</option>
               </select>
             </div>
 
@@ -680,6 +703,42 @@ export default function SettingsPage() {
                   >
                     {showApiKey ? "Hide" : "Show"}
                   </button>
+                </div>
+              </div>
+            )}
+
+            {/* Apfel settings */}
+            {llmProvider === "apfel" && (
+              <div className="mb-4 space-y-4">
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Server URL
+                  </label>
+                  <input
+                    type="text"
+                    value={apfelUrl}
+                    onChange={(e) => saveApfelUrl(e.target.value)}
+                    placeholder="http://localhost:8000"
+                    className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  />
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+                    The URL of your Apfel instance (OpenAI-compatible API)
+                  </p>
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Model
+                  </label>
+                  <input
+                    type="text"
+                    value={apfelModel}
+                    onChange={(e) => saveApfelModel(e.target.value)}
+                    placeholder="default"
+                    className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  />
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+                    The model name configured on your Apfel server
+                  </p>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
Closes #24

- Add **Apfel** as a third LLM provider option (alongside Ollama and Anthropic)
- Apfel wraps Apple Intelligence's on-device Foundation Model via an OpenAI-compatible API (`brew install Arthur-Ficial/tap/apfel`)
- New `ApfelProvider` class using `/v1/chat/completions` endpoint with JSON response format
- Settings page updated with Apfel option, server URL input, and model name input
- Factory reads `apfelUrl` and `apfelModel` from settings DB with env var fallbacks
- Default URL: `http://localhost:11434` (apfel's default port, matching Ollama convention)

Also includes two dev config fixes:
- Dev server now runs on port 3456 (avoids conflicts with other apps on 3000)
- `dev:api` script loads `.env.local` via `--env-file` so API server shares `DATA_DIR`

## Changes
- **`api/src/lib/llm/apfel.ts`** — New provider implementing `LLMProvider` interface
- **`api/src/lib/llm/index.ts`** — Register `apfel` in factory with URL-aware cache key
- **`src/app/settings/page.tsx`** — Add Apfel to provider dropdown with URL/model config
- **`.env.example`** — Add `APFEL_URL` env var documentation
- **`api/src/lib/llm/apfel.test.ts`** — 9 unit tests (complete, healthCheck, error paths)
- **`package.json`** — Dev server port 3456, API env file loading
- **`playwright.config.ts`** — Simplified webServer command

## Test plan
- [x] `bun test api/src/lib/llm/apfel.test.ts` — all 9 tests pass
- [x] Manual: select Apfel in settings, verify URL/model inputs appear
- [x] Manual: test connection with running Apfel instance — green "Connected" status
- [ ] `npx playwright test` — full e2e suite

Generated with [Claude Code](https://claude.com/claude-code)
