### PR TITLE
feat: Anthropic API key and OAuth token in settings

### DIFF
--- a/api/src/lib/llm/anthropic.ts
+++ b/api/src/lib/llm/anthropic.ts
@@ -8,18 +8,23 @@ export class AnthropicProvider implements LLMProvider {
   private client: Anthropic;
   private model: string;
 
-  constructor(apiKey?: string, model?: string) {
+  constructor(options?: { apiKey?: string; oauthToken?: string; model?: string }) {
     const oauthToken =
-      process.env.CLAUDE_OAUTH_TOKEN ||
+      options?.oauthToken ||
       process.env.CLAUDE_CODE_OAUTH_TOKEN ||
+      process.env.CLAUDE_OAUTH_TOKEN ||
       process.env.ANTHROPIC_AUTH_TOKEN;
+
+    const apiKey = options?.apiKey || process.env.ANTHROPIC_API_KEY;
 
     if (oauthToken) {
       this.client = new Anthropic({ authToken: oauthToken, apiKey: undefined as unknown as string });
+    } else if (apiKey) {
+      this.client = new Anthropic({ apiKey });
     } else {
-      this.client = new Anthropic(apiKey ? { apiKey } : undefined);
+      this.client = new Anthropic();
     }
-    this.model = model || process.env.ANTHROPIC_MODEL || DEFAULT_MODEL;
+    this.model = options?.model || process.env.ANTHROPIC_MODEL || DEFAULT_MODEL;
   }
 
   async complete(options: CompletionOptions): Promise<string> {

--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -22,34 +22,38 @@ function getSetting(key: string): string | null {
 export function getProvider(): LLMProvider {
   const name = getSetting('llmProvider') || process.env.LLM_PROVIDER || 'anthropic';
 
-  let model: string | undefined;
-  let url: string | undefined;
-  if (name === 'ollama') {
-    model = getSetting('ollamaModel') || process.env.OLLAMA_MODEL || undefined;
-  } else if (name === 'apfel') {
-    model = getSetting('apfelModel') || process.env.APFEL_MODEL || undefined;
-    url = getSetting('apfelUrl') || process.env.APFEL_URL || undefined;
-  } else {
-    model = process.env.ANTHROPIC_MODEL || undefined;
-  }
-
-  const cacheKey = `${name}:${model || 'default'}:${url || 'default'}`;
-
-  if (cachedProvider && cachedProviderKey === cacheKey) {
-    return cachedProvider;
-  }
-
+  let cacheKey: string;
   switch (name) {
-    case 'anthropic':
-      cachedProvider = new AnthropicProvider(undefined, model);
+    case 'anthropic': {
+      const apiKey = getSetting('anthropicApiKey') || undefined;
+      const oauthToken = getSetting('claudeOauthToken') || undefined;
+      const model = process.env.ANTHROPIC_MODEL || undefined;
+      cacheKey = `anthropic:${apiKey ? 'key' : oauthToken ? 'oauth' : 'env'}:${model || 'default'}`;
+      if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
+      cachedProvider = new AnthropicProvider({ apiKey, oauthToken, model });
       break;
-    case 'apfel':
+    }
+    case 'apfel': {
+      const model = getSetting('apfelModel') || process.env.APFEL_MODEL || undefined;
+      const url = getSetting('apfelUrl') || process.env.APFEL_URL || undefined;
+      cacheKey = `apfel:${model || 'default'}:${url || 'default'}`;
+      if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
       cachedProvider = new ApfelProvider(url, model);
       break;
-    case 'ollama':
-    default:
+    }
+    case 'ollama': {
+      const model = getSetting('ollamaModel') || process.env.OLLAMA_MODEL || undefined;
+      cacheKey = `ollama:${model || 'default'}`;
+      if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
       cachedProvider = new OllamaProvider(undefined, model);
       break;
+    }
+    default: {
+      cacheKey = `${name}:default`;
+      if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
+      cachedProvider = new OllamaProvider();
+      break;
+    }
   }
 
   cachedProviderKey = cacheKey;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -79,7 +79,6 @@ const defaultSettings: AppSettings = {
 export default function SettingsPage() {
   // Settings state
   const [settings, setSettings] = useState<AppSettings>(defaultSettings);
-  const [showApiKey, setShowApiKey] = useState(false);
 
   // Anki state
   const [ankiConnected, setAnkiConnected] = useState(false);
@@ -103,6 +102,10 @@ export default function SettingsPage() {
   const [ollamaModel, setOllamaModel] = useState("llama3.1:8b");
   const [apfelUrl, setApfelUrl] = useState("http://localhost:11434");
   const [apfelModel, setApfelModel] = useState("default");
+  const [anthropicApiKey, setAnthropicApiKey] = useState("");
+  const [claudeOauthToken, setClaudeOauthToken] = useState("");
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [showOauthToken, setShowOauthToken] = useState(false);
   const [llmStatus, setLlmStatus] = useState<LLMStatus | null>(null);
   const [llmTesting, setLlmTesting] = useState(false);
 
@@ -162,6 +165,12 @@ export default function SettingsPage() {
     });
     getSetting<string>('apfelModel').then((m) => {
       if (m) setApfelModel(m);
+    });
+    getSetting<string>('anthropicApiKey').then((k) => {
+      if (k) setAnthropicApiKey(k);
+    });
+    getSetting<string>('claudeOauthToken').then((t) => {
+      if (t) setClaudeOauthToken(t);
     });
 
     // Check LLM status
@@ -276,6 +285,20 @@ export default function SettingsPage() {
   const saveApfelModel = async (model: string) => {
     setApfelModel(model);
     await setSetting('apfelModel', model);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveAnthropicApiKey = async (key: string) => {
+    setAnthropicApiKey(key);
+    await setSetting('anthropicApiKey', key);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveClaudeOauthToken = async (token: string) => {
+    setClaudeOauthToken(token);
+    await setSetting('claudeOauthToken', token);
     await fetch('/api/llm-status/reset', { method: 'POST' });
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
   };
@@ -687,38 +710,65 @@ export default function SettingsPage() {
 
             {/* Anthropic settings */}
             {llmProvider === "anthropic" && (
-              <div className="mb-4">
-                <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
-                  API Key
-                </label>
-                <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
-                  Get your API key from{" "}
-                  <a
-                    href="https://console.anthropic.com/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline dark:text-blue-400"
-                  >
-                    console.anthropic.com
-                  </a>
-                </p>
-                <div className="flex gap-2">
-                  <div className="relative flex-1">
+              <div className="mb-4 space-y-4">
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    API Key
+                  </label>
+                  <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+                    Get your API key from{" "}
+                    <a
+                      href="https://console.anthropic.com/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      console.anthropic.com
+                    </a>
+                  </p>
+                  <div className="flex gap-2">
                     <input
                       type={showApiKey ? "text" : "password"}
-                      value={showApiKey ? settings.apiKey : getMaskedApiKey(settings.apiKey)}
-                      onChange={(e) => saveSetting("apiKey", e.target.value)}
+                      value={anthropicApiKey}
+                      onChange={(e) => saveAnthropicApiKey(e.target.value)}
                       placeholder="sk-ant-..."
-                      className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-                      readOnly={!showApiKey}
+                      className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
                     />
+                    <button
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    >
+                      {showApiKey ? "Hide" : "Show"}
+                    </button>
                   </div>
-                  <button
-                    onClick={() => setShowApiKey(!showApiKey)}
-                    className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
-                  >
-                    {showApiKey ? "Hide" : "Show"}
-                  </button>
+                </div>
+                <div className="relative flex items-center py-2">
+                  <div className="flex-grow border-t border-zinc-200 dark:border-zinc-700" />
+                  <span className="mx-3 flex-shrink text-xs text-zinc-400 dark:text-zinc-500">or</span>
+                  <div className="flex-grow border-t border-zinc-200 dark:border-zinc-700" />
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    OAuth Token <span className="font-normal text-zinc-400">(Pro/Team plan)</span>
+                  </label>
+                  <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+                    Uses your Claude Pro or Team subscription credits. Run <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">claude setup-token</code> to obtain a token. Note: slower initial startup than API keys.
+                  </p>
+                  <div className="flex gap-2">
+                    <input
+                      type={showOauthToken ? "text" : "password"}
+                      value={claudeOauthToken}
+                      onChange={(e) => saveClaudeOauthToken(e.target.value)}
+                      placeholder="sk-ant-oat01-..."
+                      className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                    />
+                    <button
+                      onClick={() => setShowOauthToken(!showOauthToken)}
+                      className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    >
+                      {showOauthToken ? "Hide" : "Show"}
+                    </button>
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Add API key and OAuth token configuration to the Anthropic provider settings UI
- Credentials are now saved server-side (settings DB) instead of localStorage
- Supports two auth methods: API key (pay-as-you-go) or OAuth token (Pro/Team plan credits)

## Changes
- **`api/src/lib/llm/anthropic.ts`** -- Constructor takes options object with apiKey, oauthToken, model; falls back to env vars
- **`api/src/lib/llm/index.ts`** -- Factory reads `anthropicApiKey` and `claudeOauthToken` from settings DB
- **`src/app/settings/page.tsx`** -- Anthropic section shows API key field, "or" divider, and OAuth token field with show/hide toggles

## Test plan
- [ ] Select Anthropic provider, enter API key, test connection
- [ ] Select Anthropic provider, enter OAuth token, test connection
- [ ] Verify env var fallback still works when no settings are saved
- [ ] Full e2e suite passes

Generated with [Claude Code](https://claude.com/claude-code)
