### PR TITLE
feat: multi-language support (German + Spanish)

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -6,7 +6,8 @@ import { parseEpub } from './lib/epub-parser';
 import { htmlToMarkdown, countWords } from './lib/html-to-markdown';
 
 const DATA_DIR = process.env.DATA_DIR || '../data';
-const DB_PATH = path.join(DATA_DIR, 'afrikaans.db');
+const DB_PATH = path.join(DATA_DIR, 'lector.db');
+const LEGACY_DB_PATH = path.join(DATA_DIR, 'afrikaans.db');
 export const BOOKS_DIR = path.join(DATA_DIR, 'books');
 
 let _db: Database | null = null;
@@ -16,6 +17,11 @@ function getDb(): Database {
 
   fs.mkdirSync(DATA_DIR, { recursive: true });
   fs.mkdirSync(BOOKS_DIR, { recursive: true });
+
+  // Migrate legacy DB filename
+  if (!fs.existsSync(DB_PATH) && fs.existsSync(LEGACY_DB_PATH)) {
+    fs.renameSync(LEGACY_DB_PATH, DB_PATH);
+  }
 
   _db = new Database(DB_PATH);
   _db.exec('PRAGMA journal_mode = WAL');
@@ -136,6 +142,7 @@ function getDb(): Database {
 
   migrateVocabForeignKey(_db);
   migrateBooks(_db);
+  migrateAddLanguageColumn(_db);
 
   return _db;
 }
@@ -268,6 +275,52 @@ function migrateBooks(database: Database) {
   })();
 }
 
+/**
+ * Add language column to all content tables.
+ * Existing data gets tagged as 'af' (Afrikaans).
+ * knownWords needs table recreation for compound PK (word, language).
+ */
+function migrateAddLanguageColumn(database: Database) {
+  // journal_entries only exists in the Next.js server DB, not the sidecar
+  const tables = ['collections', 'lessons', 'vocab', 'clozeSentences'];
+
+  for (const table of tables) {
+    const cols = database.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    if (!cols.some(c => c.name === 'language')) {
+      database.exec(`ALTER TABLE ${table} ADD COLUMN language TEXT NOT NULL DEFAULT 'af'`);
+    }
+  }
+
+  // knownWords: needs compound PK (word, language) — recreate table
+  const kwCreate = database.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='table' AND name='knownWords'"
+  ).get() as { sql: string } | undefined;
+
+  if (kwCreate && !kwCreate.sql.includes('language')) {
+    database.transaction(() => {
+      database.exec(`
+        CREATE TABLE knownWords_new (
+          word TEXT NOT NULL,
+          language TEXT NOT NULL DEFAULT 'af',
+          state TEXT NOT NULL CHECK (state IN ('new', 'level1', 'level2', 'level3', 'level4', 'known', 'ignored')),
+          PRIMARY KEY (word, language)
+        );
+        INSERT INTO knownWords_new (word, language, state) SELECT word, 'af', state FROM knownWords;
+        DROP TABLE knownWords;
+        ALTER TABLE knownWords_new RENAME TO knownWords;
+      `);
+    })();
+  }
+
+  // Add language indexes
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_collections_language ON collections(language);
+    CREATE INDEX IF NOT EXISTS idx_lessons_language ON lessons(language);
+    CREATE INDEX IF NOT EXISTS idx_vocab_language ON vocab(language);
+    CREATE INDEX IF NOT EXISTS idx_cloze_language ON clozeSentences(language);
+  `);
+}
+
 // Export a lazy-init proxy
 export const db = new Proxy({} as Database, {
   get(_target, prop) {
@@ -327,6 +380,7 @@ export interface VocabRow {
 
 export interface KnownWordRow {
   word: string;
+  language: string;
   state: WordState;
 }
 

--- a/api/src/lib/active-language.ts
+++ b/api/src/lib/active-language.ts
@@ -1,0 +1,39 @@
+import { db } from '../db';
+import { type LanguageCode, type LanguageConfig, LANGUAGES, DEFAULT_LANGUAGE, isValidLanguageCode } from './languages';
+
+interface SettingRow {
+  value: string;
+}
+
+/**
+ * Read the active target language from the settings table.
+ * Falls back to DEFAULT_LANGUAGE ('af') if not set.
+ */
+export function getActiveLanguageCode(): LanguageCode {
+  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('targetLanguage') as SettingRow | undefined;
+  if (!row) return DEFAULT_LANGUAGE;
+
+  try {
+    const code = JSON.parse(row.value);
+    if (typeof code === 'string' && isValidLanguageCode(code)) return code;
+  } catch {
+    if (typeof row.value === 'string' && isValidLanguageCode(row.value)) return row.value;
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+/**
+ * Get the full language config for the active language.
+ */
+export function getActiveLanguageConfig(): LanguageConfig {
+  return LANGUAGES[getActiveLanguageCode()];
+}
+
+/**
+ * Resolve a language code from a request parameter, falling back to the active setting.
+ */
+export function resolveLanguage(requestLang?: string): LanguageCode {
+  if (requestLang && isValidLanguageCode(requestLang)) return requestLang;
+  return getActiveLanguageCode();
+}

--- a/api/src/lib/languages.ts
+++ b/api/src/lib/languages.ts
@@ -1,0 +1,55 @@
+export type LanguageCode = 'af' | 'de' | 'es';
+
+export interface LanguageConfig {
+  name: string;
+  native: string;
+  code: LanguageCode;
+  ttsCode: string;
+  ttsVoice: string;
+  tatoebaCode: string;
+  fallbackTts: string[];
+  testPhrase: string;
+}
+
+export const LANGUAGES: Record<LanguageCode, LanguageConfig> = {
+  af: {
+    name: 'Afrikaans',
+    native: 'Afrikaans',
+    code: 'af',
+    ttsCode: 'af-ZA',
+    ttsVoice: 'af-ZA-Standard-A',
+    tatoebaCode: 'afr',
+    fallbackTts: ['af', 'nl-NL', 'nl'],
+    testPhrase: 'Hallo, hoe gaan dit met jou?',
+  },
+  de: {
+    name: 'German',
+    native: 'Deutsch',
+    code: 'de',
+    ttsCode: 'de-DE',
+    ttsVoice: 'de-DE-Standard-A',
+    tatoebaCode: 'deu',
+    fallbackTts: ['de', 'de-DE'],
+    testPhrase: 'Hallo, wie geht es Ihnen?',
+  },
+  es: {
+    name: 'Spanish',
+    native: 'Español',
+    code: 'es',
+    ttsCode: 'es-ES',
+    ttsVoice: 'es-ES-Standard-A',
+    tatoebaCode: 'spa',
+    fallbackTts: ['es', 'es-ES', 'es-MX'],
+    testPhrase: '¡Hola! ¿Cómo estás?',
+  },
+};
+
+export const DEFAULT_LANGUAGE: LanguageCode = 'af';
+
+export function getLanguageConfig(code: LanguageCode): LanguageConfig {
+  return LANGUAGES[code];
+}
+
+export function isValidLanguageCode(code: string): code is LanguageCode {
+  return code in LANGUAGES;
+}

--- a/api/src/routes/cloze.ts
+++ b/api/src/routes/cloze.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { db, ClozeSentenceRow, ClozeMasteryLevel } from '../db';
 import { randomUUID } from 'crypto';
 import sentenceBank from '../lib/sentence-bank.json';
+import { resolveLanguage } from '../lib/active-language';
 
 type BankEntry = {
   id: number;
@@ -20,9 +21,10 @@ app.get('/', (c) => {
   const collection = c.req.query('collection');
   const word = c.req.query('word');
   const limit = parseInt(c.req.query('limit') || '100');
+  const language = resolveLanguage(c.req.query('language'));
 
-  let query = 'SELECT * FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL)';
-  const params: unknown[] = [];
+  let query = 'SELECT * FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
+  const params: unknown[] = [language];
 
   if (collection) { query += ' AND collection = ?'; params.push(collection); }
   if (word) { query += ' AND clozeWord = ?'; params.push(word); }
@@ -44,9 +46,10 @@ app.post('/', async (c) => {
   const body = await c.req.json();
 
   if (Array.isArray(body)) {
+    const language = resolveLanguage((body[0] as Record<string, unknown>)?.language as string);
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     db.transaction(() => {
@@ -57,7 +60,7 @@ app.post('/', async (c) => {
           item.wordRank || null, item.tatoebaSentenceId || null, item.vocabEntryId || null,
           item.masteryLevel || 0, item.nextReview || new Date().toISOString(),
           item.reviewCount || 0, item.lastReviewed || null,
-          item.timesCorrect || 0, item.timesIncorrect || 0
+          item.timesCorrect || 0, item.timesIncorrect || 0, language
         );
       }
     })();
@@ -66,16 +69,17 @@ app.post('/', async (c) => {
   }
 
   const id = body.id || randomUUID();
+  const language = resolveLanguage(body.language);
 
   db.prepare(`
-    INSERT INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect, language)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id, body.sentence, body.clozeWord, body.clozeIndex, body.translation,
     body.source || 'tatoeba', body.collection || 'random', body.wordRank || null,
     body.tatoebaSentenceId || null, body.vocabEntryId || null, body.masteryLevel || 0,
     body.nextReview || new Date().toISOString(), body.reviewCount || 0,
-    body.lastReviewed || null, body.timesCorrect || 0, body.timesIncorrect || 0
+    body.lastReviewed || null, body.timesCorrect || 0, body.timesIncorrect || 0, language
   );
 
   return c.json({ id });
@@ -87,19 +91,21 @@ app.get('/due', (c) => {
   const collection = c.req.query('collection');
   const mode = c.req.query('mode');
   const excludeWords = c.req.query('excludeWords')?.split(',').filter(Boolean) || [];
+  const language = resolveLanguage(c.req.query('language'));
 
   const now = new Date().toISOString();
   let query: string;
   const params: unknown[] = [];
 
   if (mode === 'new') {
-    query = 'SELECT * FROM clozeSentences WHERE reviewCount = 0 AND (blacklisted = 0 OR blacklisted IS NULL)';
+    query = 'SELECT * FROM clozeSentences WHERE reviewCount = 0 AND (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
+    params.push(language);
   } else if (mode === 'review') {
-    query = 'SELECT * FROM clozeSentences WHERE nextReview <= ? AND reviewCount > 0 AND masteryLevel < 100 AND (blacklisted = 0 OR blacklisted IS NULL)';
-    params.push(now);
+    query = 'SELECT * FROM clozeSentences WHERE nextReview <= ? AND reviewCount > 0 AND masteryLevel < 100 AND (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
+    params.push(now, language);
   } else {
-    query = 'SELECT * FROM clozeSentences WHERE nextReview <= ? AND (blacklisted = 0 OR blacklisted IS NULL)';
-    params.push(now);
+    query = 'SELECT * FROM clozeSentences WHERE nextReview <= ? AND (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
+    params.push(now, language);
   }
 
   if (collection) { query += ' AND collection = ?'; params.push(collection); }
@@ -125,6 +131,7 @@ app.get('/due', (c) => {
 // GET /api/cloze/counts
 app.get('/counts', (c) => {
   const now = new Date().toISOString();
+  const language = resolveLanguage(c.req.query('language'));
 
   const rows = db.prepare(`
     SELECT
@@ -133,9 +140,9 @@ app.get('/counts', (c) => {
       SUM(CASE WHEN masteryLevel = 100 THEN 1 ELSE 0 END) as mastered,
       SUM(CASE WHEN nextReview <= ? AND masteryLevel < 100 AND reviewCount > 0 THEN 1 ELSE 0 END) as due
     FROM clozeSentences
-    WHERE blacklisted = 0 OR blacklisted IS NULL
+    WHERE (blacklisted = 0 OR blacklisted IS NULL) AND language = ?
     GROUP BY collection
-  `).all(now) as { collection: string; total: number; mastered: number; due: number }[];
+  `).all(now, language) as { collection: string; total: number; mastered: number; due: number }[];
 
   const counts: Record<string, { total: number; due: number; mastered: number }> = {
     top500: { total: 0, due: 0, mastered: 0 },
@@ -157,10 +164,11 @@ app.get('/counts', (c) => {
 // POST /api/cloze/seed
 app.post('/seed', (c) => {
   const bank = sentenceBank as BankEntry[];
+  const language = resolveLanguage();
 
   const existing = db.prepare(
-    'SELECT id, tatoebaSentenceId, clozeWord, collection, reviewCount FROM clozeSentences WHERE tatoebaSentenceId IS NOT NULL'
-  ).all() as { id: string; tatoebaSentenceId: number; clozeWord: string; collection: string; reviewCount: number }[];
+    'SELECT id, tatoebaSentenceId, clozeWord, collection, reviewCount FROM clozeSentences WHERE tatoebaSentenceId IS NOT NULL AND language = ?'
+  ).all(language) as { id: string; tatoebaSentenceId: number; clozeWord: string; collection: string; reviewCount: number }[];
 
   const existingMap = new Map(existing.map(r => [r.tatoebaSentenceId, r]));
 
@@ -177,8 +185,8 @@ app.post('/seed', (c) => {
   }
 
   const insertStmt = db.prepare(`
-    INSERT OR IGNORE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, masteryLevel, nextReview, reviewCount, timesCorrect, timesIncorrect)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT OR IGNORE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, masteryLevel, nextReview, reviewCount, timesCorrect, timesIncorrect, language)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const updateStmt = db.prepare(`
@@ -190,7 +198,7 @@ app.post('/seed', (c) => {
       insertStmt.run(
         randomUUID(), s.text, s.clozeWord, s.clozeIndex, s.translation,
         'tatoeba', s.collection, s.wordRank, s.id,
-        0, new Date().toISOString(), 0, 0, 0
+        0, new Date().toISOString(), 0, 0, 0, language
       );
     }
     for (const s of toUpdate) {
@@ -203,9 +211,10 @@ app.post('/seed', (c) => {
 
 // GET /api/cloze/seed
 app.get('/seed', (c) => {
+  const language = resolveLanguage(c.req.query('language'));
   const count = db.prepare(
-    'SELECT COUNT(*) as count FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL)'
-  ).get() as { count: number };
+    'SELECT COUNT(*) as count FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL) AND language = ?'
+  ).get(language) as { count: number };
 
   return c.json({
     dbCount: count.count,

--- a/api/src/routes/collections.ts
+++ b/api/src/routes/collections.ts
@@ -2,19 +2,22 @@ import { Hono } from 'hono';
 import { db, CollectionRow, LessonRow } from '../db';
 import { randomUUID } from 'crypto';
 import { countWords } from '../lib/html-to-markdown';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
 // GET /api/collections
 app.get('/', (c) => {
+  const language = resolveLanguage(c.req.query('language'));
   const collections = db.prepare(`
     SELECT c.*, COUNT(l.id) as lessonCount,
       COALESCE(AVG(l.progress_percentComplete), 0) as avgProgress
     FROM collections c
     LEFT JOIN lessons l ON l.collectionId = c.id
+    WHERE c.language = ?
     GROUP BY c.id
     ORDER BY c.lastReadAt DESC
-  `).all() as (CollectionRow & { lessonCount: number; avgProgress: number })[];
+  `).all(language) as (CollectionRow & { lessonCount: number; avgProgress: number })[];
 
   return c.json(collections);
 });
@@ -24,11 +27,12 @@ app.post('/', async (c) => {
   const body = await c.req.json();
   const id = body.id || randomUUID();
   const now = new Date().toISOString();
+  const language = resolveLanguage(body.language);
 
   db.prepare(`
-    INSERT INTO collections (id, title, author, coverUrl, createdAt, lastReadAt)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(id, body.title, body.author || 'Unknown', body.coverUrl || null, now, now);
+    INSERT INTO collections (id, title, author, coverUrl, createdAt, lastReadAt, language)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(id, body.title, body.author || 'Unknown', body.coverUrl || null, now, now, language);
 
   return c.json({ id });
 });
@@ -102,6 +106,10 @@ app.post('/:id/lessons', async (c) => {
   const id = body.id || randomUUID();
   const now = new Date().toISOString();
 
+  // Inherit language from parent collection
+  const collection = db.prepare('SELECT language FROM collections WHERE id = ?').get(collectionId) as { language: string } | undefined;
+  const language = collection?.language || resolveLanguage(body.language);
+
   const maxOrder = db.prepare(
     'SELECT COALESCE(MAX(sortOrder), -1) as maxOrder FROM lessons WHERE collectionId = ?'
   ).get(collectionId) as { maxOrder: number };
@@ -109,9 +117,9 @@ app.post('/:id/lessons', async (c) => {
   const textContent = body.textContent || '';
 
   db.prepare(`
-    INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, createdAt, lastReadAt)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, collectionId, body.title, maxOrder.maxOrder + 1, textContent, countWords(textContent), now, now);
+    INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, createdAt, lastReadAt, language)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, collectionId, body.title, maxOrder.maxOrder + 1, textContent, countWords(textContent), now, now, language);
 
   db.prepare('UPDATE collections SET lastReadAt = ? WHERE id = ?').run(now, collectionId);
 

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -6,7 +6,7 @@ import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
-// GET /api/data
+// GET /api/data — exports ALL languages (full backup, not filtered by active language)
 app.get('/', (c) => {
   const collections = db.prepare('SELECT * FROM collections').all();
   const lessons = db.prepare('SELECT * FROM lessons').all();

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { db } from '../db';
 import { countWords } from '../lib/html-to-markdown';
 import { randomUUID } from 'crypto';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
@@ -24,6 +25,7 @@ app.get('/', (c) => {
 // POST /api/data
 app.post('/', async (c) => {
   const data = await c.req.json();
+  const language = resolveLanguage(data.language);
   const results = {
     collections: 0, lessons: 0, vocab: 0, knownWords: 0,
     clozeSentences: 0, dailyStats: 0, settings: 0,
@@ -31,26 +33,28 @@ app.post('/', async (c) => {
 
   if (data.collections?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO collections (id, title, author, coverUrl, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO collections (id, title, author, coverUrl, createdAt, lastReadAt, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
     for (const col of data.collections) {
       stmt.run(col.id, col.title, col.author || 'Unknown', col.coverUrl || null,
-        col.createdAt || new Date().toISOString(), col.lastReadAt || new Date().toISOString());
+        col.createdAt || new Date().toISOString(), col.lastReadAt || new Date().toISOString(),
+        col.language || language);
       results.collections++;
     }
   }
 
   if (data.lessons?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO lessons (id, collectionId, title, sortOrder, textContent, progress_scrollPosition, progress_percentComplete, wordCount, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO lessons (id, collectionId, title, sortOrder, textContent, progress_scrollPosition, progress_percentComplete, wordCount, createdAt, lastReadAt, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const l of data.lessons) {
       stmt.run(l.id, l.collectionId || null, l.title, l.sortOrder || 0,
         l.textContent || '', l.progress_scrollPosition || 0, l.progress_percentComplete || 0,
         l.wordCount || countWords(l.textContent || ''),
-        l.createdAt || new Date().toISOString(), l.lastReadAt || new Date().toISOString());
+        l.createdAt || new Date().toISOString(), l.lastReadAt || new Date().toISOString(),
+        l.language || language);
       results.lessons++;
     }
   }
@@ -85,8 +89,8 @@ app.post('/', async (c) => {
 
   if (data.vocab?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO vocab (id, text, type, sentence, translation, state, stateUpdatedAt, reviewCount, bookId, chapter, createdAt, pushedToAnki, ankiNoteId)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO vocab (id, text, type, sentence, translation, state, stateUpdatedAt, reviewCount, bookId, chapter, createdAt, pushedToAnki, ankiNoteId, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const v of data.vocab) {
@@ -95,24 +99,24 @@ app.post('/', async (c) => {
         v.state || 'new', v.stateUpdatedAt || new Date().toISOString(),
         v.reviewCount || 0, v.bookId || null, v.chapter || null,
         v.createdAt || new Date().toISOString(), v.pushedToAnki ? 1 : 0,
-        v.ankiNoteId || null
+        v.ankiNoteId || null, v.language || language
       );
       results.vocab++;
     }
   }
 
   if (data.knownWords?.length) {
-    const stmt = db.prepare('INSERT OR REPLACE INTO knownWords (word, state) VALUES (?, ?)');
+    const stmt = db.prepare('INSERT OR REPLACE INTO knownWords (word, language, state) VALUES (?, ?, ?)');
     for (const w of data.knownWords) {
-      stmt.run(w.word, w.state);
+      stmt.run(w.word, w.language || language, w.state);
       results.knownWords++;
     }
   }
 
   if (data.clozeSentences?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const cs of data.clozeSentences) {
@@ -121,7 +125,8 @@ app.post('/', async (c) => {
         cs.source || 'tatoeba', cs.collection || 'random', cs.wordRank || null,
         cs.tatoebaSentenceId || null, cs.vocabEntryId || null, cs.masteryLevel || 0,
         cs.nextReview || new Date().toISOString(), cs.reviewCount || 0,
-        cs.lastReviewed || null, cs.timesCorrect || 0, cs.timesIncorrect || 0
+        cs.lastReviewed || null, cs.timesCorrect || 0, cs.timesIncorrect || 0,
+        cs.language || language
       );
       results.clozeSentences++;
     }

--- a/api/src/routes/explain.ts
+++ b/api/src/routes/explain.ts
@@ -1,23 +1,28 @@
 import { Hono } from 'hono';
 import { getProvider } from '../lib/llm';
+import { getActiveLanguageConfig } from '../lib/active-language';
+import { isValidLanguageCode, LANGUAGES } from '../lib/languages';
 
 const app = new Hono();
 
 // POST /api/explain
 app.post('/', async (c) => {
   try {
-    const { sentence, translation, clozeWord } = await c.req.json();
+    const { sentence, translation, clozeWord, language: reqLang } = await c.req.json();
 
     if (!sentence || !translation) {
       return c.json({ error: 'sentence and translation are required' }, 400);
     }
+
+    const langConfig = reqLang && isValidLanguageCode(reqLang) ? LANGUAGES[reqLang] : getActiveLanguageConfig();
+    const langName = langConfig.name;
 
     const provider = getProvider();
     const text = await provider.complete({
       messages: [
         {
           role: 'user',
-          content: `Break down this Afrikaans sentence for a language learner. Explain each word, its role in the sentence, and any grammar points. Keep it concise but educational. Focus especially on the word "${clozeWord}" since that's the word being studied.
+          content: `Break down this ${langName} sentence for a language learner. Explain each word, its role in the sentence, and any grammar points. Keep it concise but educational. Focus especially on the word "${clozeWord}" since that's the word being studied.
 
 Sentence: "${sentence}"
 Translation: "${translation}"

--- a/api/src/routes/import.ts
+++ b/api/src/routes/import.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { db } from '../db';
 import { parseEpub } from '../lib/epub-parser';
 import { randomUUID } from 'crypto';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
@@ -20,25 +21,26 @@ app.post('/epub', async (c) => {
     const parsed = parseEpub(buffer);
     const collectionId = randomUUID();
     const now = new Date().toISOString();
+    const language = resolveLanguage();
 
     const insertCollection = db.prepare(`
-      INSERT INTO collections (id, title, author, coverUrl, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO collections (id, title, author, coverUrl, createdAt, lastReadAt, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
 
     const insertLesson = db.prepare(`
-      INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, createdAt, lastReadAt, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     db.transaction(() => {
-      insertCollection.run(collectionId, parsed.title, parsed.author, null, now, now);
+      insertCollection.run(collectionId, parsed.title, parsed.author, null, now, now, language);
 
       for (let i = 0; i < parsed.chapters.length; i++) {
         const chapter = parsed.chapters[i];
         insertLesson.run(
           randomUUID(), collectionId, chapter.title, i,
-          chapter.markdown, chapter.wordCount, now, now
+          chapter.markdown, chapter.wordCount, now, now, language
         );
       }
     })();

--- a/api/src/routes/journal-correct.ts
+++ b/api/src/routes/journal-correct.ts
@@ -1,25 +1,30 @@
 import { Hono } from 'hono';
 import { getProvider } from '../lib/llm';
+import { getActiveLanguageConfig } from '../lib/active-language';
+import { isValidLanguageCode, LANGUAGES } from '../lib/languages';
 
 const app = new Hono();
 
 // POST /api/journal-correct
 app.post('/', async (c) => {
   try {
-    const { body } = await c.req.json();
+    const { body, language: reqLang } = await c.req.json();
 
     if (!body?.trim()) {
       return c.json({ error: 'body is required' }, 400);
     }
+
+    const langConfig = reqLang && isValidLanguageCode(reqLang) ? LANGUAGES[reqLang] : getActiveLanguageConfig();
+    const langName = langConfig.name;
 
     const provider = getProvider();
     const text = await provider.complete({
       messages: [
         {
           role: 'user',
-          content: `You are an Afrikaans language tutor reviewing a student's journal entry. The student is an English speaker learning Afrikaans.
+          content: `You are a ${langName} language tutor reviewing a student's journal entry. The student is an English speaker learning ${langName}.
 
-Correct the following Afrikaans text. For each error found, provide the correction and a brief explanation in English.
+Correct the following ${langName} text. For each error found, provide the correction and a brief explanation in English.
 
 Student's text:
 """
@@ -27,7 +32,7 @@ ${body}
 """
 
 Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
-{"correctedBody": "the full corrected text in Afrikaans", "corrections": [{"original": "the incorrect word or phrase", "corrected": "the correct version", "explanation": "brief English explanation of why this is wrong and the rule", "type": "grammar|spelling|word_choice|word_order|missing_word|extra_word"}]}
+{"correctedBody": "the full corrected text in ${langName}", "corrections": [{"original": "the incorrect word or phrase", "corrected": "the correct version", "explanation": "brief English explanation of why this is wrong and the rule", "type": "grammar|spelling|word_choice|word_order|missing_word|extra_word"}]}
 
 If the text is perfect, return an empty corrections array.
 Focus on: spelling errors, grammar (verb conjugation, tense, word order), word choice, missing or extra words, and idiomatic corrections.

--- a/api/src/routes/known-words.ts
+++ b/api/src/routes/known-words.ts
@@ -1,11 +1,13 @@
 import { Hono } from 'hono';
 import { db, KnownWordRow } from '../db';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
 // GET /api/known-words
 app.get('/', (c) => {
-  const words = db.prepare('SELECT * FROM knownWords').all() as KnownWordRow[];
+  const language = resolveLanguage(c.req.query('language'));
+  const words = db.prepare('SELECT * FROM knownWords WHERE language = ?').all(language) as KnownWordRow[];
   const map: Record<string, string> = {};
   for (const w of words) {
     map[w.word] = w.state;
@@ -21,10 +23,11 @@ app.post('/', async (c) => {
     return c.json({ error: 'updates array required' }, 400);
   }
 
-  const stmt = db.prepare('INSERT OR REPLACE INTO knownWords (word, state) VALUES (?, ?)');
+  const language = resolveLanguage(body.language);
+  const stmt = db.prepare('INSERT OR REPLACE INTO knownWords (word, language, state) VALUES (?, ?, ?)');
   db.transaction(() => {
     for (const u of body.updates) {
-      stmt.run(u.word.toLowerCase(), u.state);
+      stmt.run(u.word.toLowerCase(), language, u.state);
     }
   })();
 

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -119,7 +119,7 @@ app.get('/fluency', (c) => {
             100
         );
 
-  // Weekly growth: words marked known in last 7 days vs previous 7 days
+  // Weekly growth: vocab words updated to 'known' in last 7 days vs previous 7 (per-language)
   const today = getTodayDate();
   const d7 = new Date();
   d7.setDate(d7.getDate() - 6);
@@ -134,12 +134,12 @@ app.get('/fluency', (c) => {
   const prevWeekEnd = d8.toISOString().split('T')[0];
 
   const thisWeekRow = db.prepare(
-    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ?'
-  ).get(weekStart, today) as { total: number };
+    "SELECT COUNT(*) as total FROM vocab WHERE language = ? AND state = 'known' AND stateUpdatedAt BETWEEN ? AND ?"
+  ).get(language, weekStart, today + 'T23:59:59') as { total: number };
 
   const prevWeekRow = db.prepare(
-    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ?'
-  ).get(prevWeekStart, prevWeekEnd) as { total: number };
+    "SELECT COUNT(*) as total FROM vocab WHERE language = ? AND state = 'known' AND stateUpdatedAt BETWEEN ? AND ?"
+  ).get(language, prevWeekStart, prevWeekEnd + 'T23:59:59') as { total: number };
 
   return c.json({
     totalKnownWords,

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { db, DailyStatsRow } from '../db';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
@@ -76,10 +77,11 @@ app.put('/today', async (c) => {
 
 // GET /api/stats/fluency
 app.get('/fluency', (c) => {
+  const language = resolveLanguage(c.req.query('language'));
   // Count words by state from knownWords table
   const stateCounts = db.prepare(
-    'SELECT state, COUNT(*) as count FROM knownWords GROUP BY state'
-  ).all() as { state: string; count: number }[];
+    'SELECT state, COUNT(*) as count FROM knownWords WHERE language = ? GROUP BY state'
+  ).all(language) as { state: string; count: number }[];
 
   const countMap: Record<string, number> = {};
   for (const row of stateCounts) {

--- a/api/src/routes/tatoeba.ts
+++ b/api/src/routes/tatoeba.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono';
+import { getActiveLanguageConfig } from '../lib/active-language';
+import { isValidLanguageCode, LANGUAGES } from '../lib/languages';
 
 interface TatoebaApiSentence {
   id: number;
@@ -34,9 +36,12 @@ const app = new Hono();
 app.get('/', async (c) => {
   const limit = c.req.query('limit') || '20';
   const query = c.req.query('query');
+  const reqLang = c.req.query('language');
+
+  const langConfig = reqLang && isValidLanguageCode(reqLang) ? LANGUAGES[reqLang] : getActiveLanguageConfig();
 
   const params = new URLSearchParams({
-    from: 'afr',
+    from: langConfig.tatoebaCode,
     to: 'eng',
     sort: query ? 'relevance' : 'random',
     limit: Math.min(parseInt(limit), 100).toString(),

--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { getProvider } from '../lib/llm';
-
 import { db } from '../db';
+import { getActiveLanguageConfig } from '../lib/active-language';
+import { isValidLanguageCode } from '../lib/languages';
 
 function recordStudyPing() {
   const today = new Date().toISOString().split('T')[0];
@@ -21,7 +22,7 @@ const app = new Hono();
 // POST /api/translate
 app.post('/', async (c) => {
   try {
-    const { word, sentence, type = 'word' } = await c.req.json();
+    const { word, sentence, type = 'word', language: reqLang } = await c.req.json();
 
     if (!word) {
       return c.json({ error: 'Word is required' }, 400);
@@ -29,8 +30,13 @@ app.post('/', async (c) => {
 
     recordStudyPing();
 
+    const langConfig = reqLang && isValidLanguageCode(reqLang)
+      ? (await import('../lib/languages')).LANGUAGES[reqLang]
+      : getActiveLanguageConfig();
+    const langName = langConfig.name;
+
     if (type === 'phrase') {
-      const prompt = `You are an Afrikaans to English translator. Translate the following Afrikaans phrase, using the sentence context to determine the correct meaning.
+      const prompt = `You are a ${langName} to English translator. Translate the following ${langName} phrase, using the sentence context to determine the correct meaning.
 
 Phrase: "${word}"
 Sentence context: "${sentence || word}"
@@ -49,7 +55,7 @@ Include idiomaticMeaning only if the phrase is an idiom or has a meaning that di
 
       return c.json(JSON.parse(text));
     } else {
-      const prompt = `You are an Afrikaans to English translator. Translate the following Afrikaans word, using the sentence context to determine the correct meaning.
+      const prompt = `You are a ${langName} to English translator. Translate the following ${langName} word, using the sentence context to determine the correct meaning.
 
 Word: "${word}"
 Sentence context: "${sentence || word}"

--- a/api/src/routes/tts.ts
+++ b/api/src/routes/tts.ts
@@ -1,18 +1,15 @@
 import { Hono } from 'hono';
+import { getActiveLanguageConfig } from '../lib/active-language';
+import { isValidLanguageCode, LANGUAGES } from '../lib/languages';
 
 const GOOGLE_TTS_URL = 'https://texttospeech.googleapis.com/v1/text:synthesize';
-
-const AFRIKAANS_VOICE = {
-  languageCode: 'af-ZA',
-  name: 'af-ZA-Standard-A',
-};
 
 const app = new Hono();
 
 // POST /api/tts
 app.post('/', async (c) => {
   try {
-    const { text, rate = 0.9 } = await c.req.json();
+    const { text, rate = 0.9, language: reqLang } = await c.req.json();
 
     if (!text || typeof text !== 'string') {
       return c.json({ error: 'Text is required' }, 400);
@@ -24,11 +21,13 @@ app.post('/', async (c) => {
       return c.json({ error: 'Google Cloud API key not configured', fallback: true }, 503);
     }
 
+    const langConfig = reqLang && isValidLanguageCode(reqLang) ? LANGUAGES[reqLang] : getActiveLanguageConfig();
+
     const synthesizeRequest = {
       input: { text },
       voice: {
-        languageCode: AFRIKAANS_VOICE.languageCode,
-        name: AFRIKAANS_VOICE.name,
+        languageCode: langConfig.ttsCode,
+        name: langConfig.ttsVoice,
       },
       audioConfig: {
         audioEncoding: 'MP3' as const,

--- a/api/src/routes/vocab.ts
+++ b/api/src/routes/vocab.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { db, VocabRow } from '../db';
 import { randomUUID } from 'crypto';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
@@ -9,9 +10,10 @@ app.get('/', (c) => {
   const state = c.req.query('state');
   const bookId = c.req.query('bookId');
   const unpushed = c.req.query('unpushed');
+  const language = resolveLanguage(c.req.query('language'));
 
-  let query = 'SELECT * FROM vocab WHERE 1=1';
-  const params: unknown[] = [];
+  let query = 'SELECT * FROM vocab WHERE language = ?';
+  const params: unknown[] = [language];
 
   if (state) { query += ' AND state = ?'; params.push(state); }
   if (bookId) { query += ' AND bookId = ?'; params.push(bookId); }
@@ -34,17 +36,18 @@ app.post('/', async (c) => {
   const body = await c.req.json();
   const id = body.id || randomUUID();
   const now = new Date().toISOString();
+  const language = resolveLanguage(body.language);
 
   db.prepare(`
-    INSERT OR REPLACE INTO vocab (id, text, type, sentence, translation, state, stateUpdatedAt, reviewCount, bookId, chapter, createdAt, pushedToAnki, ankiNoteId)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT OR REPLACE INTO vocab (id, text, type, sentence, translation, state, stateUpdatedAt, reviewCount, bookId, chapter, createdAt, pushedToAnki, ankiNoteId, language)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id, body.text, body.type || 'word', body.sentence || '', body.translation || '',
     body.state || 'new', now, body.reviewCount || 0, body.bookId || null,
-    body.chapter || null, now, body.pushedToAnki ? 1 : 0, body.ankiNoteId || null
+    body.chapter || null, now, body.pushedToAnki ? 1 : 0, body.ankiNoteId || null, language
   );
 
-  db.prepare('INSERT OR REPLACE INTO knownWords (word, state) VALUES (?, ?)').run(body.text.toLowerCase(), body.state || 'new');
+  db.prepare('INSERT OR REPLACE INTO knownWords (word, language, state) VALUES (?, ?, ?)').run(body.text.toLowerCase(), language, body.state || 'new');
 
   return c.json({ id });
 });
@@ -73,7 +76,8 @@ app.put('/:id', async (c) => {
   if (body.state !== undefined) {
     updates.push('state = ?', 'stateUpdatedAt = ?');
     values.push(body.state, new Date().toISOString());
-    db.prepare('INSERT OR REPLACE INTO knownWords (word, state) VALUES (?, ?)').run(existing.text.toLowerCase(), body.state);
+    const lang = (existing as VocabRow & { language?: string }).language || 'af';
+    db.prepare('INSERT OR REPLACE INTO knownWords (word, language, state) VALUES (?, ?, ?)').run(existing.text.toLowerCase(), lang, body.state);
   }
   if (body.translation !== undefined) { updates.push('translation = ?'); values.push(body.translation); }
   if (body.sentence !== undefined) { updates.push('sentence = ?'); values.push(body.sentence); }
@@ -92,15 +96,15 @@ app.put('/:id', async (c) => {
 // DELETE /api/vocab/:id
 app.delete('/:id', (c) => {
   const id = c.req.param('id');
-  const vocab = db.prepare('SELECT text FROM vocab WHERE id = ?').get(id) as { text: string } | undefined;
+  const vocab = db.prepare('SELECT text, language FROM vocab WHERE id = ?').get(id) as { text: string; language: string } | undefined;
 
   if (!vocab) return c.json({ error: 'Vocab not found' }, 404);
 
   db.prepare('DELETE FROM vocab WHERE id = ?').run(id);
 
-  const others = db.prepare('SELECT COUNT(*) as count FROM vocab WHERE LOWER(text) = ?').get(vocab.text.toLowerCase()) as { count: number };
+  const others = db.prepare('SELECT COUNT(*) as count FROM vocab WHERE LOWER(text) = ? AND language = ?').get(vocab.text.toLowerCase(), vocab.language) as { count: number };
   if (others.count === 0) {
-    db.prepare('DELETE FROM knownWords WHERE word = ?').run(vocab.text.toLowerCase());
+    db.prepare('DELETE FROM knownWords WHERE word = ? AND language = ?').run(vocab.text.toLowerCase(), vocab.language);
   }
 
   return c.json({ success: true });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,14 @@
+import { request } from '@playwright/test';
+
+const BASE_URL = 'http://localhost:3456';
+
+export default async function globalSetup() {
+  const context = await request.newContext({ baseURL: BASE_URL });
+
+  // Seed targetLanguage setting so e2e tests don't get redirected to /setup
+  await context.put('/api/settings/targetLanguage', {
+    data: { value: 'af' },
+  });
+
+  await context.dispose();
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
+  globalSetup: './e2e/global-setup.ts',
   testDir: "./e2e",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/src/app/api/journal/route.ts
+++ b/src/app/api/journal/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, JournalEntryRow } from '@/lib/server/database';
 import { randomUUID } from 'crypto';
+import { resolveLanguage } from '@/lib/server/active-language';
 
 // GET /api/journal - List entries, optionally filtered by date
 export async function GET(request: NextRequest) {
@@ -8,12 +9,12 @@ export async function GET(request: NextRequest) {
   const date = searchParams.get('date');
   const limit = parseInt(searchParams.get('limit') || '20', 10);
   const offset = parseInt(searchParams.get('offset') || '0', 10);
+  const language = resolveLanguage(searchParams.get('language'));
 
   if (date) {
-    // Return all entries for a given date
     const entries = db.prepare(
-      'SELECT * FROM journal_entries WHERE entryDate = ? ORDER BY createdAt DESC'
-    ).all(date) as JournalEntryRow[];
+      'SELECT * FROM journal_entries WHERE entryDate = ? AND language = ? ORDER BY createdAt DESC'
+    ).all(date, language) as JournalEntryRow[];
     return NextResponse.json(entries.map(e => ({
       ...e,
       corrections: e.corrections ? JSON.parse(e.corrections) : null,
@@ -21,8 +22,8 @@ export async function GET(request: NextRequest) {
   }
 
   const entries = db.prepare(
-    'SELECT * FROM journal_entries ORDER BY createdAt DESC LIMIT ? OFFSET ?'
-  ).all(limit, offset) as JournalEntryRow[];
+    'SELECT * FROM journal_entries WHERE language = ? ORDER BY createdAt DESC LIMIT ? OFFSET ?'
+  ).all(language, limit, offset) as JournalEntryRow[];
 
   return NextResponse.json(entries.map(e => ({
     ...e,
@@ -36,12 +37,13 @@ export async function POST(request: NextRequest) {
   const date = entryDate || new Date().toISOString().split('T')[0];
   const now = new Date().toISOString();
   const wordCount = (body || '').trim().split(/\s+/).filter(Boolean).length;
+  const language = resolveLanguage();
 
   const id = randomUUID();
   db.prepare(`
-    INSERT INTO journal_entries (id, body, status, wordCount, entryDate, createdAt, updatedAt)
-    VALUES (?, ?, 'draft', ?, ?, ?, ?)
-  `).run(id, body || '', wordCount, date, now, now);
+    INSERT INTO journal_entries (id, body, status, wordCount, entryDate, createdAt, updatedAt, language)
+    VALUES (?, ?, 'draft', ?, ?, ?, ?, ?)
+  `).run(id, body || '', wordCount, date, now, now, language);
 
   return NextResponse.json({ id, entryDate: date });
 }

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { resolveLanguage, getActiveLanguageConfig } from '@/lib/server/active-language';
+import { getActiveLanguageConfig } from '@/lib/server/active-language';
 import { isValidLanguageCode, LANGUAGES } from '@/lib/languages';
 
 // Google Cloud TTS API endpoint

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveLanguage, getActiveLanguageConfig } from '@/lib/server/active-language';
+import { isValidLanguageCode, LANGUAGES } from '@/lib/languages';
 
 // Google Cloud TTS API endpoint
 const GOOGLE_TTS_URL = 'https://texttospeech.googleapis.com/v1/text:synthesize';
-
-// Afrikaans voice options (Neural2 voices are highest quality)
-const AFRIKAANS_VOICE = {
-  languageCode: 'af-ZA',
-  name: 'af-ZA-Standard-A', // Standard female voice
-  // Alternative: 'af-ZA-Wavenet-A' for WaveNet quality (if available)
-};
 
 interface SynthesizeRequest {
   input: { text: string };
@@ -26,7 +21,7 @@ interface SynthesizeRequest {
 
 export async function POST(request: NextRequest) {
   try {
-    const { text, rate = 0.9 } = await request.json();
+    const { text, rate = 0.9, language: reqLang } = await request.json();
 
     if (!text || typeof text !== 'string') {
       return NextResponse.json(
@@ -45,12 +40,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const langConfig = reqLang && isValidLanguageCode(reqLang) ? LANGUAGES[reqLang] : getActiveLanguageConfig();
+
     // Prepare the request to Google Cloud TTS
     const synthesizeRequest: SynthesizeRequest = {
       input: { text },
       voice: {
-        languageCode: AFRIKAANS_VOICE.languageCode,
-        name: AFRIKAANS_VOICE.name,
+        languageCode: langConfig.ttsCode,
+        name: langConfig.ttsVoice,
       },
       audioConfig: {
         audioEncoding: 'MP3',

--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -392,7 +392,7 @@ export default function JournalPage() {
               <textarea
                 value={bodyText}
                 onChange={(e) => handleBodyChange(e.target.value)}
-                placeholder="Skryf vandag se joernaal inskrywing in Afrikaans..."
+                placeholder="Write today's journal entry in your target language..."
                 className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-4 text-sm leading-relaxed text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y min-h-[160px]"
                 disabled={isSubmitting}
                 autoFocus

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, Literata } from "next/font/google";
 import "./globals.css";
+import SetupGuard from "@/components/SetupGuard";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -30,7 +31,9 @@ export default function RootLayout({
       <body
         className={`${inter.variable} ${literata.variable} font-sans antialiased bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen`}
       >
-        {children}
+        <SetupGuard>
+          {children}
+        </SetupGuard>
         {/* Spacer for mobile bottom nav — invisible on sm+ */}
         <div className="h-16 sm:hidden" aria-hidden="true" />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,7 +263,7 @@ function EmptyState({ onImport }: { onImport: () => void }) {
         No books in your library
       </h3>
       <p className="mb-6 max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
-        Import an Afrikaans book (EPUB or Markdown) to start learning. Your vocabulary and progress will be
+        Import a book (EPUB or Markdown) to start learning. Your vocabulary and progress will be
         tracked as you read.
       </p>
       <button

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -25,7 +25,7 @@ import { translateWord } from '@/lib/claude';
 import { lookupWord } from '@/lib/dictionary';
 
 const ANKI_CLOZE_DECK_SETTING_KEY = 'lector-anki-cloze-deck';
-const DEFAULT_ANKI_CLOZE_DECK = 'Afrikaans::Cloze';
+const DEFAULT_ANKI_CLOZE_DECK = 'Lector::Cloze';
 
 // Strip trailing punctuation from a word, returning [cleanWord, punctuation]
 function splitTrailingPunctuation(word: string): [string, string] {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import NavHeader from "@/components/NavHeader";
 import { getDeckNames, isAnkiConnected } from "@/lib/anki";
 import { getTTSMode, setTTSMode, isGoogleTTSConfigured, speak, type TTSMode } from "@/lib/tts";
+import { LANGUAGES, type LanguageCode, DEFAULT_LANGUAGE } from "@/lib/languages";
 import {
   exportAllData,
   clearAllData,
@@ -68,8 +69,8 @@ interface AppSettings {
 const defaultSettings: AppSettings = {
   apiKey: "",
   googleApiKey: "",
-  ankiDeckName: "Afrikaans",
-  ankiClozeDeckName: "Afrikaans::Cloze",
+  ankiDeckName: "Lector",
+  ankiClozeDeckName: "Lector::Cloze",
   defaultCardType: "basic",
   ttsSpeed: 1.0,
   ttsMode: "google",
@@ -113,6 +114,9 @@ export default function SettingsPage() {
   const [googleTTSAvailable, setGoogleTTSAvailable] = useState<boolean | null>(null);
   const [showGoogleApiKey, setShowGoogleApiKey] = useState(false);
 
+  // Language state
+  const [activeLanguage, setActiveLanguage] = useState<LanguageCode>(DEFAULT_LANGUAGE);
+
   // API Token state
   const [apiTokens, setApiTokens] = useState<ApiTokenMeta[]>([]);
   const [showTokenForm, setShowTokenForm] = useState(false);
@@ -128,9 +132,9 @@ export default function SettingsPage() {
       apiKey: localStorage.getItem(SETTINGS_KEYS.ANTHROPIC_API_KEY) || "",
       googleApiKey: localStorage.getItem(SETTINGS_KEYS.GOOGLE_CLOUD_API_KEY) || "",
       ankiDeckName:
-        localStorage.getItem(SETTINGS_KEYS.ANKI_DECK_NAME) || "Afrikaans",
+        localStorage.getItem(SETTINGS_KEYS.ANKI_DECK_NAME) || "Lector",
       ankiClozeDeckName:
-        localStorage.getItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME) || "Afrikaans::Cloze",
+        localStorage.getItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME) || "Lector::Cloze",
       defaultCardType:
         (localStorage.getItem(SETTINGS_KEYS.DEFAULT_CARD_TYPE) as CardType) ||
         "basic",
@@ -178,7 +182,21 @@ export default function SettingsPage() {
 
     // Load API tokens
     getApiTokens().then(setApiTokens).catch(() => {});
+
+    // Load active language
+    getSetting<string>('targetLanguage').then((lang) => {
+      if (lang && lang in LANGUAGES) setActiveLanguage(lang as LanguageCode);
+    });
   }, []);
+
+  // Switch language
+  const switchLanguage = async (code: LanguageCode) => {
+    setActiveLanguage(code);
+    await setSetting('targetLanguage', code);
+    localStorage.setItem('lector-target-language', code);
+    // Reset TTS voice cache when switching languages
+    localStorage.removeItem('lector-tts-voice');
+  };
 
   // Check Anki connection
   const checkAnkiConnection = useCallback(async () => {
@@ -504,7 +522,7 @@ export default function SettingsPage() {
         ),
       ].join("\n");
 
-      downloadFile(csv, "afrikaans-vocab.csv", "text/csv");
+      downloadFile(csv, "lector-vocab.csv", "text/csv");
       setExportStatus("Vocab exported as CSV.");
     } catch (error) {
       setExportStatus(`Export failed: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -516,7 +534,7 @@ export default function SettingsPage() {
     try {
       const vocab = await getAllVocab();
       const json = JSON.stringify(vocab, null, 2);
-      downloadFile(json, "afrikaans-vocab.json", "application/json");
+      downloadFile(json, "lector-vocab.json", "application/json");
       setExportStatus("Vocab exported as JSON.");
     } catch (error) {
       setExportStatus(`Export failed: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -531,7 +549,7 @@ export default function SettingsPage() {
         .filter((w) => w.state === "known")
         .map((w) => w.word);
       const text = words.join("\n");
-      downloadFile(text, "afrikaans-known-words.txt", "text/plain");
+      downloadFile(text, "lector-known-words.txt", "text/plain");
       setExportStatus(`Exported ${words.length} known words.`);
     } catch (error) {
       setExportStatus(`Export failed: ${error instanceof Error ? error.message : "Unknown error"}`);
@@ -646,6 +664,39 @@ export default function SettingsPage() {
 
       <main className="mx-auto max-w-3xl px-4 py-8">
         <div className="space-y-8">
+          {/* Language Section */}
+          <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+            <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              Language
+            </h2>
+            <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+              Choose the language you are learning. All content is filtered by the active language.
+            </p>
+            <div className="grid grid-cols-3 gap-3">
+              {(Object.entries(LANGUAGES) as [LanguageCode, typeof LANGUAGES[LanguageCode]][]).map(
+                ([code, config]) => (
+                  <button
+                    key={code}
+                    onClick={() => switchLanguage(code)}
+                    className={`flex flex-col items-center gap-1.5 rounded-lg border-2 px-4 py-4 text-sm font-medium transition-all ${
+                      activeLanguage === code
+                        ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400"
+                        : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    }`}
+                  >
+                    <span className="text-xl">
+                      {code === "af" ? "\u{1F1FF}\u{1F1E6}" : code === "de" ? "\u{1F1E9}\u{1F1EA}" : "\u{1F1EA}\u{1F1F8}"}
+                    </span>
+                    <span>{config.native}</span>
+                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {config.name}
+                    </span>
+                  </button>
+                )
+              )}
+            </div>
+          </section>
+
           {/* AI Provider Section */}
           <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
             <div className="mb-4 flex items-center justify-between">
@@ -991,7 +1042,7 @@ export default function SettingsPage() {
                 Google Cloud API Key
               </label>
               <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
-                For high-quality Afrikaans pronunciation. Get a key from{" "}
+                For high-quality pronunciation. Get a key from{" "}
                 <a
                   href="https://console.cloud.google.com/apis/credentials"
                   target="_blank"
@@ -1060,7 +1111,11 @@ export default function SettingsPage() {
             {/* Test TTS */}
             <div className="mb-4">
               <button
-                onClick={() => speak("Hallo, hoe gaan dit met jou?", settings.ttsSpeed)}
+                onClick={() => {
+                  const lang = (localStorage.getItem('lector-target-language') || DEFAULT_LANGUAGE) as LanguageCode;
+                  const config = LANGUAGES[lang] || LANGUAGES[DEFAULT_LANGUAGE];
+                  speak(config.testPhrase, settings.ttsSpeed);
+                }}
                 className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
               >
                 Test Voice

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import NavHeader from "@/components/NavHeader";
 import { getDeckNames, isAnkiConnected } from "@/lib/anki";
-import { getTTSMode, setTTSMode, isGoogleTTSConfigured, speak, type TTSMode } from "@/lib/tts";
+import { getTTSMode, setTTSMode, isGoogleTTSConfigured, speak, resetVoiceCache, type TTSMode } from "@/lib/tts";
 import { LANGUAGES, type LanguageCode, DEFAULT_LANGUAGE } from "@/lib/languages";
 import {
   exportAllData,
@@ -194,8 +194,8 @@ export default function SettingsPage() {
     setActiveLanguage(code);
     await setSetting('targetLanguage', code);
     localStorage.setItem('lector-target-language', code);
-    // Reset TTS voice cache when switching languages
-    localStorage.removeItem('lector-tts-voice');
+    // Reset both persistent and in-memory TTS voice cache
+    resetVoiceCache();
   };
 
   // Check Anki connection

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { LANGUAGES, type LanguageCode } from "@/lib/languages";
+import { setSetting } from "@/lib/data-layer";
+
+const LANGUAGE_FLAGS: Record<LanguageCode, string> = {
+  af: "🇿🇦",
+  de: "🇩🇪",
+  es: "🇪🇸",
+};
+
+export default function SetupPage() {
+  const router = useRouter();
+  const [selecting, setSelecting] = useState(false);
+
+  const handleSelect = async (code: LanguageCode) => {
+    setSelecting(true);
+    try {
+      await setSetting("targetLanguage", code);
+      localStorage.setItem("lector-target-language", code);
+      router.replace("/");
+    } catch {
+      setSelecting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-zinc-50 dark:bg-zinc-950 px-4">
+      <div className="mb-10 flex flex-col items-center">
+        <Image
+          src="/logo.svg"
+          alt="Lector"
+          width={48}
+          height={48}
+          className="mb-4 rounded-lg"
+        />
+        <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+          Welcome to Lector
+        </h1>
+        <p className="mt-2 text-zinc-500 dark:text-zinc-400 text-center max-w-md">
+          Choose the language you want to learn. You can add more languages later in Settings.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 w-full max-w-2xl">
+        {(Object.entries(LANGUAGES) as [LanguageCode, typeof LANGUAGES[LanguageCode]][]).map(
+          ([code, config]) => (
+            <button
+              key={code}
+              onClick={() => handleSelect(code)}
+              disabled={selecting}
+              className="group flex flex-col items-center gap-3 rounded-xl border-2 border-zinc-200 bg-white p-8 transition-all hover:border-blue-500 hover:shadow-lg disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-blue-400"
+            >
+              <span className="text-5xl">{LANGUAGE_FLAGS[code]}</span>
+              <span className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                {config.native}
+              </span>
+              <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                {config.name}
+              </span>
+            </button>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -307,7 +307,7 @@ export default function VocabPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [selectedEntry, setSelectedEntry] = useState<VocabEntry | null>(null);
   const [ankiConnected, setAnkiConnected] = useState<boolean | null>(null);
-  const [ankiDeck, setAnkiDeck] = useState("Afrikaans");
+  const [ankiDeck, setAnkiDeck] = useState("Lector");
   const [notification, setNotification] = useState<{
     type: "success" | "error";
     message: string;

--- a/src/components/PasteImportModal.tsx
+++ b/src/components/PasteImportModal.tsx
@@ -149,7 +149,7 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
               value={content}
               onChange={(e) => setContent(e.target.value)}
               disabled={isSaving}
-              placeholder="Paste your Afrikaans text here..."
+              placeholder="Paste your text here..."
               rows={12}
               className="w-full px-4 py-3 rounded-lg border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 disabled:opacity-50 resize-none text-sm leading-relaxed"
             />

--- a/src/components/SetupGuard.tsx
+++ b/src/components/SetupGuard.tsx
@@ -7,16 +7,27 @@ import { getSetting } from "@/lib/data-layer";
 export default function SetupGuard({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
-  const [ready, setReady] = useState(false);
+
+  // Check localStorage synchronously to avoid flash for returning users
+  const [ready, setReady] = useState(() => {
+    if (typeof window === "undefined") return false;
+    if (pathname === "/setup") return true;
+    return !!localStorage.getItem("lector-target-language");
+  });
 
   useEffect(() => {
-    // Don't redirect if already on setup page
     if (pathname === "/setup") {
       setReady(true);
       return;
     }
 
-    // Check if targetLanguage is set
+    // Fast path: localStorage already has the language
+    if (localStorage.getItem("lector-target-language")) {
+      setReady(true);
+      return;
+    }
+
+    // Slow path: check server setting (first visit or cleared localStorage)
     async function check() {
       try {
         const lang = await getSetting<string>("targetLanguage");
@@ -24,7 +35,6 @@ export default function SetupGuard({ children }: { children: React.ReactNode }) 
           router.replace("/setup");
           return;
         }
-        // Sync to localStorage for client-side TTS/tatoeba use
         localStorage.setItem("lector-target-language", lang);
       } catch {
         // If the API is down, don't block — just continue
@@ -36,7 +46,6 @@ export default function SetupGuard({ children }: { children: React.ReactNode }) 
   }, [pathname, router]);
 
   if (!ready && pathname !== "/setup") {
-    // Show nothing while checking (avoids flash)
     return null;
   }
 

--- a/src/components/SetupGuard.tsx
+++ b/src/components/SetupGuard.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { getSetting } from "@/lib/data-layer";
+
+export default function SetupGuard({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // Don't redirect if already on setup page
+    if (pathname === "/setup") {
+      setReady(true);
+      return;
+    }
+
+    // Check if targetLanguage is set
+    async function check() {
+      try {
+        const lang = await getSetting<string>("targetLanguage");
+        if (!lang) {
+          router.replace("/setup");
+          return;
+        }
+        // Sync to localStorage for client-side TTS/tatoeba use
+        localStorage.setItem("lector-target-language", lang);
+      } catch {
+        // If the API is down, don't block — just continue
+      }
+      setReady(true);
+    }
+
+    check();
+  }, [pathname, router]);
+
+  if (!ready && pathname !== "/setup") {
+    // Show nothing while checking (avoids flash)
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/WebImportModal.tsx
+++ b/src/components/WebImportModal.tsx
@@ -216,7 +216,7 @@ export default function WebImportModal({ isOpen, onClose, onSave }: WebImportMod
               )}
 
               <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                Paste a URL to an Afrikaans news article or blog post. The article content will be extracted and added to your library.
+                Paste a URL to a news article or blog post. The article content will be extracted and added to your library.
               </p>
             </div>
           )}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -106,7 +106,7 @@ export interface Settings {
 // Database Class
 // ============================================================================
 
-class AfrikaansLearningDB extends Dexie {
+class LectorDB extends Dexie {
   vocab!: EntityTable<VocabEntry, 'id'>;
   knownWords!: EntityTable<KnownWord, 'word'>;
   clozeSentences!: EntityTable<ClozeSentence, 'id'>;
@@ -114,7 +114,7 @@ class AfrikaansLearningDB extends Dexie {
   settings!: EntityTable<Settings, 'key'>;
 
   constructor() {
-    super('AfrikaansLearningDB');
+    super('LectorDB');
 
     this.version(2).stores({
       // Vocab: indexed by id, with indexes for lookups and filtering
@@ -139,7 +139,7 @@ class AfrikaansLearningDB extends Dexie {
 }
 
 // Create and export the database instance
-export const db = new AfrikaansLearningDB();
+export const db = new LectorDB();
 
 // ============================================================================
 // Helper Functions - Vocabulary

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -141,6 +141,11 @@ class LectorDB extends Dexie {
 // Create and export the database instance
 export const db = new LectorDB();
 
+// Clean up orphaned legacy IndexedDB (renamed from AfrikaansLearningDB)
+if (typeof indexedDB !== 'undefined') {
+  indexedDB.deleteDatabase('AfrikaansLearningDB');
+}
+
 // ============================================================================
 // Helper Functions - Vocabulary
 // ============================================================================

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -17,7 +17,7 @@ const dictionaryMap = new Map<string, DictionaryEntry>();
 
 /**
  * Look up a word in the dictionary
- * @param word - The Afrikaans word to look up (case-insensitive)
+ * @param word - The word to look up (case-insensitive)
  * @returns The dictionary entry or undefined if not found
  */
 export function lookupWord(word: string): DictionaryEntry | undefined {
@@ -26,7 +26,7 @@ export function lookupWord(word: string): DictionaryEntry | undefined {
 
 /**
  * Check if a word exists in the dictionary
- * @param word - The Afrikaans word to check (case-insensitive)
+ * @param word - The word to check (case-insensitive)
  * @returns true if the word is in the dictionary
  */
 export function hasWord(word: string): boolean {
@@ -51,7 +51,7 @@ export function getDictionaryMap(): Map<string, DictionaryEntry> {
 
 /**
  * Get word frequency rank (lower = more common)
- * @param word - The Afrikaans word
+ * @param word - The word to check
  * @returns The rank (1-2000) or undefined if not in top 2000
  */
 export function getWordRank(word: string): number | undefined {

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -1,0 +1,86 @@
+export type LanguageCode = 'af' | 'de' | 'es';
+
+export interface LanguageConfig {
+  name: string;
+  native: string;
+  code: LanguageCode;
+  ttsCode: string;
+  ttsVoice: string;
+  tatoebaCode: string;
+  fallbackTts: string[];
+  avoidWords: Set<string>;
+  testPhrase: string;
+}
+
+const AF_AVOID_WORDS = new Set([
+  "'n", "die", "en", "of", "in", "op", "vir", "met", "na", "van",
+  "is", "het", "om", "te", "dat", "wat", "as", "aan", "by", "sy", "hy",
+  "nie", "ek", "jy", "ons", "hulle", "dit", "was", "sal", "kan", "moet",
+  "maar", "ook", "al", "nog", "so", "toe", "nou", "net", "eers", "dan",
+]);
+
+const DE_AVOID_WORDS = new Set([
+  "der", "die", "das", "ein", "eine", "und", "oder", "in", "auf", "für",
+  "mit", "nach", "von", "ist", "hat", "um", "zu", "dass", "was", "als",
+  "an", "bei", "sie", "er", "nicht", "ich", "du", "wir", "ihr", "es",
+  "war", "wird", "kann", "muss", "aber", "auch", "schon", "noch", "so",
+  "dann", "nur", "erst", "den", "dem", "des", "im", "am", "vom", "zum",
+]);
+
+const ES_AVOID_WORDS = new Set([
+  "el", "la", "los", "las", "un", "una", "y", "o", "en", "de",
+  "por", "con", "para", "del", "al", "es", "ha", "ser", "que", "como",
+  "a", "su", "él", "ella", "no", "yo", "tú", "nos", "ellos", "eso",
+  "fue", "será", "puede", "debe", "pero", "también", "ya", "aún", "así",
+  "muy", "más", "sin", "se", "me", "te", "lo", "le", "nos", "les",
+]);
+
+export const LANGUAGES: Record<LanguageCode, LanguageConfig> = {
+  af: {
+    name: 'Afrikaans',
+    native: 'Afrikaans',
+    code: 'af',
+    ttsCode: 'af-ZA',
+    ttsVoice: 'af-ZA-Standard-A',
+    tatoebaCode: 'afr',
+    fallbackTts: ['af', 'nl-NL', 'nl'],
+    avoidWords: AF_AVOID_WORDS,
+    testPhrase: 'Hallo, hoe gaan dit met jou?',
+  },
+  de: {
+    name: 'German',
+    native: 'Deutsch',
+    code: 'de',
+    ttsCode: 'de-DE',
+    ttsVoice: 'de-DE-Standard-A',
+    tatoebaCode: 'deu',
+    fallbackTts: ['de', 'de-DE'],
+    avoidWords: DE_AVOID_WORDS,
+    testPhrase: 'Hallo, wie geht es Ihnen?',
+  },
+  es: {
+    name: 'Spanish',
+    native: 'Español',
+    code: 'es',
+    ttsCode: 'es-ES',
+    ttsVoice: 'es-ES-Standard-A',
+    tatoebaCode: 'spa',
+    fallbackTts: ['es', 'es-ES', 'es-MX'],
+    avoidWords: ES_AVOID_WORDS,
+    testPhrase: '¡Hola! ¿Cómo estás?',
+  },
+};
+
+export const DEFAULT_LANGUAGE: LanguageCode = 'af';
+
+export function getLanguageConfig(code: LanguageCode): LanguageConfig {
+  return LANGUAGES[code];
+}
+
+export function isValidLanguageCode(code: string): code is LanguageCode {
+  return code in LANGUAGES;
+}
+
+export function getAllLanguages(): LanguageConfig[] {
+  return Object.values(LANGUAGES);
+}

--- a/src/lib/server/active-language.ts
+++ b/src/lib/server/active-language.ts
@@ -1,0 +1,29 @@
+import { db } from './database';
+import { type LanguageCode, LANGUAGES, DEFAULT_LANGUAGE, isValidLanguageCode } from '../languages';
+
+interface SettingRow {
+  value: string;
+}
+
+export function getActiveLanguageCode(): LanguageCode {
+  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('targetLanguage') as SettingRow | undefined;
+  if (!row) return DEFAULT_LANGUAGE;
+
+  try {
+    const code = JSON.parse(row.value);
+    if (typeof code === 'string' && isValidLanguageCode(code)) return code;
+  } catch {
+    if (typeof row.value === 'string' && isValidLanguageCode(row.value)) return row.value;
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+export function getActiveLanguageConfig() {
+  return LANGUAGES[getActiveLanguageCode()];
+}
+
+export function resolveLanguage(requestLang?: string | null): LanguageCode {
+  if (requestLang && isValidLanguageCode(requestLang)) return requestLang;
+  return getActiveLanguageCode();
+}

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -6,7 +6,8 @@ import { parseEpub } from './epub-parser';
 import { htmlToMarkdown, countWords } from '../html-to-markdown';
 
 const DATA_DIR = process.env.DATA_DIR || './data';
-const DB_PATH = path.join(DATA_DIR, 'afrikaans.db');
+const DB_PATH = path.join(DATA_DIR, 'lector.db');
+const LEGACY_DB_PATH = path.join(DATA_DIR, 'afrikaans.db');
 export const BOOKS_DIR = path.join(DATA_DIR, 'books');
 
 // Lazy initialization to avoid build-time database access
@@ -18,6 +19,11 @@ function getDb(): DatabaseType {
   // Ensure directories exist
   fs.mkdirSync(DATA_DIR, { recursive: true });
   fs.mkdirSync(BOOKS_DIR, { recursive: true });
+
+  // Migrate legacy DB filename
+  if (!fs.existsSync(DB_PATH) && fs.existsSync(LEGACY_DB_PATH)) {
+    fs.renameSync(LEGACY_DB_PATH, DB_PATH);
+  }
 
   _db = new Database(DB_PATH);
   _db.pragma('journal_mode = WAL');
@@ -168,7 +174,56 @@ function getDb(): DatabaseType {
   // Migrate books → collections/lessons if books table exists
   migrateBooks(_db);
 
+  // Add language column to all content tables
+  migrateAddLanguageColumn(_db);
+
   return _db;
+}
+
+/**
+ * Add language column to all content tables.
+ * Existing data gets tagged as 'af' (Afrikaans).
+ * knownWords needs table recreation for compound PK (word, language).
+ */
+function migrateAddLanguageColumn(database: DatabaseType) {
+  const tables = ['collections', 'lessons', 'vocab', 'clozeSentences', 'journal_entries'];
+
+  for (const table of tables) {
+    const cols = database.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    if (!cols.some(c => c.name === 'language')) {
+      database.exec(`ALTER TABLE ${table} ADD COLUMN language TEXT NOT NULL DEFAULT 'af'`);
+    }
+  }
+
+  // knownWords: needs compound PK (word, language) — recreate table
+  const kwCreate = database.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='table' AND name='knownWords'"
+  ).get() as { sql: string } | undefined;
+
+  if (kwCreate && !kwCreate.sql.includes('language')) {
+    database.transaction(() => {
+      database.exec(`
+        CREATE TABLE knownWords_new (
+          word TEXT NOT NULL,
+          language TEXT NOT NULL DEFAULT 'af',
+          state TEXT NOT NULL CHECK (state IN ('new', 'level1', 'level2', 'level3', 'level4', 'known', 'ignored')),
+          PRIMARY KEY (word, language)
+        );
+        INSERT INTO knownWords_new (word, language, state) SELECT word, 'af', state FROM knownWords;
+        DROP TABLE knownWords;
+        ALTER TABLE knownWords_new RENAME TO knownWords;
+      `);
+    })();
+  }
+
+  // Add language indexes
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_collections_language ON collections(language);
+    CREATE INDEX IF NOT EXISTS idx_lessons_language ON lessons(language);
+    CREATE INDEX IF NOT EXISTS idx_vocab_language ON vocab(language);
+    CREATE INDEX IF NOT EXISTS idx_cloze_language ON clozeSentences(language);
+    CREATE INDEX IF NOT EXISTS idx_journal_language ON journal_entries(language);
+  `);
 }
 
 /**
@@ -392,6 +447,7 @@ export interface VocabRow {
 
 export interface KnownWordRow {
   word: string;
+  language: string;
   state: WordState;
 }
 

--- a/src/lib/tatoeba.ts
+++ b/src/lib/tatoeba.ts
@@ -1,18 +1,18 @@
-// Tatoeba API client for fetching Afrikaans sentences with translations
+// Tatoeba API client for fetching sentences with translations
 
 import { lookupWord } from './dictionary';
 import { ClozeCollection } from './db';
+import { LANGUAGES, DEFAULT_LANGUAGE, type LanguageCode } from './languages';
 
 // Use local API route to avoid CORS issues
 const API_URL = "/api/tatoeba";
 
-// Common words to avoid using as cloze targets
-const AVOID_WORDS = new Set([
-  "'n", "die", "en", "of", "in", "op", "vir", "met", "na", "van",
-  "is", "het", "om", "te", "dat", "wat", "as", "aan", "by", "sy", "hy",
-  "nie", "ek", "jy", "ons", "hulle", "dit", "was", "sal", "kan", "moet",
-  "maar", "ook", "al", "nog", "so", "toe", "nou", "net", "eers", "dan",
-]);
+function getAvoidWords(): Set<string> {
+  if (typeof window === 'undefined') return LANGUAGES[DEFAULT_LANGUAGE].avoidWords;
+  const stored = localStorage.getItem('lector-target-language');
+  const code = (stored && stored in LANGUAGES ? stored : DEFAULT_LANGUAGE) as LanguageCode;
+  return LANGUAGES[code].avoidWords;
+}
 
 // Types
 export interface TatoebaSentence {
@@ -71,7 +71,7 @@ export function findBestClozeWord(sentence: string): { word: string; index: numb
     const cleanWord = words[i].replace(/[.,!?;:'"()[\]{}]/g, '').toLowerCase();
 
     // Skip short words and common words
-    if (cleanWord.length < 3 || AVOID_WORDS.has(cleanWord)) continue;
+    if (cleanWord.length < 3 || getAvoidWords().has(cleanWord)) continue;
 
     // Look up in dictionary
     const entry = lookupWord(cleanWord);

--- a/src/lib/tatoeba.ts
+++ b/src/lib/tatoeba.ts
@@ -27,11 +27,11 @@ export interface TatoebaSentence {
 }
 
 /**
- * Fetch random Afrikaans sentences with English translations
+ * Fetch random sentences in the target language with English translations
  * @param limit - Maximum number of sentences to fetch (default: 10, max: 100)
  * @returns Array of sentences with translations
  */
-export async function fetchAfrikaansSentences(
+export async function fetchSentences(
   limit: number = 10
 ): Promise<TatoebaSentence[]> {
   try {
@@ -172,7 +172,7 @@ export async function fetchBulkSentences(
 }
 
 /**
- * Search for Afrikaans sentences containing a specific word
+ * Search for sentences containing a specific word
  * @param word - The word to search for
  * @returns Array of sentences containing the word with English translations
  */

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -256,7 +256,7 @@ function speakWithBrowser(text: string, rate: number): void {
 }
 
 /**
- * Speak text in Afrikaans
+ * Speak text in the target language
  * Uses Google Cloud TTS if available, falls back to browser TTS
  * @param text - The text to speak
  * @param rate - Speech rate (default 0.9 for clearer learning)

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -1,14 +1,10 @@
-// Text-to-Speech wrapper for Afrikaans
+// Text-to-Speech wrapper — language-aware
 // Uses Google Cloud TTS when available, falls back to browser TTS
+
+import { type LanguageCode, LANGUAGES, DEFAULT_LANGUAGE } from './languages';
 
 // Default speech rate (1.0 is normal speed)
 const DEFAULT_RATE = 0.9;
-
-// Afrikaans language code
-const AFRIKAANS_LANG = "af-ZA";
-
-// Fallback languages if Afrikaans is not available
-const FALLBACK_LANGS = ["af", "nl-NL", "nl"]; // Dutch is somewhat similar
 
 // Preferred voice name patterns (higher quality voices)
 const PREFERRED_VOICE_PATTERNS = [
@@ -63,11 +59,26 @@ export function setTTSMode(mode: TTSMode): void {
   localStorage.setItem(TTS_MODE_KEY, mode);
 }
 
+/** Get the current target language code from settings */
+function getTargetLanguage(): LanguageCode {
+  if (typeof window === "undefined") return DEFAULT_LANGUAGE;
+  const stored = localStorage.getItem('lector-target-language');
+  if (stored && stored in LANGUAGES) return stored as LanguageCode;
+  return DEFAULT_LANGUAGE;
+}
+
+/** Get the language config for browser TTS */
+function getTTSLanguageConfig() {
+  const code = getTargetLanguage();
+  return LANGUAGES[code];
+}
+
 /**
  * Score a voice based on quality indicators
  * Higher score = better quality
  */
 function scoreVoice(voice: SpeechSynthesisVoice): number {
+  const langConfig = getTTSLanguageConfig();
   let score = 0;
 
   // Prefer local/offline voices (usually higher quality)
@@ -90,18 +101,18 @@ function scoreVoice(voice: SpeechSynthesisVoice): number {
   }
 
   // Prefer exact language match
-  if (voice.lang === AFRIKAANS_LANG) score += 3;
-  if (voice.lang.startsWith("af")) score += 2;
+  if (voice.lang === langConfig.ttsCode) score += 3;
+  if (voice.lang.startsWith(langConfig.code)) score += 2;
 
   return score;
 }
 
 /**
- * Get the best available voice for Afrikaans (browser TTS)
+ * Get the best available voice for the target language (browser TTS)
  * Caches the result for consistent voice selection
  * @returns The voice to use, or undefined if none found
  */
-function getAfrikaansVoice(): SpeechSynthesisVoice | undefined {
+function getTargetVoice(): SpeechSynthesisVoice | undefined {
   if (!isTTSAvailable()) {
     return undefined;
   }
@@ -127,8 +138,9 @@ function getAfrikaansVoice(): SpeechSynthesisVoice | undefined {
     }
   }
 
-  // Find all candidate voices (Afrikaans or Dutch)
-  const allLangs = [AFRIKAANS_LANG, "af", ...FALLBACK_LANGS];
+  // Find all candidate voices for the target language
+  const langConfig = getTTSLanguageConfig();
+  const allLangs = [langConfig.ttsCode, langConfig.code, ...langConfig.fallbackTts];
   const candidateVoices = voices.filter(v =>
     allLangs.some(lang => v.lang === lang || v.lang.startsWith(lang.split("-")[0]))
   );
@@ -224,14 +236,14 @@ function speakWithBrowser(text: string, rate: number): void {
 
   const utterance = new SpeechSynthesisUtterance(text);
 
-  // Set the voice (try Afrikaans, fall back to Dutch)
-  const voice = getAfrikaansVoice();
+  // Set the voice for the target language
+  const voice = getTargetVoice();
   if (voice) {
     utterance.voice = voice;
     utterance.lang = voice.lang;
   } else {
     // Set language even without a specific voice
-    utterance.lang = AFRIKAANS_LANG;
+    utterance.lang = getTTSLanguageConfig().ttsCode;
   }
 
   // Set speech parameters
@@ -280,7 +292,7 @@ export function stopSpeaking(): void {
 }
 
 /**
- * Get available voices for Afrikaans or Dutch (browser TTS)
+ * Get available voices for the target language (browser TTS)
  * Useful for debugging or letting users choose a voice
  * @returns Array of available voices
  */
@@ -289,8 +301,9 @@ export function getAvailableVoices(): SpeechSynthesisVoice[] {
     return [];
   }
 
+  const langConfig = getTTSLanguageConfig();
   const voices = window.speechSynthesis.getVoices();
-  const relevantLangs = [AFRIKAANS_LANG, ...FALLBACK_LANGS];
+  const relevantLangs = [langConfig.ttsCode, ...langConfig.fallbackTts];
 
   return voices.filter((v) =>
     relevantLangs.some(
@@ -315,7 +328,7 @@ export function waitForVoices(): Promise<SpeechSynthesisVoice[]> {
       const voices = window.speechSynthesis.getVoices();
       // Pre-initialize the voice cache
       if (voices.length > 0 && !voiceInitialized) {
-        getAfrikaansVoice();
+        getTargetVoice();
       }
       resolve(voices);
     };


### PR DESCRIPTION
## Summary

- Adds global language setting with support for **Afrikaans**, **German**, and **Spanish**
- New onboarding `/setup` page where users pick their target language on first launch
- All content tables get a `language` column; all API queries filter by active language
- LLM prompts, TTS voice selection, and Tatoeba sentence fetching are all parameterized by language
- Language switcher added to Settings page for quick switching between languages
- DB file renamed from `afrikaans.db` to `lector.db` (automatic migration for existing users)

### What's deferred (follow-up PRs)
- German/Spanish sentence bank and dictionary data files (Phase 4 from #12)
- `scripts/fetch-sentences.ts` parameterization for generating per-language data

### Files changed
- **7 new files**: language configs, active-language helpers, setup page, setup guard, e2e global setup
- **28 modified files**: schema migrations, API routes, LLM prompts, TTS, UI copy, settings page

## Test plan

- [x] First-time users: redirect to `/setup`, language selection saves and redirects to library - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] Settings page: language switcher shows 3 options, switching updates active language + resets TTS cache - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] Library: collections only show for active language; new imports tagged with active language - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] Vocab/Practice/Journal: all filtered by active language - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] Translation: LLM prompts use correct language name - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] TTS: voice matches target language (Google Cloud + browser fallback) - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] Returning users: no blank flash on page load (localStorage sync check) - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)
- [x] Existing Afrikaans users: data migrates cleanly (language column defaults to 'af', DB file renames) - [proof](https://github.com/heuwels/lector/pull/51#issuecomment-4295131596)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
