### PR TITLE
feat: translation comparison and evaluation tool

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
     "adm-zip": "^0.5.17",
     "hono": "^4.7.0",
     "linkedom": "^0.18.12",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -121,6 +121,18 @@ function getDb(): Database {
       lastUsedAt TEXT,
       expiresAt TEXT
     );
+
+    CREATE TABLE IF NOT EXISTS translation_evaluations (
+      id TEXT PRIMARY KEY,
+      inputSentence TEXT NOT NULL,
+      contextSentence TEXT,
+      apfelTranslation TEXT,
+      ollamaTranslation TEXT,
+      claudeTranslation TEXT,
+      selectedProvider TEXT NOT NULL CHECK (selectedProvider IN ('apfel', 'ollama', 'claude', 'manual')),
+      manualTranslation TEXT,
+      createdAt TEXT NOT NULL
+    );
   `);
 
   // Migrations for existing databases
@@ -375,4 +387,18 @@ export interface ApiTokenRow {
   createdAt: string;
   lastUsedAt: string | null;
   expiresAt: string | null;
+}
+
+export type EvalProvider = 'apfel' | 'ollama' | 'claude' | 'manual';
+
+export interface TranslationEvaluationRow {
+  id: string;
+  inputSentence: string;
+  contextSentence: string | null;
+  apfelTranslation: string | null;
+  ollamaTranslation: string | null;
+  claudeTranslation: string | null;
+  selectedProvider: EvalProvider;
+  manualTranslation: string | null;
+  createdAt: string;
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -22,6 +22,7 @@ import importRoutes from './routes/import';
 import journalCorrect from './routes/journal-correct';
 import llmStatus from './routes/llm-status';
 import tokens from './routes/tokens';
+import translateCompare from './routes/translate-compare';
 import { authMiddleware } from './lib/auth';
 
 const app = new Hono();
@@ -49,6 +50,7 @@ app.route('/api/import', importRoutes);
 app.route('/api/journal-correct', journalCorrect);
 app.route('/api/llm-status', llmStatus);
 app.route('/api/tokens', tokens);
+app.route('/api/translate-compare', translateCompare);
 
 // Capture unhandled errors to Sentry/GlitchTip
 app.onError((err, c) => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -69,4 +69,5 @@ console.log(`Lector API running on http://localhost:${port}`);
 export default {
   port,
   fetch: app.fetch,
+  idleTimeout: 120, // SSE streams for auto-evaluate need longer than the 10s default
 };

--- a/api/src/lib/afrikaans-spelreels/framework.yaml
+++ b/api/src/lib/afrikaans-spelreels/framework.yaml
@@ -1,0 +1,56 @@
+name: Afrikaanse Woordelys en Spelreëls
+version: "7.2"
+authority: Suid-Afrikaanse Akademie vir Wetenskap en Kuns — Taalkommissie
+source: Internet Archive (archive.org/details/afrikaansewoorde07suid)
+purpose: |
+  Spelling and orthography rules for Afrikaans, encoded as machine-readable
+  assertions. Designed to be loaded as LLM context when translating English
+  to Afrikaans, to ensure correct spelling, hyphenation, compounding, and
+  inflection.
+
+chapters:
+  - id: I
+    title: Grondbeginsels
+    description: Foundational spelling principles
+  - id: II
+    title: Dubbelspellinge
+    description: Double spellings and variant forms
+  - id: III
+    title: Wisselvorme
+    description: Alternating forms in inflection
+  - id: V
+    title: Skeiding van woorddele
+    description: Word division and syllable breaks
+  - id: VI
+    title: Deeltekens
+    description: Diaeresis usage
+  - id: VII
+    title: Koppeltekens
+    description: Hyphen rules
+  - id: VIII
+    title: Afkappingstekens
+    description: Apostrophe rules
+  - id: IX
+    title: Kappies
+    description: Circumflex accent rules
+  - id: X
+    title: Aksenttekens
+    description: Accent mark rules
+  - id: XI
+    title: Klinkers en tweeklanke
+    description: Vowels and diphthongs
+  - id: XII
+    title: Medeklinkers
+    description: Consonants
+  - id: XIII
+    title: Meervoudsvorme
+    description: Plural formation
+  - id: XIV
+    title: Woorde van vreemde herkoms
+    description: Loan words and foreign-origin words
+  - id: XV
+    title: Hoofletters
+    description: Capitalisation rules
+  - id: XVI
+    title: Los of vas
+    description: Words written separately or joined

--- a/api/src/lib/afrikaans-spelreels/rules/deeltekens.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/deeltekens.yaml
@@ -1,0 +1,54 @@
+# VI. Deeltekens — Diaeresis Rules
+# Source: AWS 7.2, page 25
+
+chapter: VI
+title: Deeltekens
+description: |
+  Rules for the diaeresis (trema/deelteken: ¨) which indicates that
+  adjacent vowels are pronounced separately rather than as a diphthong.
+
+rules:
+  - id: VI-1
+    description: Diaeresis on second vowel of a split pair
+    rule: |
+      A diaeresis is placed on the second of two adjacent vowel letters
+      when they must be pronounced as separate syllables, in two cases:
+      (a) when one part is a full word, or
+      (b) when neither part is a full word.
+    examples:
+      full_word_part:
+        - bieër (beer — bi-er)
+        - ploeë (ploughs — plo-e)
+        - vlieër (flier — vli-er)
+      neither_full_word:
+        - beëdig (swear in)
+        - geleë (situated)
+        - hoër (higher)
+        - leër (army)
+        - spieël (mirror)
+        - vermoë (ability)
+    severity: must
+
+  - id: VI-2
+    description: Diaeresis preserved in derivatives
+    rule: |
+      A word spelled with a diaeresis retains it in all further
+      derivations, compounds, and inflected forms.
+    examples:
+      correct:
+        - bedrieëry (from bedrieë)
+        - beïnvloeding (from beïnvloed)
+        - geleëner (from geleë)
+        - koeëllaer (from koeël)
+        - vlieëry (from vlieë)
+        - weerspieël (from spieël)
+    severity: must
+
+  - id: VI-3
+    description: No diaeresis on native "ae" combinations
+    rule: |
+      The vowel combination "ae" in native Afrikaans words never takes
+      a diaeresis, whether pronounced as one or two syllables.
+    examples:
+      no_diaeresis: [behae, dae, hael, maer, plae, swael, swaer]
+    severity: must

--- a/api/src/lib/afrikaans-spelreels/rules/grondbeginsels.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/grondbeginsels.yaml
@@ -1,0 +1,82 @@
+# I. Grondbeginsels — Foundational Spelling Principles
+# Source: AWS 7.2, pages 15-16
+
+chapter: I
+title: Grondbeginsels
+description: |
+  The three foundational principles of Afrikaans spelling, maintained since 1931.
+
+rules:
+  - id: I-1
+    principle: Pronunciation basis
+    description: |
+      Afrikaans spelling takes the generally accepted pronunciation in
+      educated Afrikaans as its foundation.
+    implication: |
+      When in doubt about spelling, the spoken form in standard Afrikaans
+      takes precedence.
+
+  - id: I-2
+    principle: Dutch correspondence
+    description: |
+      Afrikaans spelling takes into account the spelling officially
+      recognised in the Netherlands.
+    implication: |
+      Where Afrikaans pronunciation does not clearly deviate from Dutch,
+      the Dutch spelling convention is followed. This primarily affects
+      the ei/y and f/v distinctions.
+
+  - id: I-3
+    principle: Uniformity (gelykvormigheid)
+    description: |
+      The principle of uniformity is maintained as far as possible.
+      A word stem retains its spelling across inflected forms, even when
+      pronunciation shifts.
+    examples:
+      - rule: "The stem 'hond' keeps its d even though word-final d sounds like t"
+        forms: [hond, honde, hondjie]
+      - rule: "The stem 'goud' keeps its d"
+        forms: [goud, goue, goudjie]
+    implication: |
+      When generating inflected forms, preserve the stem spelling.
+      Do not respell based on pronunciation of the uninflected form.
+
+  - id: I-4
+    principle: Dutch ei/y and f/v retention
+    description: |
+      Where Afrikaans pronunciation does not clearly deviate from Dutch,
+      the Dutch distinction between ei/y and f/v is preserved.
+    examples:
+      - pairs:
+          ei: [feit, lei, Mei, peil, reis, steil, wei]
+          y: [fyt, ly, my, pyl, rys, styl, wy]
+          f: [fat, fee, feil, fel, fier, fonds, fors, frank]
+          v: [vat, vee, veil, vel, vier, vonds, vors, vrank]
+
+  - id: I-5
+    principle: Afrikaans deviations from Dutch
+    description: |
+      Where Afrikaans pronunciation clearly deviates from Dutch,
+      the Afrikaans pronunciation governs spelling.
+    examples:
+      - mapping:
+          afrikaans: bruilof
+          dutch: bruiloft
+      - mapping:
+          afrikaans: doring
+          dutch: doorn
+      - mapping:
+          afrikaans: harsings
+          dutch: hersenen
+      - mapping:
+          afrikaans: hoof
+          dutch: hoofd
+      - mapping:
+          afrikaans: yster
+          dutch: ijzer
+      - mapping:
+          afrikaans: lewe
+          dutch: leven
+      - mapping:
+          afrikaans: nag
+          dutch: nacht

--- a/api/src/lib/afrikaans-spelreels/rules/koppeltekens.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/koppeltekens.yaml
@@ -1,0 +1,132 @@
+# VII. Koppeltekens — Hyphen Rules
+# Source: AWS 7.2, pages 26-27
+
+chapter: VII
+title: Koppeltekens
+description: |
+  Rules governing when compound words and other constructions require hyphens.
+  This is one of the most complex areas of Afrikaans orthography.
+
+rules:
+  - id: VII-1
+    description: Compounds with proper nouns retain the noun's capitalisation
+    rule: |
+      When a proper noun forms part of a compound, it keeps its capital letter
+      and is joined with a hyphen.
+    examples:
+      correct: [Afrika-kenner, Bybelstof, Kaaps-Hollands, Moeder-Kaap]
+    severity: must
+
+  - id: VII-2
+    description: Multi-word compounds retain hyphens between all parts
+    rule: |
+      Compound words of three or more parts, where at least one part is itself
+      a compound, use hyphens throughout.
+    examples:
+      correct:
+        - vrou-voël
+        - piet-tjou-tjou-roep
+        - pond-vir-pond-stelsel
+        - wag-'n-bietjie-boom
+    severity: must
+
+  - id: VII-3
+    description: Compounds joined by "en" are hyphenated
+    rule: |
+      Compound words whose parts are connected by "en" are written with hyphens
+      between all parts.
+    examples:
+      correct:
+        - bek-en-klouseer
+        - haak-en-steekbossie
+        - olie-en-asynstel
+        - wins-en-verliesrekening
+    exceptions:
+      - rule: |
+          The suspended hyphen pattern (e.g. "hout- en sinkhuise") means two
+          separate types (houthuise AND sinkhuise). Contrast with
+          "hout-en-sinkhuise" meaning houses built FROM BOTH wood and zinc.
+        examples:
+          two_types: "hout- en sinkhuise"
+          combined_material: "hout-en-sinkhuise"
+    severity: must
+
+  - id: VII-4
+    description: Title compounds with rank + role
+    rule: |
+      Compound titles where the first element is a rank and the second a role
+      are hyphenated.
+    examples:
+      correct:
+        - adjunk-minister
+        - assistent-direkteur
+        - generaal-majoor
+        - kommandant-generaal
+        - luitenant-kolonel
+    severity: must
+
+  - id: VII-5
+    description: Paired adjective compounds
+    rule: |
+      Linked adjective pairs describing a combined quality are hyphenated.
+    examples:
+      correct:
+        - Christelik-histories
+        - Christelik-nasionaal
+        - Rooms-Katoliek
+        - sosiaal-demokraties
+    severity: must
+
+  - id: VII-6
+    description: State-of-being expressions
+    rule: |
+      Fixed expressions denoting a state of being (gesteldheid) are hyphenated.
+    examples:
+      correct: [been-af, bek-af, hand-uit, raad-op]
+      usage: "'n bek-af houding, 'n raad-op man"
+    exceptions:
+      - rule: |
+          When such expressions indicate direction or time rather than a state,
+          they are written separately (no hyphen).
+        examples:
+          separate: [berg af, berg op, jaar in, jaar uit, pad langs, son op]
+    severity: must
+
+  - id: VII-7
+    description: Vowel collision in full words
+    rule: |
+      When joining full words would create an awkward cluster of vowels,
+      use a hyphen to separate them.
+    examples:
+      correct:
+        - see-eend (not seeeend)
+        - na-aap (not naaap)
+        - knie-effek
+    implication: |
+      When generating compounds, check if the join point creates three or
+      more consecutive vowel letters. If so, hyphenate.
+    severity: must
+
+  - id: VII-8
+    description: Plural of compound titles
+    rule: |
+      In compound titles where the last part specifies the first, only the
+      first part takes the plural suffix.
+    examples:
+      correct:
+        - adjudante-generaal
+        - goewerneurs-generaal
+        - prokureurs-generaal
+    severity: must
+
+  - id: VII-9
+    description: Plural of compound titles (last part specifies)
+    rule: |
+      In compound titles where each part could stand alone, only the last
+      part takes the plural suffix.
+    examples:
+      correct:
+        - koning-keisers
+        - luitenant-betaalmeesters
+        - sekretaris-penningmeesters
+    severity: must

--- a/api/src/lib/afrikaans-spelreels/rules/los-of-vas.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/los-of-vas.yaml
@@ -1,0 +1,252 @@
+# XVI. Los of Vas — Words Written Separately or Joined
+# Source: AWS 7.2, pages 45-69
+# This is the largest and most complex chapter. These rules govern whether
+# multi-word expressions are written as one word, hyphenated, or separate.
+
+chapter: XVI
+title: Los of vas
+description: |
+  Rules for whether Afrikaans word combinations are written separately (los),
+  joined (vas), or hyphenated. This is the single most common source of
+  spelling errors in Afrikaans.
+
+  General principle: if a combination has lost its individual word stress and
+  functions as a single semantic unit, it is written as one word (vas).
+  If each part retains independent stress and meaning, write separately (los).
+
+rules:
+  # ── A. Mostly written separately (los) ──────────────────────
+
+  - id: XVI-A1
+    section: Nouns followed by nouns
+    description: General descriptions with noun + noun
+    rule: |
+      A noun followed by another noun as a loose descriptive phrase
+      is written separately.
+    examples:
+      separate:
+        - die berg Nebo
+        - die distrik Stellenbosch
+        - die dorp Senekal
+        - die stad Pretoria
+        - die woestyn Sinai
+    severity: must
+
+  - id: XVI-A2
+    section: Nouns with measurement/quantity
+    description: Measurement expressions
+    rule: |
+      Nouns expressing weight, quantity, measure, or currency followed by
+      another noun are written separately.
+    examples:
+      separate:
+        - "'n koppie tee"
+        - "'n pond botter"
+        - "'n uur lank"
+        - "'n myl ver"
+    severity: must
+
+  - id: XVI-A3
+    section: Adjective + noun (descriptive)
+    description: Attributive adjectives before nouns
+    rule: |
+      An adjective used attributively before a noun is written separately.
+    examples:
+      separate:
+        - "'n maer man"
+        - "'n siek man"
+        - hoë bome
+        - koue wind
+        - kwaai honde
+    severity: must
+
+  - id: XVI-A4
+    section: Numerals
+    description: Cardinal numbers with nouns
+    rule: |
+      Cardinal numbers before nouns are written separately.
+      The Taalkommissie considers it acceptable to write compound numerals
+      either separately or joined — neither is a spelling error.
+    examples:
+      separate:
+        - twee honderd
+        - drie duisend
+        - een en twintig
+      also_acceptable:
+        - tweehonderd
+        - drieduisend
+        - een-en-twintig
+    severity: should
+
+  - id: XVI-A5
+    section: Verb combinations
+    description: Adverb/adjective + verb (separate when literal)
+    rule: |
+      When an adverb or adjective precedes a verb and retains its literal
+      meaning, write separately.
+    examples:
+      separate:
+        - hard loop (run fast, on wet floor)
+        - mis skiet (shoot and miss)
+        - mooi praat (speak eloquently)
+        - raak skiet (shoot and hit)
+    severity: must
+
+  # ── B. Mostly written joined (vas) ──────────────────────────
+
+  - id: XVI-B1
+    section: Noun + noun compounds
+    description: True compound nouns
+    rule: |
+      When a noun + noun combination forms a true compound (single semantic
+      unit with unified stress), it is written as one word.
+    examples:
+      joined:
+        - boeksak
+        - dadelpit
+        - grasdak
+        - klaskamer
+        - sakboek
+    implication: |
+      Compound nouns where the first element modifies the second (like English
+      "bookshelf") are always written as one word in Afrikaans.
+    severity: must
+
+  - id: XVI-B2
+    section: Noun + verb compounds
+    description: Compound verbs with nouns
+    rule: |
+      When noun + verb combinations are used as nouns themselves, they are
+      often written as one word.
+    examples:
+      joined:
+        - motorry (driving a car)
+        - ryseet (rice planting)
+        - aalmoeskry (begging for alms)
+    severity: should
+
+  - id: XVI-B3
+    section: Adjective + noun compounds
+    description: Lexicalised adjective-noun compounds
+    rule: |
+      When an adjective + noun combination has become a fixed lexical unit
+      (no longer a free description), write as one word.
+    examples:
+      joined:
+        - grootpad (main road)
+        - kleinvee (small livestock)
+        - oubaas (old boss/master)
+        - rooibok (impala)
+        - witbrood (white bread)
+      contrast_with_separate:
+        - "'n groot pad" (a road that is big)
+        - "'n rooi bok" (a buck that is red)
+    implication: |
+      The test is whether the combination has a specialised meaning beyond
+      the sum of its parts. "witbrood" is a type of bread, not just any
+      bread that happens to be white.
+    severity: must
+
+  - id: XVI-B4
+    section: Adverb + verb compounds
+    description: Lexicalised adverb-verb compounds
+    rule: |
+      Many adverb + verb combinations are written as one word when they
+      form a single concept.
+    examples:
+      joined:
+        - agtervolg (pursue)
+        - omklém (embrace)
+        - onderstéun (support)
+        - onderwérp (subject)
+    note: |
+      The stress pattern often shifts in these compounds — the adverb
+      loses its independent stress.
+    severity: must
+
+  - id: XVI-B5
+    section: Preposition compounds
+    description: Prepositions fused into adverbs/conjunctions
+    rule: |
+      Many preposition + pronoun/noun combinations have fused into single
+      words.
+    examples:
+      joined:
+        - daardeur (through that)
+        - daarvan (of that)
+        - hierdeur (through this)
+        - hiervan (of this)
+        - waarom (why)
+        - waarin (in which)
+        - buitendien (besides)
+        - bowendien (moreover)
+        - indien (if)
+        - sedertdien (since then)
+    severity: must
+
+  - id: XVI-B6
+    section: Common joined adverbs
+    description: Fixed adverb compounds
+    rule: |
+      A large number of adverb + adverb or adverb + preposition
+      combinations are written as one word.
+    examples:
+      joined:
+        - agteraan (at the back)
+        - agteraf (in a remote place)
+        - agterna (afterwards)
+        - agteruit (backwards)
+        - binnekort (shortly)
+        - boonop (on top of that)
+        - buitendien (besides)
+        - daarbenewens (in addition)
+        - dadelik (immediately)
+        - deeglik (thoroughly)
+        - inmiddels (meanwhile)
+        - naby (near)
+        - vandag (today)
+        - vanaand (tonight)
+        - vanmôre (this morning)
+        - vorentoe (forward)
+    severity: must
+
+  # ── C. Context-dependent (los or vas) ───────────────────────
+
+  - id: XVI-C1
+    section: Direction vs state
+    description: Same words, different meaning = different spelling
+    rule: |
+      Some combinations are written separately when indicating literal
+      direction/time, but joined when they have become a fixed expression
+      or noun.
+    examples:
+      separate_direction:
+        - "berg af (down the mountain)"
+        - "berg op (up the mountain)"
+        - "pad langs (along the road)"
+        - "son op (as the sun comes up)"
+      joined_fixed:
+        - "bergaf (downhill, figuratively declining)"
+        - "bergop (uphill, figuratively improving)"
+        - "padlangs (along the way)"
+        - "sonop (sunrise)"
+    implication: |
+      When translating, determine whether the expression is literal
+      (spatial/temporal = separate) or figurative/lexicalised (= joined).
+    severity: must
+
+  - id: XVI-C2
+    section: Verb particle separation
+    description: Separable verb particles
+    rule: |
+      Many Afrikaans verbs have separable particles (similar to German).
+      The particle is written separately in main clauses but joined in
+      subordinate clauses and infinitives.
+    examples:
+      main_clause: "Hy kom môre terug (He comes back tomorrow)"
+      subordinate: "...dat hy môre terugkom (...that he comes back tomorrow)"
+      infinitive: "om terug te kom (to come back)"
+    implication: |
+      When generating Afrikaans sentences, check clause type to determine
+      whether to separate or join the verb particle.
+    severity: must

--- a/api/src/lib/afrikaans-spelreels/rules/los-of-vas.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/los-of-vas.yaml
@@ -139,8 +139,8 @@ rules:
         - rooibok (impala)
         - witbrood (white bread)
       contrast_with_separate:
-        - "'n groot pad" (a road that is big)
-        - "'n rooi bok" (a buck that is red)
+        - "'n groot pad (a road that is big)"
+        - "'n rooi bok (a buck that is red)"
     implication: |
       The test is whether the combination has a specialised meaning beyond
       the sum of its parts. "witbrood" is a type of bread, not just any

--- a/api/src/lib/afrikaans-spelreels/rules/medeklinkers.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/medeklinkers.yaml
@@ -1,0 +1,124 @@
+# XII. Medeklinkers — Consonant Rules
+# Source: AWS 7.2, pages 32-35
+
+chapter: XII
+title: Medeklinkers
+description: |
+  Rules for consonant spelling, including word-final devoicing,
+  inflected forms, and consonant doubling.
+
+rules:
+  - id: XII-1
+    description: No final d or t after f, g, s
+    rule: |
+      Word-final d or t is not written after f, g, or s.
+    examples:
+      correct: [bedroef, beleef, drif, hoof, bedug, benodig, besorg, bedees, bewus, gerus]
+      not: [bedroeft, benodigdt]
+    exceptions:
+      - rule: |
+          When d or t surfaces in inflected forms or derivations,
+          it IS written in those forms.
+        examples:
+          base_vs_inflected:
+            - base: bedroef
+              inflected: [bedroefde, bedroefdheid]
+            - base: hoof
+              inflected: [hoofde, hoofdelik]
+            - base: benodig
+              inflected: [benodigdheid]
+            - base: bewus
+              inflected: [bewuste, bewustelik]
+    severity: must
+
+  - id: XII-2
+    description: Inflection suffix -de after voiced consonants
+    rule: |
+      Words ending in b or d preceded by a short vowel take the
+      inflection suffix -de.
+    examples:
+      correct:
+        - geribde (from rib)
+        - geskubde (from skub)
+        - bekladde (from blad)
+        - ingebedde (from bed)
+    severity: must
+
+  - id: XII-3
+    description: Inflection suffix -te after voiceless consonants
+    rule: |
+      Words ending in k, p, or t take the inflection suffix -te.
+    examples:
+      correct:
+        - bedekte (from bedek)
+        - geykte (from yk)
+        - verlepte (from verlep)
+        - versuipte (from versuip)
+    after_short_vowel:
+      rule: Double the final consonant before -te
+      examples:
+        - geblekte (from blek)
+        - gestopte (from stop)
+    severity: must
+
+  - id: XII-4
+    description: The letter g pronunciation contexts
+    rule: |
+      The letter g has three distinct pronunciations depending on context.
+    contexts:
+      - position: "Between vowels or word-initially before a vowel"
+        sound: "Voiced velar fricative (like Dutch g)"
+        examples: [dag, gee, lag, mag, nog, oog, tog, weg]
+      - position: "After r"
+        sound: "Harder g"
+        examples: [berge, morge, sorge, terge]
+      - position: "Written gg between short stressed vowel and weak e"
+        sound: "Hard g"
+        examples: [brugge, egge, rugge, sogge, trogge]
+    severity: informational
+
+  - id: XII-5
+    description: Consonant doubling — general principle
+    rule: |
+      A single consonant after a short stressed vowel is doubled before
+      a suffix beginning with a vowel, to preserve the short vowel sound.
+    examples:
+      correct:
+        - bed → beddens
+        - kat → katte
+        - man → manne
+        - son → sonne
+    severity: must
+
+  - id: XII-6
+    description: Double nn in derivatives of words ending in -n
+    rule: |
+      Words derived from stems ending in -n that retain a connection
+      to the base word get double nn.
+    examples:
+      correct:
+        - kannibaal → kannibale (from kan)
+        - personeel → personneel
+    exceptions:
+      - rule: |
+          Derived words that no longer have a felt connection to the
+          -n base word get a single n.
+        examples:
+          - fraksioneer
+          - funksioneel
+          - impressionisme
+          - reaksionêr
+          - stasioneer
+    severity: must
+
+  - id: XII-7
+    description: Double ss rules
+    rule: |
+      Write ss in two specific contexts.
+    contexts:
+      - context: Superlative of adjectives ending in -s
+        examples: [boosste, dwaasste, fluksste, snaaksste]
+      - context: Compounds where first part ends in s and second begins with s
+        examples: [grassaad, missinjaal, toetssteen]
+        contrast: [gewetenstryd, lewenskets, meisieskool, regeringsaak]
+    severity: must

--- a/api/src/lib/afrikaans-spelreels/rules/meervoudsvorme.yaml
+++ b/api/src/lib/afrikaans-spelreels/rules/meervoudsvorme.yaml
@@ -1,0 +1,74 @@
+# XIII. Meervoudsvorme — Plural Formation Rules
+# Source: AWS 7.2, pages 35-36
+
+chapter: XIII
+title: Meervoudsvorme
+description: |
+  Rules for forming plurals in Afrikaans. The primary suffixes are -e and -s,
+  with various sub-rules for each.
+
+rules:
+  - id: XIII-1
+    description: Standard plural with -e
+    rule: |
+      Most Afrikaans nouns form their plural by adding -e.
+      If the noun ends in a single consonant after a short vowel,
+      double the consonant before adding -e.
+    examples:
+      simple: [dag → dae, been → bene, huis → huise]
+      with_doubling: [bed → bedde, kat → katte, man → manne, son → sonne]
+    severity: must
+
+  - id: XIII-2
+    description: Plural with -s
+    rule: |
+      Nouns ending in -el, -em, -en, -er, -aar, -ier, -eur, and
+      diminutives (-tjie, -jie, -pie) typically take -s.
+    examples:
+      correct:
+        - tafel → tafels
+        - bodem → bodems
+        - teken → tekens
+        - kamer → kamers
+        - bewonderaar → bewonderaars
+        - offisier → offisiere
+        - amptenaar → amptenaars (or amptenare)
+        - meisietjie → meisietjies
+    severity: must
+
+  - id: XIII-3
+    description: Foreign plural forms alongside Afrikaans forms
+    rule: |
+      Some words of foreign origin retain their original plural alongside
+      an Afrikaans plural.
+    examples:
+      dual_forms:
+        - singular: laboratorium
+          plurals: [laboratoria, laboratoriums]
+        - singular: museum
+          plurals: [musea, museums]
+        - singular: sentrum
+          plurals: [sentra, sentrums]
+        - singular: daktilus
+          plurals: [daktili, daktilusse]
+    implication: |
+      Both forms are acceptable. The Afrikaans -s/-usse form is more
+      colloquial; the classical form is more formal.
+    severity: should
+
+  - id: XIII-4
+    description: Compound noun plurals
+    rule: |
+      In compound nouns, only the last element takes the plural suffix.
+    examples:
+      correct:
+        - skooldae (school days)
+        - hoërskole (high schools)
+        - motorhuise (garages)
+    exceptions:
+      - rule: |
+          In compound titles where the last part specifies the first,
+          the FIRST part takes the plural (see VII-8).
+        examples:
+          correct: [adjudante-generaal, goewerneurs-generaal]
+    severity: must

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -21,6 +21,7 @@ const SCOPE_MAP: Record<string, { read: string; write: string }> = {
   import:          { read: 'collections:write', write: 'collections:write' },
   'journal-correct': { read: 'vocab:read',     write: 'vocab:read' },
   'llm-status':    { read: 'settings:read',    write: 'settings:write' },
+  'translate-compare': { read: 'vocab:read',  write: 'vocab:write' },
 };
 
 function getResourceFromPath(path: string): string | null {

--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -60,6 +60,24 @@ export function getProvider(): LLMProvider {
   return cachedProvider;
 }
 
+/** Instantiate all 3 providers independently for parallel comparison */
+export function getAllProviders(): Record<string, LLMProvider> {
+  const apiKey = getSetting('anthropicApiKey') || undefined;
+  const oauthToken = getSetting('claudeOauthToken') || undefined;
+  const anthropicModel = process.env.ANTHROPIC_MODEL || undefined;
+
+  const apfelModel = getSetting('apfelModel') || process.env.APFEL_MODEL || undefined;
+  const apfelUrl = getSetting('apfelUrl') || process.env.APFEL_URL || undefined;
+
+  const ollamaModel = getSetting('ollamaModel') || process.env.OLLAMA_MODEL || undefined;
+
+  return {
+    claude: new AnthropicProvider({ apiKey, oauthToken, model: anthropicModel }),
+    apfel: new ApfelProvider(apfelUrl, apfelModel),
+    ollama: new OllamaProvider(undefined, ollamaModel),
+  };
+}
+
 /** Clear cached provider (e.g. when settings change) */
 export function resetProvider(): void {
   cachedProvider = null;

--- a/api/src/lib/spelreels.ts
+++ b/api/src/lib/spelreels.ts
@@ -1,0 +1,115 @@
+import { parse } from 'yaml';
+import fs from 'fs';
+import path from 'path';
+
+interface SpelreelsRule {
+  id: string;
+  description?: string;
+  principle?: string;
+  section?: string;
+  rule?: string;
+  examples?: unknown;
+  implication?: string;
+  severity?: string;
+  note?: string;
+}
+
+interface SpelreelsChapter {
+  chapter: string;
+  title: string;
+  description: string;
+  rules: SpelreelsRule[];
+}
+
+let _chapters: SpelreelsChapter[] | null = null;
+let _contextBlock: string | null = null;
+
+function loadChapters(): SpelreelsChapter[] {
+  if (_chapters) return _chapters;
+
+  const rulesDir = path.join(__dirname, 'afrikaans-spelreels', 'rules');
+  const files = fs.readdirSync(rulesDir).filter((f) => f.endsWith('.yaml'));
+
+  _chapters = files.map((file) => {
+    const content = fs.readFileSync(path.join(rulesDir, file), 'utf-8');
+    return parse(content) as SpelreelsChapter;
+  });
+
+  return _chapters;
+}
+
+/** Format a single rule as concise text for LLM context */
+function formatRule(rule: SpelreelsRule): string {
+  const lines: string[] = [];
+  const label = rule.description || rule.principle || rule.section || rule.id;
+  lines.push(`[${rule.id}] ${label}`);
+
+  if (rule.rule) {
+    lines.push(rule.rule.trim());
+  }
+
+  if (rule.implication) {
+    lines.push(`Implication: ${rule.implication.trim()}`);
+  }
+
+  // Format examples compactly
+  if (rule.examples && typeof rule.examples === 'object') {
+    const ex = rule.examples as Record<string, unknown>;
+    const exParts: string[] = [];
+
+    for (const [key, val] of Object.entries(ex)) {
+      if (Array.isArray(val)) {
+        const items = val.map((v) =>
+          typeof v === 'string' ? v : typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v)
+        );
+        exParts.push(`${key}: ${items.join(', ')}`);
+      } else if (typeof val === 'string') {
+        exParts.push(`${key}: ${val}`);
+      }
+    }
+
+    if (exParts.length > 0) {
+      lines.push(`Examples — ${exParts.join('; ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/** Get all rules formatted as a single context block for LLM injection */
+export function getSpelreelsContext(): string {
+  if (_contextBlock) return _contextBlock;
+
+  const chapters = loadChapters();
+  const sections: string[] = [];
+
+  for (const chapter of chapters) {
+    const header = `## ${chapter.title} (Chapter ${chapter.chapter})`;
+    const desc = chapter.description.trim();
+    const rules = chapter.rules.map(formatRule).join('\n\n');
+    sections.push(`${header}\n${desc}\n\n${rules}`);
+  }
+
+  _contextBlock = `# Afrikaanse Woordelys en Spelreëls (AWS 7.2)
+Official Afrikaans spelling and orthography rules from the Taalkommissie.
+Apply these rules when evaluating or producing Afrikaans text.
+
+${sections.join('\n\n---\n\n')}`;
+
+  return _contextBlock;
+}
+
+/** Get rules for specific chapters only (for smaller context windows) */
+export function getSpelreelsForChapters(chapterIds: string[]): string {
+  const chapters = loadChapters();
+  const filtered = chapters.filter((c) => chapterIds.includes(c.chapter));
+
+  const sections = filtered.map((chapter) => {
+    const header = `## ${chapter.title} (Chapter ${chapter.chapter})`;
+    const desc = chapter.description.trim();
+    const rules = chapter.rules.map(formatRule).join('\n\n');
+    return `${header}\n${desc}\n\n${rules}`;
+  });
+
+  return sections.join('\n\n---\n\n');
+}

--- a/api/src/routes/translate-compare.ts
+++ b/api/src/routes/translate-compare.ts
@@ -1,0 +1,169 @@
+import { Hono } from 'hono';
+import { getAllProviders } from '../lib/llm';
+import { db, TranslationEvaluationRow } from '../db';
+import { randomUUID } from 'crypto';
+
+const app = new Hono();
+
+// Simple token auth for eval endpoints exposed via ngrok
+const evalAuth = async (c: any, next: any) => {
+  const token = process.env.EVAL_TOKEN;
+  if (!token) return next(); // No token configured = no auth required
+
+  const provided =
+    c.req.header('X-Eval-Token') ||
+    c.req.query('token');
+
+  if (provided !== token) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  return next();
+};
+
+app.use('*', evalAuth);
+
+// POST /api/translate-compare/compare
+app.post('/compare', async (c) => {
+  try {
+    const { sentence } = await c.req.json();
+
+    if (!sentence) {
+      return c.json({ error: 'Sentence is required' }, 400);
+    }
+
+    const prompt = `You are an Afrikaans to English translator. Translate the following Afrikaans sentence into natural English.
+
+Sentence: "${sentence}"
+
+Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
+{"translation": "the natural English translation"}`;
+
+    const providers = getAllProviders();
+    const providerEntries = Object.entries(providers);
+
+    const results = await Promise.allSettled(
+      providerEntries.map(async ([, provider]) => {
+        const text = await provider.complete({
+          messages: [{ role: 'user', content: prompt }],
+          maxTokens: 512,
+        });
+        try {
+          const parsed = JSON.parse(text);
+          return parsed.translation || text;
+        } catch {
+          return text;
+        }
+      })
+    );
+
+    const translations: Record<string, { translation: string | null; error: string | null }> = {};
+    for (let i = 0; i < results.length; i++) {
+      const [name] = providerEntries[i];
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        translations[name] = { translation: result.value, error: null };
+      } else {
+        translations[name] = { translation: null, error: result.reason?.message || 'Failed' };
+      }
+    }
+
+    return c.json({ sentence, translations });
+  } catch (error) {
+    console.error('Compare error:', error);
+    return c.json(
+      { error: error instanceof Error ? error.message : 'Comparison failed' },
+      500
+    );
+  }
+});
+
+// POST /api/translate-compare/evaluate
+app.post('/evaluate', async (c) => {
+  try {
+    const body = await c.req.json();
+    const {
+      inputSentence,
+      contextSentence,
+      apfelTranslation,
+      ollamaTranslation,
+      claudeTranslation,
+      selectedProvider,
+      manualTranslation,
+    } = body;
+
+    if (!inputSentence || !selectedProvider) {
+      return c.json({ error: 'inputSentence and selectedProvider are required' }, 400);
+    }
+
+    if (!['apfel', 'ollama', 'claude', 'manual'].includes(selectedProvider)) {
+      return c.json({ error: 'Invalid selectedProvider' }, 400);
+    }
+
+    if (selectedProvider === 'manual' && !manualTranslation) {
+      return c.json({ error: 'manualTranslation required when selectedProvider is manual' }, 400);
+    }
+
+    const id = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(`
+      INSERT INTO translation_evaluations
+        (id, inputSentence, contextSentence, apfelTranslation, ollamaTranslation, claudeTranslation, selectedProvider, manualTranslation, createdAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, inputSentence, contextSentence || null, apfelTranslation || null, ollamaTranslation || null, claudeTranslation || null, selectedProvider, manualTranslation || null, now);
+
+    return c.json({ id, createdAt: now });
+  } catch (error) {
+    console.error('Evaluate error:', error);
+    return c.json(
+      { error: error instanceof Error ? error.message : 'Evaluation failed' },
+      500
+    );
+  }
+});
+
+// GET /api/translate-compare/evaluations
+app.get('/evaluations', async (c) => {
+  const format = c.req.query('format') || 'json';
+
+  const rows = db.prepare(
+    'SELECT * FROM translation_evaluations ORDER BY createdAt DESC'
+  ).all() as TranslationEvaluationRow[];
+
+  if (format === 'corpus') {
+    // Export as RAG corpus format matching issue #25
+    const corpus = rows.map((row) => {
+      const bestTranslation =
+        row.selectedProvider === 'manual'
+          ? row.manualTranslation
+          : row[`${row.selectedProvider}Translation` as keyof TranslationEvaluationRow];
+
+      return {
+        afrikaans: row.inputSentence,
+        english: bestTranslation,
+        literal: null,
+        category: 'evaluated',
+        example_sentence: row.inputSentence,
+        example_translation: bestTranslation,
+      };
+    });
+    return c.json(corpus);
+  }
+
+  return c.json({ evaluations: rows, count: rows.length });
+});
+
+// GET /api/translate-compare/random-sentence
+app.get('/random-sentence', async (c) => {
+  const row = db.prepare(
+    'SELECT sentence, translation FROM clozeSentences ORDER BY RANDOM() LIMIT 1'
+  ).get() as { sentence: string; translation: string } | undefined;
+
+  if (!row) {
+    return c.json({ error: 'No sentences available' }, 404);
+  }
+
+  return c.json({ sentence: row.sentence, referenceTranslation: row.translation });
+});
+
+export default app;

--- a/api/src/routes/translate-compare.ts
+++ b/api/src/routes/translate-compare.ts
@@ -5,6 +5,7 @@ import { AnthropicProvider } from '../lib/llm/anthropic';
 import { OllamaProvider } from '../lib/llm/ollama';
 import { db, TranslationEvaluationRow } from '../db';
 import { randomUUID } from 'crypto';
+import { getSpelreelsContext } from '../lib/spelreels';
 
 const app = new Hono();
 
@@ -34,18 +35,41 @@ app.post('/compare', async (c) => {
       return c.json({ error: 'Sentence is required' }, 400);
     }
 
-    const prompt = `You are an Afrikaans to English translator. Translate the following Afrikaans sentence into natural English.
+    const spelreels = getSpelreelsContext();
+
+    const jsonPrompt = `You are an Afrikaans to English translator with deep knowledge of Afrikaans orthography.
+
+Use the following official spelling rules to inform your understanding of the Afrikaans input:
+
+${spelreels}
+
+---
+
+Translate the following Afrikaans sentence into natural English.
 
 Sentence: "${sentence}"
 
 Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
 {"translation": "the natural English translation"}`;
 
+    const plainPrompt = `You are an Afrikaans to English translator. Translate the following Afrikaans phrase, using the sentence context to determine the correct meaning.
+
+Phrase: "${sentence}"
+Sentence context: "${sentence}"
+
+Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
+{"translation": "the natural English translation", "literalBreakdown": "word-by-word literal translation", "idiomaticMeaning": "explanation if this is an idiom or has special meaning"}
+
+Include literalBreakdown if the phrase is more than one word.
+Include idiomaticMeaning only if the phrase is an idiom or has a meaning that differs from the literal translation.`;
+
     const providers = getAllProviders();
     const providerEntries = Object.entries(providers);
 
     const results = await Promise.allSettled(
-      providerEntries.map(async ([, provider]) => {
+      providerEntries.map(async ([name, provider]) => {
+        // Apfel (Apple model) uses the same prompt as the reader's translate route
+        const prompt = name === 'apfel' ? plainPrompt : jsonPrompt;
         const text = await provider.complete({
           messages: [{ role: 'user', content: prompt }],
           maxTokens: 512,
@@ -169,21 +193,37 @@ app.get('/random-sentence', async (c) => {
   return c.json({ sentence: row.sentence, referenceTranslation: row.translation });
 });
 
+// GET /api/translate-compare/auto-evaluate/status
+app.get('/auto-evaluate/status', async (c) => {
+  const total = (db.prepare(
+    'SELECT COUNT(*) as count FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL)'
+  ).get() as { count: number }).count;
+
+  const evaluated = (db.prepare(
+    `SELECT COUNT(*) as count FROM clozeSentences cs
+     WHERE (cs.blacklisted = 0 OR cs.blacklisted IS NULL)
+       AND cs.sentence IN (SELECT inputSentence FROM translation_evaluations)`
+  ).get() as { count: number }).count;
+
+  return c.json({ total, evaluated, remaining: total - evaluated });
+});
+
 // POST /api/translate-compare/auto-evaluate
 // Claude evaluates Ollama's translations in batch, streaming progress via SSE
+// Processes all unevaluated sentences sequentially, resumable across runs
 app.post('/auto-evaluate', async (c) => {
-  const { batchSize = 10 } = await c.req.json();
-  const size = Math.min(Math.max(1, batchSize), 100);
+  const { batchSize = 50 } = await c.req.json();
+  const size = Math.min(Math.max(1, batchSize), 500);
 
-  // Get sentences not yet evaluated
+  // Get next batch of unevaluated sentences, ordered by wordRank (most common first)
   const sentences = db.prepare(`
-    SELECT cs.sentence, cs.translation AS referenceTranslation
+    SELECT cs.sentence, cs.translation AS referenceTranslation, cs.wordRank
     FROM clozeSentences cs
     WHERE (cs.blacklisted = 0 OR cs.blacklisted IS NULL)
       AND cs.sentence NOT IN (SELECT inputSentence FROM translation_evaluations)
-    ORDER BY RANDOM()
+    ORDER BY cs.wordRank ASC NULLS LAST, cs.sentence ASC
     LIMIT ?
-  `).all(size) as { sentence: string; referenceTranslation: string }[];
+  `).all(size) as { sentence: string; referenceTranslation: string; wordRank: number | null }[];
 
   if (sentences.length === 0) {
     return c.json({ error: 'No unevaluated sentences remaining' }, 404);
@@ -193,9 +233,18 @@ app.post('/auto-evaluate', async (c) => {
   const providers = getAllProviders();
   const ollama = providers.ollama;
   const claude = providers.claude;
+  const spelreels = getSpelreelsContext();
 
   const translatePrompt = (sentence: string) =>
-    `You are an Afrikaans to English translator. Translate the following Afrikaans sentence into natural English.
+    `You are an Afrikaans to English translator with deep knowledge of Afrikaans orthography.
+
+Use the following official spelling rules to inform your understanding of the Afrikaans input:
+
+${spelreels}
+
+---
+
+Translate the following Afrikaans sentence into natural English.
 
 Sentence: "${sentence}"
 
@@ -203,7 +252,13 @@ Respond with ONLY a JSON object in this exact format (no markdown, no code block
 {"translation": "the natural English translation"}`;
 
   const judgePrompt = (sentence: string, ollamaTranslation: string, referenceTranslation: string) =>
-    `You are a translation quality judge for Afrikaans to English.
+    `You are a translation quality judge for Afrikaans to English, with expert knowledge of Afrikaans spelling and orthography.
+
+Use the following official Afrikaans spelling rules (AWS 7.2) to inform your evaluation:
+
+${spelreels}
+
+---
 
 Afrikaans sentence: "${sentence}"
 Reference translation: "${referenceTranslation}"
@@ -215,6 +270,12 @@ Score the translation 1-5:
 3 = understandable but awkward or partially wrong
 4 = good, minor issues only
 5 = excellent, matches or improves on the reference
+
+Pay special attention to whether the translator correctly understood:
+- Compound words (los of vas — separate vs joined)
+- Hyphenation rules (koppeltekens)
+- Plural forms (meervoudsvorme)
+- Diaeresis usage (deeltekens)
 
 If the score is below 4, provide a corrected translation.
 

--- a/api/src/routes/translate-compare.ts
+++ b/api/src/routes/translate-compare.ts
@@ -1,8 +1,7 @@
 import { Hono } from 'hono';
+import type { Context, Next } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { getAllProviders } from '../lib/llm';
-import { AnthropicProvider } from '../lib/llm/anthropic';
-import { OllamaProvider } from '../lib/llm/ollama';
 import { db, TranslationEvaluationRow } from '../db';
 import { randomUUID } from 'crypto';
 import { getSpelreelsContext } from '../lib/spelreels';
@@ -10,7 +9,7 @@ import { getSpelreelsContext } from '../lib/spelreels';
 const app = new Hono();
 
 // Simple token auth for eval endpoints exposed via ngrok
-const evalAuth = async (c: any, next: any) => {
+const evalAuth = async (c: Context, next: Next) => {
   const token = process.env.EVAL_TOKEN;
   if (!token) return next(); // No token configured = no auth required
 
@@ -304,7 +303,7 @@ If correction is needed:
           } catch {
             ollamaTranslation = ollamaRaw;
           }
-        } catch (err) {
+        } catch {
           ollamaTranslation = null;
         }
 

--- a/api/src/routes/translate-compare.ts
+++ b/api/src/routes/translate-compare.ts
@@ -1,5 +1,8 @@
 import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
 import { getAllProviders } from '../lib/llm';
+import { AnthropicProvider } from '../lib/llm/anthropic';
+import { OllamaProvider } from '../lib/llm/ollama';
 import { db, TranslationEvaluationRow } from '../db';
 import { randomUUID } from 'crypto';
 
@@ -164,6 +167,184 @@ app.get('/random-sentence', async (c) => {
   }
 
   return c.json({ sentence: row.sentence, referenceTranslation: row.translation });
+});
+
+// POST /api/translate-compare/auto-evaluate
+// Claude evaluates Ollama's translations in batch, streaming progress via SSE
+app.post('/auto-evaluate', async (c) => {
+  const { batchSize = 10 } = await c.req.json();
+  const size = Math.min(Math.max(1, batchSize), 100);
+
+  // Get sentences not yet evaluated
+  const sentences = db.prepare(`
+    SELECT cs.sentence, cs.translation AS referenceTranslation
+    FROM clozeSentences cs
+    WHERE (cs.blacklisted = 0 OR cs.blacklisted IS NULL)
+      AND cs.sentence NOT IN (SELECT inputSentence FROM translation_evaluations)
+    ORDER BY RANDOM()
+    LIMIT ?
+  `).all(size) as { sentence: string; referenceTranslation: string }[];
+
+  if (sentences.length === 0) {
+    return c.json({ error: 'No unevaluated sentences remaining' }, 404);
+  }
+
+  // Build providers
+  const providers = getAllProviders();
+  const ollama = providers.ollama;
+  const claude = providers.claude;
+
+  const translatePrompt = (sentence: string) =>
+    `You are an Afrikaans to English translator. Translate the following Afrikaans sentence into natural English.
+
+Sentence: "${sentence}"
+
+Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
+{"translation": "the natural English translation"}`;
+
+  const judgePrompt = (sentence: string, ollamaTranslation: string, referenceTranslation: string) =>
+    `You are a translation quality judge for Afrikaans to English.
+
+Afrikaans sentence: "${sentence}"
+Reference translation: "${referenceTranslation}"
+Translation to evaluate: "${ollamaTranslation}"
+
+Score the translation 1-5:
+1 = completely wrong
+2 = captures some meaning but significant errors
+3 = understandable but awkward or partially wrong
+4 = good, minor issues only
+5 = excellent, matches or improves on the reference
+
+If the score is below 4, provide a corrected translation.
+
+Respond with ONLY a JSON object (no markdown, no code blocks):
+{"score": 4, "correctedTranslation": null, "notes": "brief explanation"}
+
+If correction is needed:
+{"score": 2, "correctedTranslation": "the better translation", "notes": "brief explanation"}`;
+
+  return streamSSE(c, async (stream) => {
+    let completed = 0;
+    let improved = 0;
+
+    for (const { sentence, referenceTranslation } of sentences) {
+      try {
+        // Step 1: Ollama translates
+        let ollamaTranslation: string | null = null;
+        try {
+          const ollamaRaw = await ollama.complete({
+            messages: [{ role: 'user', content: translatePrompt(sentence) }],
+            maxTokens: 512,
+          });
+          try {
+            const parsed = JSON.parse(ollamaRaw);
+            ollamaTranslation = parsed.translation || ollamaRaw;
+          } catch {
+            ollamaTranslation = ollamaRaw;
+          }
+        } catch (err) {
+          ollamaTranslation = null;
+        }
+
+        // Step 2: Claude judges
+        const judgeRaw = await claude.complete({
+          messages: [{
+            role: 'user',
+            content: judgePrompt(sentence, ollamaTranslation || '(failed to translate)', referenceTranslation),
+          }],
+          maxTokens: 512,
+        });
+
+        let score = 0;
+        let correctedTranslation: string | null = null;
+        let claudeTranslation: string | null = null;
+        let notes: string | null = null;
+        try {
+          const judgeResult = JSON.parse(judgeRaw);
+          score = judgeResult.score;
+          correctedTranslation = judgeResult.correctedTranslation || null;
+          notes = judgeResult.notes || null;
+        } catch {
+          // If Claude didn't return valid JSON, skip
+          completed++;
+          await stream.writeSSE({
+            data: JSON.stringify({ type: 'progress', completed, total: sentences.length, sentence, status: 'error', error: 'Claude returned invalid JSON' }),
+          });
+          continue;
+        }
+
+        // Determine best translation and provider
+        let selectedProvider: string;
+        let manualTranslation: string | null = null;
+
+        if (score >= 4) {
+          // Ollama was good enough
+          selectedProvider = 'ollama';
+          claudeTranslation = correctedTranslation;
+        } else if (correctedTranslation) {
+          // Claude provided a correction — store as manual (Claude-generated)
+          selectedProvider = 'manual';
+          manualTranslation = correctedTranslation;
+          claudeTranslation = correctedTranslation;
+          improved++;
+        } else {
+          // Low score but no correction — use reference
+          selectedProvider = 'manual';
+          manualTranslation = referenceTranslation;
+          claudeTranslation = null;
+          improved++;
+        }
+
+        // Store evaluation
+        const id = randomUUID();
+        const now = new Date().toISOString();
+
+        db.prepare(`
+          INSERT INTO translation_evaluations
+            (id, inputSentence, contextSentence, apfelTranslation, ollamaTranslation, claudeTranslation, selectedProvider, manualTranslation, createdAt)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(id, sentence, referenceTranslation, null, ollamaTranslation, claudeTranslation, selectedProvider, manualTranslation, now);
+
+        completed++;
+        await stream.writeSSE({
+          data: JSON.stringify({
+            type: 'progress',
+            completed,
+            total: sentences.length,
+            sentence,
+            ollamaTranslation,
+            score,
+            correctedTranslation,
+            notes,
+            selectedProvider,
+            status: 'ok',
+          }),
+        });
+      } catch (err) {
+        completed++;
+        await stream.writeSSE({
+          data: JSON.stringify({
+            type: 'progress',
+            completed,
+            total: sentences.length,
+            sentence,
+            status: 'error',
+            error: err instanceof Error ? err.message : 'Unknown error',
+          }),
+        });
+      }
+    }
+
+    await stream.writeSSE({
+      data: JSON.stringify({
+        type: 'done',
+        completed,
+        improved,
+        total: sentences.length,
+      }),
+    });
+  });
 });
 
 export default app;

--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getProvider } from '../lib/llm';
+import { getSpelreelsContext } from '../lib/spelreels';
 
 import { db } from '../db';
 
@@ -29,8 +30,18 @@ app.post('/', async (c) => {
 
     recordStudyPing();
 
+    const spelreels = getSpelreelsContext();
+
     if (type === 'phrase') {
-      const prompt = `You are an Afrikaans to English translator. Translate the following Afrikaans phrase, using the sentence context to determine the correct meaning.
+      const prompt = `You are an Afrikaans to English translator with deep knowledge of Afrikaans orthography.
+
+Use the following official spelling rules to inform your understanding of the Afrikaans input:
+
+${spelreels}
+
+---
+
+Translate the following Afrikaans phrase, using the sentence context to determine the correct meaning.
 
 Phrase: "${word}"
 Sentence context: "${sentence || word}"
@@ -49,7 +60,15 @@ Include idiomaticMeaning only if the phrase is an idiom or has a meaning that di
 
       return c.json(JSON.parse(text));
     } else {
-      const prompt = `You are an Afrikaans to English translator. Translate the following Afrikaans word, using the sentence context to determine the correct meaning.
+      const prompt = `You are an Afrikaans to English translator with deep knowledge of Afrikaans orthography.
+
+Use the following official spelling rules to inform your understanding of the Afrikaans input:
+
+${spelreels}
+
+---
+
+Translate the following Afrikaans word, using the sentence context to determine the correct meaning.
 
 Word: "${word}"
 Sentence context: "${sentence || word}"

--- a/src/app/api/translate-compare/route.ts
+++ b/src/app/api/translate-compare/route.ts
@@ -57,7 +57,9 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const type = searchParams.get('type');
 
-    const endpoint = type === 'random' ? 'random-sentence' : 'evaluations';
+    const endpoint = type === 'random' ? 'random-sentence'
+      : type === 'auto-status' ? 'auto-evaluate/status'
+      : 'evaluations';
     const params = new URLSearchParams();
     const format = searchParams.get('format');
     if (format) params.set('format', format);

--- a/src/app/api/translate-compare/route.ts
+++ b/src/app/api/translate-compare/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_URL = process.env.INTERNAL_API_URL || 'http://localhost:3457';
+
+function forwardHeaders(request: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const evalToken = request.headers.get('X-Eval-Token');
+  if (evalToken) headers['X-Eval-Token'] = evalToken;
+  return headers;
+}
+
+// POST /api/translate-compare — proxy to compare endpoint
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const action = body.action;
+    delete body.action;
+
+    const endpoint = action === 'evaluate' ? 'evaluate' : 'compare';
+
+    const response = await fetch(`${API_URL}/api/translate-compare/${endpoint}`, {
+      method: 'POST',
+      headers: forwardHeaders(request),
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Translate compare error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Request failed' },
+      { status: 500 }
+    );
+  }
+}
+
+// GET /api/translate-compare — proxy to evaluations or random-sentence
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get('type');
+
+    const endpoint = type === 'random' ? 'random-sentence' : 'evaluations';
+    const params = new URLSearchParams();
+    const format = searchParams.get('format');
+    if (format) params.set('format', format);
+
+    const evalToken = request.headers.get('X-Eval-Token') || searchParams.get('token');
+    const headers: Record<string, string> = {};
+    if (evalToken) headers['X-Eval-Token'] = evalToken;
+
+    const url = `${API_URL}/api/translate-compare/${endpoint}${params.toString() ? '?' + params.toString() : ''}`;
+    const response = await fetch(url, { headers });
+
+    const data = await response.json();
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Translate compare GET error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Request failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/translate-compare/route.ts
+++ b/src/app/api/translate-compare/route.ts
@@ -16,13 +16,26 @@ export async function POST(request: NextRequest) {
     const action = body.action;
     delete body.action;
 
-    const endpoint = action === 'evaluate' ? 'evaluate' : 'compare';
+    const endpoint = action === 'evaluate' ? 'evaluate'
+      : action === 'auto-evaluate' ? 'auto-evaluate'
+      : 'compare';
 
     const response = await fetch(`${API_URL}/api/translate-compare/${endpoint}`, {
       method: 'POST',
       headers: forwardHeaders(request),
       body: JSON.stringify(body),
     });
+
+    // Stream SSE responses through for auto-evaluate
+    if (action === 'auto-evaluate' && response.body) {
+      return new Response(response.body, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+      });
+    }
 
     const data = await response.json();
     if (!response.ok) {

--- a/src/app/evaluate/page.tsx
+++ b/src/app/evaluate/page.tsx
@@ -58,7 +58,8 @@ export default function EvaluatePage() {
 
   // Auto-evaluate state
   const [autoRunning, setAutoRunning] = useState(false);
-  const [autoBatchSize, setAutoBatchSize] = useState(20);
+  const [autoBatchSize, setAutoBatchSize] = useState(50);
+  const [autoStatus, setAutoStatus] = useState<{ total: number; evaluated: number; remaining: number } | null>(null);
   const [autoProgress, setAutoProgress] = useState<{ completed: number; total: number } | null>(null);
   const [autoResults, setAutoResults] = useState<Array<{
     sentence: string;
@@ -196,6 +197,18 @@ export default function EvaluatePage() {
     fetchRandomSentence();
   };
 
+  const fetchAutoStatus = useCallback(async () => {
+    try {
+      const res = await fetch('/api/translate-compare?type=auto-status', { headers: headers() });
+      if (res.ok) {
+        const data = await res.json();
+        setAutoStatus(data);
+      }
+    } catch {
+      // ignore
+    }
+  }, [headers]);
+
   const startAutoEvaluate = async () => {
     setAutoRunning(true);
     setAutoResults([]);
@@ -258,6 +271,7 @@ export default function EvaluatePage() {
     } finally {
       setAutoRunning(false);
       autoAbortRef.current = null;
+      fetchAutoStatus();
     }
   };
 
@@ -528,7 +542,11 @@ export default function EvaluatePage() {
         {/* Auto-evaluate section */}
         <div className="border-t border-zinc-200 dark:border-zinc-800 pt-6">
           <button
-            onClick={() => setShowAuto(!showAuto)}
+            onClick={() => {
+              const next = !showAuto;
+              setShowAuto(next);
+              if (next) fetchAutoStatus();
+            }}
             className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300"
           >
             <svg
@@ -538,9 +556,11 @@ export default function EvaluatePage() {
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
             </svg>
             Auto-evaluate with Claude
-            <span className="text-xs text-zinc-400 dark:text-zinc-500 font-normal">
-              Claude judges Ollama's translations in batch
-            </span>
+            {autoStatus && (
+              <span className="text-xs text-zinc-400 dark:text-zinc-500 font-normal">
+                {autoStatus.evaluated}/{autoStatus.total} done, {autoStatus.remaining} remaining
+              </span>
+            )}
           </button>
 
           {showAuto && (
@@ -556,7 +576,7 @@ export default function EvaluatePage() {
                     disabled={autoRunning}
                     className="px-3 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm"
                   >
-                    {[10, 20, 50, 100].map((n) => (
+                    {[50, 100, 200, 500].map((n) => (
                       <option key={n} value={n}>{n} sentences</option>
                     ))}
                   </select>

--- a/src/app/evaluate/page.tsx
+++ b/src/app/evaluate/page.tsx
@@ -477,7 +477,7 @@ export default function EvaluatePage() {
                     }}
                     className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
                   >
-                    None of these are good enough — I'll write my own
+                    None of these are good enough — I&apos;ll write my own
                   </button>
                 ) : (
                   <div className="space-y-2">

--- a/src/app/evaluate/page.tsx
+++ b/src/app/evaluate/page.tsx
@@ -1,0 +1,501 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+type Provider = 'apfel' | 'ollama' | 'claude';
+type SelectedProvider = Provider | 'manual';
+
+interface TranslationResult {
+  translation: string | null;
+  error: string | null;
+}
+
+interface CompareResponse {
+  sentence: string;
+  translations: Record<Provider, TranslationResult>;
+}
+
+interface Evaluation {
+  id: string;
+  inputSentence: string;
+  selectedProvider: SelectedProvider;
+  manualTranslation: string | null;
+  apfelTranslation: string | null;
+  ollamaTranslation: string | null;
+  claudeTranslation: string | null;
+  createdAt: string;
+}
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  apfel: 'Apfel',
+  ollama: 'Ollama',
+  claude: 'Claude',
+};
+
+const PROVIDER_COLORS: Record<Provider, { ring: string; bg: string; text: string }> = {
+  apfel: { ring: 'ring-amber-500', bg: 'bg-amber-50 dark:bg-amber-900/20', text: 'text-amber-700 dark:text-amber-300' },
+  ollama: { ring: 'ring-purple-500', bg: 'bg-purple-50 dark:bg-purple-900/20', text: 'text-purple-700 dark:text-purple-300' },
+  claude: { ring: 'ring-sky-500', bg: 'bg-sky-50 dark:bg-sky-900/20', text: 'text-sky-700 dark:text-sky-300' },
+};
+
+export default function EvaluatePage() {
+  const [token, setToken] = useState('');
+  const [authenticated, setAuthenticated] = useState(false);
+  const [tokenRequired, setTokenRequired] = useState<boolean | null>(null);
+
+  const [sentence, setSentence] = useState('');
+  const [results, setResults] = useState<CompareResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<SelectedProvider | null>(null);
+  const [manualText, setManualText] = useState('');
+  const [showManual, setShowManual] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [evalCount, setEvalCount] = useState(0);
+  const [history, setHistory] = useState<Evaluation[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const headers = useCallback((): Record<string, string> => {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (token) h['X-Eval-Token'] = token;
+    return h;
+  }, [token]);
+
+  // Check if auth is required
+  useEffect(() => {
+    fetch('/api/translate-compare?type=random')
+      .then((r) => {
+        if (r.status === 401) {
+          setTokenRequired(true);
+        } else {
+          setTokenRequired(false);
+          setAuthenticated(true);
+        }
+      })
+      .catch(() => setTokenRequired(true));
+  }, []);
+
+  const authenticate = async () => {
+    const res = await fetch('/api/translate-compare?type=random', {
+      headers: { 'X-Eval-Token': token },
+    });
+    if (res.ok) {
+      setAuthenticated(true);
+    } else {
+      setError('Invalid token');
+    }
+  };
+
+  const fetchRandomSentence = async () => {
+    setError(null);
+    try {
+      const res = await fetch('/api/translate-compare?type=random', { headers: headers() });
+      if (!res.ok) throw new Error('Failed to fetch sentence');
+      const data = await res.json();
+      setSentence(data.sentence);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch sentence');
+    }
+  };
+
+  const compare = async () => {
+    if (!sentence.trim()) return;
+    setLoading(true);
+    setResults(null);
+    setSelected(null);
+    setShowManual(false);
+    setManualText('');
+    setSubmitted(false);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/translate-compare', {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify({ action: 'compare', sentence: sentence.trim() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Comparison failed');
+      }
+
+      const data: CompareResponse = await res.json();
+      setResults(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Comparison failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submit = async () => {
+    if (!results) return;
+    if (showManual && !manualText.trim()) return;
+    if (!showManual && !selected) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    const provider = showManual ? 'manual' : selected;
+
+    try {
+      const res = await fetch('/api/translate-compare', {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify({
+          action: 'evaluate',
+          inputSentence: results.sentence,
+          apfelTranslation: results.translations.apfel?.translation || null,
+          ollamaTranslation: results.translations.ollama?.translation || null,
+          claudeTranslation: results.translations.claude?.translation || null,
+          selectedProvider: provider,
+          manualTranslation: showManual ? manualText.trim() : null,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Submission failed');
+      }
+
+      setSubmitted(true);
+      setEvalCount((c) => c + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const next = () => {
+    setResults(null);
+    setSelected(null);
+    setShowManual(false);
+    setManualText('');
+    setSubmitted(false);
+    setSentence('');
+    fetchRandomSentence();
+  };
+
+  const loadHistory = async () => {
+    try {
+      const res = await fetch('/api/translate-compare?type=evaluations', { headers: headers() });
+      if (!res.ok) throw new Error('Failed to load history');
+      const data = await res.json();
+      setHistory(data.evaluations);
+      setShowHistory(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load history');
+    }
+  };
+
+  // Auth gate
+  if (tokenRequired === null) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-zinc-50 dark:bg-zinc-950">
+        <div className="text-zinc-500 dark:text-zinc-400">Loading...</div>
+      </div>
+    );
+  }
+
+  if (tokenRequired && !authenticated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-zinc-50 dark:bg-zinc-950 p-4">
+        <div className="w-full max-w-sm space-y-4">
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100 text-center">
+            Lector Eval
+          </h1>
+          <p className="text-zinc-500 dark:text-zinc-400 text-center text-sm">
+            Enter the access token to continue
+          </p>
+          {error && (
+            <div className="text-red-600 dark:text-red-400 text-sm text-center">{error}</div>
+          )}
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && authenticate()}
+            placeholder="Access token"
+            className="w-full px-4 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            autoFocus
+          />
+          <button
+            onClick={authenticate}
+            className="w-full px-4 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-medium transition-colors"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-white/80 dark:bg-zinc-900/80 backdrop-blur border-b border-zinc-200 dark:border-zinc-800">
+        <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+          <h1 className="text-lg font-bold text-zinc-900 dark:text-zinc-100">
+            Lector Eval
+          </h1>
+          <div className="flex items-center gap-3">
+            {evalCount > 0 && (
+              <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                {evalCount} evaluated
+              </span>
+            )}
+            <button
+              onClick={loadHistory}
+              className="text-sm px-3 py-1.5 rounded-lg border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300 transition-colors"
+            >
+              History
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        {error && (
+          <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* Input section */}
+        <div className="space-y-3">
+          <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            Afrikaans sentence
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={sentence}
+              onChange={(e) => setSentence(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && !loading && compare()}
+              placeholder="Type an Afrikaans sentence..."
+              className="flex-1 px-4 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              disabled={loading}
+            />
+            <button
+              onClick={fetchRandomSentence}
+              disabled={loading}
+              className="px-4 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300 transition-colors disabled:opacity-50 flex-shrink-0"
+              title="Random sentence from Tatoeba bank"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </button>
+          </div>
+          <button
+            onClick={compare}
+            disabled={loading || !sentence.trim()}
+            className="w-full px-4 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 disabled:bg-zinc-300 dark:disabled:bg-zinc-700 text-white font-medium transition-colors disabled:cursor-not-allowed"
+          >
+            {loading ? 'Translating with all 3 providers...' : 'Compare Translations'}
+          </button>
+        </div>
+
+        {/* Loading skeleton */}
+        {loading && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {(['apfel', 'ollama', 'claude'] as Provider[]).map((p) => (
+              <div
+                key={p}
+                className="p-5 rounded-xl border-2 border-zinc-200 dark:border-zinc-700 animate-pulse"
+              >
+                <div className="h-5 w-20 bg-zinc-200 dark:bg-zinc-700 rounded mb-3" />
+                <div className="h-4 w-full bg-zinc-200 dark:bg-zinc-700 rounded mb-2" />
+                <div className="h-4 w-3/4 bg-zinc-200 dark:bg-zinc-700 rounded" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Results */}
+        {results && !loading && (
+          <div className="space-y-4">
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              Select the best translation, or write your own below.
+            </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              {(['apfel', 'ollama', 'claude'] as Provider[]).map((provider) => {
+                const result = results.translations[provider];
+                const isSelected = selected === provider && !showManual;
+                const colors = PROVIDER_COLORS[provider];
+                const hasError = !!result?.error;
+                const isDisabled = hasError || submitted;
+
+                return (
+                  <button
+                    key={provider}
+                    onClick={() => {
+                      if (isDisabled) return;
+                      setSelected(provider);
+                      setShowManual(false);
+                    }}
+                    disabled={isDisabled}
+                    className={`
+                      p-5 rounded-xl border-2 text-left transition-all
+                      ${isSelected
+                        ? `${colors.ring.replace('ring', 'border')} ${colors.bg} ring-2 ${colors.ring} ring-offset-2 ring-offset-white dark:ring-offset-zinc-950`
+                        : 'border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600'
+                      }
+                      ${isDisabled && !isSelected ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                      ${submitted && isSelected ? 'ring-2 ring-green-500 border-green-500' : ''}
+                    `}
+                  >
+                    <div className={`text-sm font-semibold mb-2 ${isSelected ? colors.text : 'text-zinc-500 dark:text-zinc-400'}`}>
+                      {PROVIDER_LABELS[provider]}
+                    </div>
+                    {hasError ? (
+                      <p className="text-sm text-red-500 dark:text-red-400 italic">
+                        {result.error}
+                      </p>
+                    ) : (
+                      <p className="text-zinc-800 dark:text-zinc-200 leading-relaxed">
+                        {result?.translation || 'No translation'}
+                      </p>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Manual fallback */}
+            {!submitted && (
+              <div className="space-y-3">
+                {!showManual ? (
+                  <button
+                    onClick={() => {
+                      setShowManual(true);
+                      setSelected(null);
+                    }}
+                    className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+                  >
+                    None of these are good enough — I'll write my own
+                  </button>
+                ) : (
+                  <div className="space-y-2">
+                    <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                      Your translation
+                    </label>
+                    <textarea
+                      value={manualText}
+                      onChange={(e) => setManualText(e.target.value)}
+                      placeholder="Type the correct English translation..."
+                      rows={3}
+                      className="w-full px-4 py-3 rounded-xl border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+                      autoFocus
+                    />
+                    <button
+                      onClick={() => {
+                        setShowManual(false);
+                        setManualText('');
+                      }}
+                      className="text-sm text-zinc-500 dark:text-zinc-400 hover:underline"
+                    >
+                      Cancel — pick from above instead
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Submit */}
+            {!submitted && (selected || (showManual && manualText.trim())) && (
+              <button
+                onClick={submit}
+                disabled={submitting}
+                className="w-full px-4 py-3 rounded-xl bg-green-600 hover:bg-green-700 disabled:bg-zinc-300 dark:disabled:bg-zinc-700 text-white font-medium transition-colors"
+              >
+                {submitting
+                  ? 'Saving...'
+                  : showManual
+                    ? 'Submit my translation'
+                    : `Select ${PROVIDER_LABELS[selected as Provider]} as best`
+                }
+              </button>
+            )}
+
+            {/* Success + next */}
+            {submitted && (
+              <div className="space-y-3">
+                <div className="p-3 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-300 text-sm text-center">
+                  Saved! Evaluation recorded.
+                </div>
+                <button
+                  onClick={next}
+                  className="w-full px-4 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-medium transition-colors"
+                >
+                  Next sentence
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* History panel */}
+        {showHistory && (
+          <div className="fixed inset-0 z-50 bg-black/50 flex items-end sm:items-center justify-center p-4">
+            <div className="bg-white dark:bg-zinc-900 rounded-xl w-full max-w-2xl max-h-[80vh] overflow-hidden flex flex-col">
+              <div className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-700 flex items-center justify-between">
+                <h2 className="font-semibold text-zinc-900 dark:text-zinc-100">
+                  Evaluation History ({history.length})
+                </h2>
+                <button
+                  onClick={() => setShowHistory(false)}
+                  className="p-1.5 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500"
+                >
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <div className="overflow-y-auto flex-1 divide-y divide-zinc-100 dark:divide-zinc-800">
+                {history.length === 0 ? (
+                  <p className="p-6 text-center text-zinc-500 dark:text-zinc-400">
+                    No evaluations yet
+                  </p>
+                ) : (
+                  history.map((ev) => {
+                    const bestTranslation =
+                      ev.selectedProvider === 'manual'
+                        ? ev.manualTranslation
+                        : ev[`${ev.selectedProvider}Translation` as keyof Evaluation];
+                    return (
+                      <div key={ev.id} className="px-4 py-3 space-y-1">
+                        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          {ev.inputSentence}
+                        </p>
+                        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                          {bestTranslation as string}
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                            ev.selectedProvider === 'manual'
+                              ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400'
+                              : `${PROVIDER_COLORS[ev.selectedProvider as Provider]?.bg || ''} ${PROVIDER_COLORS[ev.selectedProvider as Provider]?.text || ''}`
+                          }`}>
+                            {ev.selectedProvider === 'manual' ? 'Manual' : PROVIDER_LABELS[ev.selectedProvider as Provider]}
+                          </span>
+                          <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                            {new Date(ev.createdAt).toLocaleString()}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/evaluate/page.tsx
+++ b/src/app/evaluate/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 type Provider = 'apfel' | 'ollama' | 'claude';
 type SelectedProvider = Provider | 'manual';
@@ -55,6 +55,23 @@ export default function EvaluatePage() {
   const [history, setHistory] = useState<Evaluation[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Auto-evaluate state
+  const [autoRunning, setAutoRunning] = useState(false);
+  const [autoBatchSize, setAutoBatchSize] = useState(20);
+  const [autoProgress, setAutoProgress] = useState<{ completed: number; total: number } | null>(null);
+  const [autoResults, setAutoResults] = useState<Array<{
+    sentence: string;
+    ollamaTranslation: string | null;
+    score: number;
+    correctedTranslation: string | null;
+    notes: string | null;
+    status: string;
+    error?: string;
+  }>>([]);
+  const [autoSummary, setAutoSummary] = useState<{ completed: number; improved: number; total: number } | null>(null);
+  const [showAuto, setShowAuto] = useState(false);
+  const autoAbortRef = useRef<AbortController | null>(null);
 
   const headers = useCallback((): Record<string, string> => {
     const h: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -177,6 +194,75 @@ export default function EvaluatePage() {
     setSubmitted(false);
     setSentence('');
     fetchRandomSentence();
+  };
+
+  const startAutoEvaluate = async () => {
+    setAutoRunning(true);
+    setAutoResults([]);
+    setAutoSummary(null);
+    setAutoProgress(null);
+    setError(null);
+
+    const controller = new AbortController();
+    autoAbortRef.current = controller;
+
+    try {
+      const res = await fetch('/api/translate-compare', {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify({ action: 'auto-evaluate', batchSize: autoBatchSize }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Auto-evaluate failed');
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error('No response stream');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data:')) continue;
+          const jsonStr = line.slice(5).trim();
+          if (!jsonStr) continue;
+
+          try {
+            const event = JSON.parse(jsonStr);
+            if (event.type === 'progress') {
+              setAutoProgress({ completed: event.completed, total: event.total });
+              setAutoResults((prev) => [...prev, event]);
+            } else if (event.type === 'done') {
+              setAutoSummary(event);
+            }
+          } catch {
+            // Skip malformed SSE lines
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setError(err instanceof Error ? err.message : 'Auto-evaluate failed');
+      }
+    } finally {
+      setAutoRunning(false);
+      autoAbortRef.current = null;
+    }
+  };
+
+  const stopAutoEvaluate = () => {
+    autoAbortRef.current?.abort();
   };
 
   const loadHistory = async () => {
@@ -438,6 +524,138 @@ export default function EvaluatePage() {
             )}
           </div>
         )}
+
+        {/* Auto-evaluate section */}
+        <div className="border-t border-zinc-200 dark:border-zinc-800 pt-6">
+          <button
+            onClick={() => setShowAuto(!showAuto)}
+            className="flex items-center gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          >
+            <svg
+              className={`w-4 h-4 transition-transform ${showAuto ? 'rotate-90' : ''}`}
+              fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+            Auto-evaluate with Claude
+            <span className="text-xs text-zinc-400 dark:text-zinc-500 font-normal">
+              Claude judges Ollama's translations in batch
+            </span>
+          </button>
+
+          {showAuto && (
+            <div className="mt-4 space-y-4">
+              <div className="flex items-end gap-3">
+                <div>
+                  <label className="block text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                    Batch size
+                  </label>
+                  <select
+                    value={autoBatchSize}
+                    onChange={(e) => setAutoBatchSize(Number(e.target.value))}
+                    disabled={autoRunning}
+                    className="px-3 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm"
+                  >
+                    {[10, 20, 50, 100].map((n) => (
+                      <option key={n} value={n}>{n} sentences</option>
+                    ))}
+                  </select>
+                </div>
+                {!autoRunning ? (
+                  <button
+                    onClick={startAutoEvaluate}
+                    className="px-4 py-2 rounded-lg bg-sky-600 hover:bg-sky-700 text-white text-sm font-medium transition-colors"
+                  >
+                    Run auto-evaluation
+                  </button>
+                ) : (
+                  <button
+                    onClick={stopAutoEvaluate}
+                    className="px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors"
+                  >
+                    Stop
+                  </button>
+                )}
+              </div>
+
+              {/* Progress bar */}
+              {autoProgress && (
+                <div className="space-y-1">
+                  <div className="flex justify-between text-xs text-zinc-500 dark:text-zinc-400">
+                    <span>{autoProgress.completed} / {autoProgress.total}</span>
+                    <span>{Math.round((autoProgress.completed / autoProgress.total) * 100)}%</span>
+                  </div>
+                  <div className="h-2 bg-zinc-200 dark:bg-zinc-800 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-sky-500 transition-all duration-300 rounded-full"
+                      style={{ width: `${(autoProgress.completed / autoProgress.total) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Summary */}
+              {autoSummary && (
+                <div className="p-3 rounded-lg bg-sky-50 dark:bg-sky-900/20 border border-sky-200 dark:border-sky-800 text-sm">
+                  <p className="font-medium text-sky-700 dark:text-sky-300">
+                    Batch complete: {autoSummary.completed} evaluated, {autoSummary.improved} corrected by Claude
+                  </p>
+                  <p className="text-sky-600 dark:text-sky-400 mt-1">
+                    {autoSummary.completed - autoSummary.improved} sentences where Ollama was good (score 4+)
+                  </p>
+                </div>
+              )}
+
+              {/* Results feed */}
+              {autoResults.length > 0 && (
+                <div className="max-h-96 overflow-y-auto space-y-2">
+                  {autoResults.map((r, i) => (
+                    <div
+                      key={i}
+                      className={`p-3 rounded-lg border text-sm ${
+                        r.status === 'error'
+                          ? 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20'
+                          : r.score >= 4
+                            ? 'border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20'
+                            : 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20'
+                      }`}
+                    >
+                      <p className="font-medium text-zinc-800 dark:text-zinc-200">{r.sentence}</p>
+                      {r.status === 'error' ? (
+                        <p className="text-red-600 dark:text-red-400 mt-1">{r.error}</p>
+                      ) : (
+                        <>
+                          <div className="mt-1 flex items-center gap-2">
+                            <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                              r.score >= 4
+                                ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300'
+                                : r.score >= 3
+                                  ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+                                  : 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+                            }`}>
+                              {r.score}/5
+                            </span>
+                            <span className="text-zinc-500 dark:text-zinc-400">
+                              Ollama: {r.ollamaTranslation || '(failed)'}
+                            </span>
+                          </div>
+                          {r.correctedTranslation && (
+                            <p className="mt-1 text-sky-700 dark:text-sky-300">
+                              Claude: {r.correctedTranslation}
+                            </p>
+                          )}
+                          {r.notes && (
+                            <p className="mt-0.5 text-zinc-400 dark:text-zinc-500 text-xs">{r.notes}</p>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
 
         {/* History panel */}
         {showHistory && (

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -445,6 +445,35 @@ export default function ReadPage({
                 </div>
               </div>
               <button
+                onClick={async () => {
+                  setWordPanel((prev) => ({ ...prev, isLoading: true, error: null }));
+                  const isPhrase = wordPanel.word.includes(' ');
+                  try {
+                    const result = isPhrase
+                      ? await translatePhrase(wordPanel.word, wordPanel.sentence)
+                      : await translateWord(wordPanel.word, wordPanel.sentence);
+                    setWordPanel((prev) => ({
+                      ...prev,
+                      translation: result.translation,
+                      partOfSpeech: isPhrase ? 'phrase' : ('partOfSpeech' in result ? result.partOfSpeech || null : null),
+                      isLoading: false,
+                    }));
+                  } catch {
+                    setWordPanel((prev) => ({
+                      ...prev,
+                      isLoading: false,
+                      error: 'Re-translate failed',
+                    }));
+                  }
+                }}
+                className="p-1.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors flex-shrink-0"
+                title="Re-translate (fresh LLM call)"
+              >
+                <svg className="w-4 h-4 text-zinc-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              </button>
+              <button
                 onClick={closeWordPanel}
                 className="p-1.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors flex-shrink-0"
                 title="Close (Esc)"


### PR DESCRIPTION
## Summary

- Add `/evaluate` page for comparing translations from all 3 LLM providers (Apfel, Ollama, Claude) side-by-side
- User selects the best translation or writes their own — preference data stored as seed corpus for RAG (#25)
- `EVAL_TOKEN` env var auth gate so the page can be shared via ngrok to external evaluators
- Export endpoint outputs evaluations in RAG corpus format matching #25's schema

## New endpoints

- `POST /api/translate-compare/compare` — fires all 3 providers in parallel
- `POST /api/translate-compare/evaluate` — stores the preference
- `GET /api/translate-compare/evaluations` — list/export stored evaluations
- `GET /api/translate-compare/random-sentence` — pull from Tatoeba bank

## Test plan

- [ ] E2E tests for /evaluate page (pending follow-up)
- [ ] Unit tests for translate-compare routes (pending follow-up)
- [ ] Manual: set `EVAL_TOKEN=test`, visit /evaluate, verify auth gate
- [ ] Manual: compare translations, select one, verify stored in DB
- [ ] Manual: use "Random sentence" button, verify pulls from cloze bank
- [ ] Manual: write manual translation, verify stored with provider=manual
- [ ] Manual: export via GET /api/translate-compare/evaluations?format=corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
