### PR TITLE
feat: root-based dictionary with lemmatization and 74 new words

### DIFF
--- a/e2e/reader-word-handling.spec.ts
+++ b/e2e/reader-word-handling.spec.ts
@@ -59,6 +59,13 @@ test.describe('Reader word handling', () => {
       }
     }
 
+    // Delete any stale vocab entries for test words (server-side SQLite)
+    const vocabRes = await page.request.get('/api/vocab?text=perdekraal-fees');
+    const vocabEntries = await vocabRes.json();
+    for (const v of vocabEntries) {
+      await page.request.delete(`/api/vocab/${v.id}`);
+    }
+
     collectionId = await importHyphenatedLesson(page);
   });
 
@@ -103,11 +110,16 @@ test.describe('Reader word handling', () => {
     ).toHaveText('Perdekraal-fees');
     await expect(wordPanel.getByText('[translated:')).toBeVisible();
 
-    // Press Cmd+1 (Meta+1) — should NOT set word level
-    await page.keyboard.press('Meta+1');
+    // Dispatch a keydown with metaKey=true via JS (Playwright keyboard API
+    // doesn't reliably set metaKey in headless Chromium)
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '1', metaKey: true, bubbles: true })
+      );
+    });
+    await page.waitForTimeout(300);
 
-    // The word panel should still be open and no level should be set
-    // (if it were captured, level1 button would get a ring highlight)
+    // Level should NOT be set — Cmd+1 should pass through
     const levelButton = wordPanel.locator('button', { hasText: '1' });
     const classes = await levelButton.getAttribute('class');
     expect(classes).not.toContain('ring-2');

--- a/scripts/build-root-dictionary.ts
+++ b/scripts/build-root-dictionary.ts
@@ -1,0 +1,220 @@
+/**
+ * Transforms flat dictionary-data.json into root-based structure.
+ *
+ * Output format:
+ * {
+ *   "staan": {
+ *     "rank": 42,
+ *     "translation": "to stand",
+ *     "partOfSpeech": "verb",
+ *     "prefixes": {
+ *       "ver": { "rank": 100, "translation": "understand" },
+ *       "be": { "rank": 200, "translation": "exist", "partOfSpeech": "noun" }
+ *     },
+ *     "suffixes": {
+ *       "e": { "rank": 300, "translation": "stands (plural)" }
+ *     }
+ *   }
+ * }
+ *
+ * Run: npx tsx scripts/build-root-dictionary.ts
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+interface FlatEntry {
+  word: string;
+  rank: number;
+  translation: string;
+  partOfSpeech: string;
+}
+
+interface DerivedEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech?: string; // only if different from root
+}
+
+interface RootEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech: string;
+  prefixes?: Record<string, DerivedEntry>;
+  suffixes?: Record<string, DerivedEntry>;
+}
+
+const PREFIXES = ['ont', 'ver', 'her', 'ge', 'be'];
+const SUFFIXES = ['heid', 'tjie', 'jie', 'ing', 'lik', 'te', 'de', 'e', 's'];
+const VOWELS = new Set('aeiouyêëéèôöûüîïáà'.split(''));
+const MIN_STEM = 2;
+
+function undoubleConsonant(stem: string): string | null {
+  if (stem.length >= 3) {
+    const last = stem[stem.length - 1];
+    const prev = stem[stem.length - 2];
+    if (last === prev && !VOWELS.has(last)) {
+      return stem.slice(0, -1);
+    }
+  }
+  return null;
+}
+
+const dataPath = path.join(__dirname, '../src/lib/dictionary-data.json');
+const data: FlatEntry[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+
+// Build word→entry lookup
+const entryMap = new Map<string, FlatEntry>();
+for (const e of data) {
+  entryMap.set(e.word.toLowerCase(), e);
+}
+
+// Track which words get nested (so we don't keep them as roots too)
+const nested = new Set<string>();
+
+// Track derivation relationships: rootWord → [{ word, type, affix }]
+interface Derivation {
+  word: string;
+  type: 'prefix' | 'suffix';
+  affix: string;
+  root: string; // the actual root word matched
+}
+
+// False positives: words that structurally match prefix+root or root+suffix
+// but are etymologically unrelated. Keep these as standalone root entries.
+const EXCLUDE = new Set([
+  // Prefix false positives
+  'been',     // leg/bone, not be- + en
+  'geen',     // no/none, not ge- + en
+  'geweer',   // rifle, not ge- + weer
+  'gebed',    // prayer, not ge- + bed
+  'bevel',    // command, not be- + vel
+  'geval',    // case, not ge- + val
+  'gesin',    // family, not ge- + sin
+  'veral',    // especially, not ver- + al
+  'verhaal',  // tale, not ver- + haal
+  'verhoog',  // stage, not ver- + hoog
+  'ontrou',   // unfaithful, not ont- + rou
+  // Suffix false positives
+  'tee',      // tea, not te + -e
+  'ses',      // six, not se + -s
+  'see',      // sea, not se + -e
+  'dans',     // dance, not dan + -s
+  'gees',     // spirit, not gee + -s
+  'sonde',    // sin, not son + -de
+  'vals',     // false, not val + -s
+  'hele',     // whole, not hel + -e
+  'jas',      // jacket, not ja + -s
+  'selde',    // seldom, not sel + -de
+  'soms',     // sometimes, not som + -s
+  'hulle',    // they/them, not hul + -e
+  'selfs',    // even, not self + -s
+  'slegs',    // only, not sleg + -s
+]);
+
+const derivations: Derivation[] = [];
+
+for (const entry of data) {
+  const w = entry.word.toLowerCase();
+  if (EXCLUDE.has(w)) continue;
+
+  // Try prefix stripping
+  for (const p of PREFIXES) {
+    if (w.startsWith(p)) {
+      const stem = w.slice(p.length);
+      if (stem.length >= MIN_STEM && entryMap.has(stem)) {
+        derivations.push({ word: w, type: 'prefix', affix: p, root: stem });
+        break; // take first prefix match (longest prefixes are first)
+      }
+    }
+  }
+
+  // Try suffix stripping
+  for (const s of SUFFIXES) {
+    if (w.endsWith(s)) {
+      const stem = w.slice(0, -s.length);
+
+      if (stem.length >= MIN_STEM && entryMap.has(stem)) {
+        derivations.push({ word: w, type: 'suffix', affix: s, root: stem });
+        break;
+      }
+
+      // Try consonant undoubling
+      const undoubled = undoubleConsonant(stem);
+      if (undoubled && undoubled.length >= MIN_STEM && entryMap.has(undoubled)) {
+        derivations.push({ word: w, type: 'suffix', affix: s, root: undoubled });
+        break;
+      }
+    }
+  }
+}
+
+// A word that is itself the root of other derivations should NOT be nested
+const rootsOfOthers = new Set(derivations.map((d) => d.root));
+
+// Filter: don't nest words that are roots for other derivations
+const validDerivations = derivations.filter((d) => !rootsOfOthers.has(d.word));
+
+for (const d of validDerivations) {
+  nested.add(d.word);
+}
+
+// Build the root-based dictionary
+const rootDict: Record<string, RootEntry> = {};
+
+// First pass: add all root entries (entries not nested under another)
+for (const entry of data) {
+  const w = entry.word.toLowerCase();
+  if (nested.has(w)) continue;
+
+  rootDict[w] = {
+    rank: entry.rank,
+    translation: entry.translation,
+    partOfSpeech: entry.partOfSpeech,
+  };
+}
+
+// Second pass: nest derivations under their roots
+for (const d of validDerivations) {
+  const root = rootDict[d.root];
+  if (!root) continue; // safety check
+
+  const derivedEntry = entryMap.get(d.word)!;
+  const derived: DerivedEntry = {
+    rank: derivedEntry.rank,
+    translation: derivedEntry.translation,
+  };
+
+  // Only include POS if different from root
+  if (derivedEntry.partOfSpeech !== root.partOfSpeech) {
+    derived.partOfSpeech = derivedEntry.partOfSpeech;
+  }
+
+  if (d.type === 'prefix') {
+    if (!root.prefixes) root.prefixes = {};
+    root.prefixes[d.affix] = derived;
+  } else {
+    if (!root.suffixes) root.suffixes = {};
+    root.suffixes[d.affix] = derived;
+  }
+}
+
+// Write output
+const outPath = path.join(__dirname, '../src/lib/dictionary-roots.json');
+fs.writeFileSync(outPath, JSON.stringify(rootDict, null, 2));
+
+// Stats
+const rootCount = Object.keys(rootDict).length;
+let prefixCount = 0;
+let suffixCount = 0;
+for (const entry of Object.values(rootDict)) {
+  prefixCount += Object.keys(entry.prefixes || {}).length;
+  suffixCount += Object.keys(entry.suffixes || {}).length;
+}
+
+console.log(`Root entries: ${rootCount}`);
+console.log(`Prefix derivations nested: ${prefixCount}`);
+console.log(`Suffix derivations nested: ${suffixCount}`);
+console.log(`Total words covered: ${rootCount + prefixCount + suffixCount}`);
+console.log(`Slots freed: ${data.length - rootCount} (available for new roots)`);
+console.log(`\nWritten to: ${outPath}`);

--- a/scripts/expand-dictionary.ts
+++ b/scripts/expand-dictionary.ts
@@ -1,0 +1,208 @@
+/**
+ * Expands dictionary-roots.json with new root entries.
+ * Run: npx tsx scripts/expand-dictionary.ts
+ */
+import fs from 'fs';
+import path from 'path';
+
+interface DerivedEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech?: string;
+}
+
+interface RootEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech: string;
+  prefixes?: Record<string, DerivedEntry>;
+  suffixes?: Record<string, DerivedEntry>;
+}
+
+// New words to add — sourced from user's reading corpus + common Afrikaans gaps
+// rank: 0 = unranked (not in original top-2000 frequency list)
+const NEW_WORDS: { word: string; translation: string; partOfSpeech: string }[] = [
+  // High frequency in reading corpus (>50 occurrences)
+  { word: 'dis', translation: "it is/that's", partOfSpeech: 'contraction' },
+  { word: 'oom', translation: 'uncle/sir', partOfSpeech: 'noun' },
+  { word: 'want', translation: 'because/for', partOfSpeech: 'conjunction' },
+  { word: 'lyk', translation: 'seem/look/corpse', partOfSpeech: 'verb' },
+  { word: 'alles', translation: 'everything', partOfSpeech: 'pronoun' },
+  { word: 'tog', translation: 'yet/still/after all', partOfSpeech: 'adverb' },
+  { word: 'julle', translation: 'you (plural)', partOfSpeech: 'pronoun' },
+  { word: 'almal', translation: 'everyone', partOfSpeech: 'pronoun' },
+  { word: 'keer', translation: 'time/turn/prevent', partOfSpeech: 'noun' },
+  { word: 'lang', translation: 'long/tall', partOfSpeech: 'adjective' },
+  { word: 'alleen', translation: 'alone/only', partOfSpeech: 'adverb' },
+  { word: 'vas', translation: 'firm/stuck/fast', partOfSpeech: 'adjective' },
+  { word: 'veld', translation: 'field/bush/veld', partOfSpeech: 'noun' },
+  { word: 'ag', translation: 'oh/eight', partOfSpeech: 'interjection' },
+  { word: 'ma', translation: 'mother/mom', partOfSpeech: 'noun' },
+  { word: 'tant', translation: 'aunt/ma\'am', partOfSpeech: 'noun' },
+  { word: 'staar', translation: 'stare', partOfSpeech: 'verb' },
+  { word: 'iemand', translation: 'someone', partOfSpeech: 'pronoun' },
+  { word: 'taal', translation: 'language', partOfSpeech: 'noun' },
+  { word: 'wel', translation: 'well/indeed', partOfSpeech: 'adverb' },
+  { word: 'volk', translation: 'nation/people', partOfSpeech: 'noun' },
+  { word: 'mekaar', translation: 'each other', partOfSpeech: 'pronoun' },
+  { word: 'dié', translation: 'this/these', partOfSpeech: 'determiner' },
+  { word: 'niemand', translation: 'nobody/no one', partOfSpeech: 'pronoun' },
+  { word: 'raak', translation: 'touch/become/get', partOfSpeech: 'verb' },
+  { word: 'pa', translation: 'father/dad', partOfSpeech: 'noun' },
+  { word: 'verdwyn', translation: 'disappear', partOfSpeech: 'verb' },
+  { word: 'jare', translation: 'years', partOfSpeech: 'noun' },
+  { word: 'moes', translation: 'had to/must (past)', partOfSpeech: 'verb' },
+  { word: 'asof', translation: 'as if', partOfSpeech: 'conjunction' },
+  { word: 'steek', translation: 'stab/sting/put', partOfSpeech: 'verb' },
+  { word: 'sterre', translation: 'stars', partOfSpeech: 'noun' },
+  { word: 'daarvan', translation: 'of it/thereof', partOfSpeech: 'adverb' },
+  { word: 'skyn', translation: 'shine/seem', partOfSpeech: 'verb' },
+  { word: 'neer', translation: 'down', partOfSpeech: 'adverb' },
+  { word: 'half', translation: 'half', partOfSpeech: 'adjective' },
+  { word: 'luister', translation: 'listen', partOfSpeech: 'verb' },
+  { word: 'veel', translation: 'much/many', partOfSpeech: 'adverb' },
+  { word: 'blink', translation: 'shine/bright', partOfSpeech: 'verb' },
+  { word: 'droom', translation: 'dream', partOfSpeech: 'noun' },
+  { word: 'gebeur', translation: 'happen', partOfSpeech: 'verb' },
+  { word: 'mee', translation: 'with/along', partOfSpeech: 'adverb' },
+  { word: 'glimlag', translation: 'smile', partOfSpeech: 'noun' },
+  { word: 'gang', translation: 'corridor/pace', partOfSpeech: 'noun' },
+  { word: 'mos', translation: 'after all/surely', partOfSpeech: 'adverb' },
+  { word: 'aarde', translation: 'earth/ground', partOfSpeech: 'noun' },
+  { word: 'kleur', translation: 'colour', partOfSpeech: 'noun' },
+  { word: 'ore', translation: 'ears', partOfSpeech: 'noun' },
+  { word: 'slang', translation: 'snake', partOfSpeech: 'noun' },
+  { word: 'verskyn', translation: 'appear', partOfSpeech: 'verb' },
+  { word: 'middel', translation: 'middle/waist', partOfSpeech: 'noun' },
+  { word: 'meisie', translation: 'girl', partOfSpeech: 'noun' },
+  { word: 'geniet', translation: 'enjoy', partOfSpeech: 'verb' },
+  { word: 'ontdek', translation: 'discover', partOfSpeech: 'verb' },
+  { word: 'eis', translation: 'demand/claim', partOfSpeech: 'verb' },
+  { word: 'ouma', translation: 'grandmother', partOfSpeech: 'noun' },
+  { word: 'verdien', translation: 'earn/deserve', partOfSpeech: 'verb' },
+  { word: 'oupa', translation: 'grandfather', partOfSpeech: 'noun' },
+  { word: 'brug', translation: 'bridge', partOfSpeech: 'noun' },
+  { word: 'baba', translation: 'baby', partOfSpeech: 'noun' },
+  { word: 'blad', translation: 'leaf/page', partOfSpeech: 'noun' },
+  { word: 'vlees', translation: 'meat/flesh', partOfSpeech: 'noun' },
+  { word: 'berei', translation: 'prepare', partOfSpeech: 'verb' },
+  { word: 'skaap', translation: 'sheep', partOfSpeech: 'noun' },
+  { word: 'hoender', translation: 'chicken', partOfSpeech: 'noun' },
+  { word: 'sowat', translation: 'about/approximately', partOfSpeech: 'adverb' },
+  { word: 'bely', translation: 'confess', partOfSpeech: 'verb' },
+  { word: 'koei', translation: 'cow', partOfSpeech: 'noun' },
+  // Additional common words not in corpus but useful
+  { word: 'later', translation: 'later', partOfSpeech: 'adverb' },
+  { word: 'seun', translation: 'boy/son', partOfSpeech: 'noun' },
+  { word: 'oggend', translation: 'morning', partOfSpeech: 'noun' },
+  { word: 'nag', translation: 'night', partOfSpeech: 'noun' },
+  { word: 'dorp', translation: 'town/village', partOfSpeech: 'noun' },
+  { word: 'reën', translation: 'rain', partOfSpeech: 'noun' },
+  { word: 'pad', translation: 'road/path', partOfSpeech: 'noun' },
+  { word: 'kamer', translation: 'room', partOfSpeech: 'noun' },
+  { word: 'plek', translation: 'place/spot', partOfSpeech: 'noun' },
+  { word: 'voel', translation: 'feel', partOfSpeech: 'verb' },
+  { word: 'brief', translation: 'letter', partOfSpeech: 'noun' },
+  { word: 'paar', translation: 'pair/few/couple', partOfSpeech: 'noun' },
+  { word: 'uur', translation: 'hour', partOfSpeech: 'noun' },
+  { word: 'maand', translation: 'month', partOfSpeech: 'noun' },
+  { word: 'maal', translation: 'time/grind', partOfSpeech: 'noun' },
+  { word: 'niks', translation: 'nothing', partOfSpeech: 'pronoun' },
+  { word: 'bietjie', translation: 'a little/bit', partOfSpeech: 'adverb' },
+  { word: 'buite', translation: 'outside', partOfSpeech: 'adverb' },
+  { word: 'blom', translation: 'flower', partOfSpeech: 'noun' },
+  { word: 'boom', translation: 'tree', partOfSpeech: 'noun' },
+  { word: 'rivier', translation: 'river', partOfSpeech: 'noun' },
+  { word: 'hemel', translation: 'heaven/sky', partOfSpeech: 'noun' },
+  { word: 'brood', translation: 'bread', partOfSpeech: 'noun' },
+  { word: 'suiker', translation: 'sugar', partOfSpeech: 'noun' },
+  { word: 'sout', translation: 'salt', partOfSpeech: 'noun' },
+  { word: 'kaas', translation: 'cheese', partOfSpeech: 'noun' },
+  { word: 'botter', translation: 'butter', partOfSpeech: 'noun' },
+  { word: 'appel', translation: 'apple', partOfSpeech: 'noun' },
+  { word: 'lemoen', translation: 'orange', partOfSpeech: 'noun' },
+  { word: 'wind', translation: 'wind', partOfSpeech: 'noun' },
+  { word: 'klip', translation: 'rock/stone', partOfSpeech: 'noun' },
+  { word: 'goud', translation: 'gold', partOfSpeech: 'noun' },
+  { word: 'yster', translation: 'iron', partOfSpeech: 'noun' },
+  { word: 'voël', translation: 'bird', partOfSpeech: 'noun' },
+  { word: 'vis', translation: 'fish', partOfSpeech: 'noun' },
+  { word: 'perd', translation: 'horse', partOfSpeech: 'noun' },
+  { word: 'muis', translation: 'mouse', partOfSpeech: 'noun' },
+  { word: 'genoeg', translation: 'enough', partOfSpeech: 'adverb' },
+  { word: 'binne', translation: 'inside/within', partOfSpeech: 'adverb' },
+  { word: 'wens', translation: 'wish', partOfSpeech: 'verb' },
+  { word: 'antwoord', translation: 'answer', partOfSpeech: 'noun' },
+  { word: 'probeer', translation: 'try/attempt', partOfSpeech: 'verb' },
+  { word: 'soek', translation: 'search/look for', partOfSpeech: 'verb' },
+  { word: 'draai', translation: 'turn/twist', partOfSpeech: 'verb' },
+  { word: 'klim', translation: 'climb', partOfSpeech: 'verb' },
+  { word: 'spring', translation: 'jump', partOfSpeech: 'verb' },
+  { word: 'hardloop', translation: 'run', partOfSpeech: 'verb' },
+  { word: 'vergeet', translation: 'forget', partOfSpeech: 'verb' },
+  { word: 'besluit', translation: 'decide', partOfSpeech: 'verb' },
+  { word: 'besoek', translation: 'visit', partOfSpeech: 'verb' },
+  { word: 'beweeg', translation: 'move', partOfSpeech: 'verb' },
+  { word: 'vermy', translation: 'avoid', partOfSpeech: 'verb' },
+  { word: 'bedoel', translation: 'mean/intend', partOfSpeech: 'verb' },
+  { word: 'donker', translation: 'dark', partOfSpeech: 'adjective' },
+  { word: 'terug', translation: 'back', partOfSpeech: 'adverb' },
+  { word: 'saam', translation: 'together', partOfSpeech: 'adverb' },
+  { word: 'muur', translation: 'wall', partOfSpeech: 'noun' },
+  { word: 'oop', translation: 'open', partOfSpeech: 'adjective' },
+  { word: 'kop', translation: 'head/cup', partOfSpeech: 'noun' },
+  { word: 'ryk', translation: 'rich/kingdom', partOfSpeech: 'adjective' },
+  { word: 'vra', translation: 'ask', partOfSpeech: 'verb' },
+  { word: 'rond', translation: 'round/around', partOfSpeech: 'adverb' },
+  { word: 'nodig', translation: 'necessary/need', partOfSpeech: 'adjective' },
+  { word: 'rustig', translation: 'calm/peaceful', partOfSpeech: 'adjective' },
+  { word: 'naby', translation: 'near/close', partOfSpeech: 'adverb' },
+  { word: 'trap', translation: 'stairs/kick', partOfSpeech: 'noun' },
+  { word: 'kyk', translation: 'look/watch', partOfSpeech: 'verb' },
+  { word: 'rug', translation: 'back (body)', partOfSpeech: 'noun' },
+  { word: 'wag', translation: 'wait/guard', partOfSpeech: 'verb' },
+];
+
+const rootsPath = path.join(__dirname, '../src/lib/dictionary-roots.json');
+const roots: Record<string, RootEntry> = JSON.parse(fs.readFileSync(rootsPath, 'utf-8'));
+
+// Find the max rank used in existing entries
+let maxRank = 0;
+for (const entry of Object.values(roots)) {
+  if (entry.rank > maxRank) maxRank = entry.rank;
+  if (entry.prefixes) for (const d of Object.values(entry.prefixes)) if (d.rank > maxRank) maxRank = d.rank;
+  if (entry.suffixes) for (const d of Object.values(entry.suffixes)) if (d.rank > maxRank) maxRank = d.rank;
+}
+
+let added = 0;
+let skipped = 0;
+let nextRank = maxRank + 1;
+
+for (const w of NEW_WORDS) {
+  const key = w.word.toLowerCase();
+  if (roots[key]) {
+    skipped++;
+    continue;
+  }
+  roots[key] = {
+    rank: nextRank++,
+    translation: w.translation,
+    partOfSpeech: w.partOfSpeech,
+  };
+  added++;
+}
+
+fs.writeFileSync(rootsPath, JSON.stringify(roots, null, 2));
+
+console.log(`Added: ${added} new root entries`);
+console.log(`Skipped: ${skipped} (already exist)`);
+console.log(`Total roots: ${Object.keys(roots).length}`);
+
+// Count total coverage
+let prefixCount = 0;
+let suffixCount = 0;
+for (const entry of Object.values(roots)) {
+  prefixCount += Object.keys(entry.prefixes || {}).length;
+  suffixCount += Object.keys(entry.suffixes || {}).length;
+}
+console.log(`Total coverage: ${Object.keys(roots).length + prefixCount + suffixCount} words`);

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -141,9 +141,12 @@ export default function ReadPage({
         const dictionaryEntry = lookupWord(word);
 
         if (dictionaryEntry) {
+          const translation = dictionaryEntry.lemmaInfo
+            ? `${dictionaryEntry.translation} (${dictionaryEntry.lemmaInfo.label} ${dictionaryEntry.lemmaInfo.stem})`
+            : dictionaryEntry.translation;
           setWordPanel((prev) => ({
             ...prev,
-            translation: dictionaryEntry.translation,
+            translation,
             partOfSpeech: dictionaryEntry.partOfSpeech || null,
             isLoading: false,
             isDictionaryResult: true,

--- a/src/lib/__tests__/dictionary.test.ts
+++ b/src/lib/__tests__/dictionary.test.ts
@@ -1,0 +1,96 @@
+import { lookupWord } from '../dictionary';
+
+describe('lookupWord — exact root match', () => {
+  test('finds a root word', () => {
+    const entry = lookupWord('die');
+    expect(entry).toBeDefined();
+    expect(entry!.word).toBe('die');
+    expect(entry!.translation).toBe('the');
+    expect(entry!.lemmaInfo).toBeUndefined();
+  });
+
+  test('case-insensitive', () => {
+    const entry = lookupWord('Die');
+    expect(entry).toBeDefined();
+    expect(entry!.word).toBe('die');
+  });
+});
+
+describe('lookupWord — known prefix derivation', () => {
+  test('verstaan found via ver- prefix on staan', () => {
+    const entry = lookupWord('verstaan');
+    expect(entry).toBeDefined();
+    expect(entry!.translation).toBe('understand');
+    expect(entry!.lemmaInfo).toBeDefined();
+    expect(entry!.lemmaInfo!.stem).toBe('staan');
+  });
+
+  test('gesien found via ge- prefix on sien', () => {
+    const entry = lookupWord('gesien');
+    expect(entry).toBeDefined();
+    expect(entry!.translation).toBe('seen');
+    expect(entry!.lemmaInfo!.stem).toBe('sien');
+    expect(entry!.lemmaInfo!.label).toBe('past participle of');
+  });
+
+  test('verkoop found via ver- prefix on koop', () => {
+    const entry = lookupWord('verkoop');
+    expect(entry).toBeDefined();
+    expect(entry!.translation).toBe('sell');
+    expect(entry!.lemmaInfo!.stem).toBe('koop');
+  });
+});
+
+describe('lookupWord — known suffix derivation', () => {
+  test('werklik found via -lik suffix on werk', () => {
+    const entry = lookupWord('werklik');
+    expect(entry).toBeDefined();
+    expect(entry!.translation).toBe('really');
+    expect(entry!.lemmaInfo!.stem).toBe('werk');
+  });
+
+  test('liefde found via -de suffix on lief', () => {
+    const entry = lookupWord('liefde');
+    expect(entry).toBeDefined();
+    expect(entry!.translation).toBe('love');
+    expect(entry!.lemmaInfo!.stem).toBe('lief');
+  });
+});
+
+describe('lookupWord — affix-strip fallback', () => {
+  test('strips ge- prefix to find root when no nested entry exists', () => {
+    // "gemaak" = ge- + maak (make), maak is a root but gemaak isn't a nested prefix entry
+    const maak = lookupWord('maak');
+    if (!maak) return;
+    const entry = lookupWord('gemaak');
+    expect(entry).toBeDefined();
+    expect(entry!.lemmaInfo).toBeDefined();
+    expect(entry!.lemmaInfo!.stem).toBe('maak');
+    expect(entry!.lemmaInfo!.label).toBe('past participle of');
+    // Fallback entries get rank 0
+    expect(entry!.rank).toBe(0);
+  });
+});
+
+describe('lookupWord — consonant undoubling', () => {
+  test('katte → kat via -e suffix + undoubling', () => {
+    const kat = lookupWord('kat');
+    if (!kat) return;
+    const entry = lookupWord('katte');
+    expect(entry).toBeDefined();
+    expect(entry!.lemmaInfo!.stem).toBe('kat');
+  });
+});
+
+describe('lookupWord — no match', () => {
+  test('returns undefined for unknown words', () => {
+    expect(lookupWord('xyzzyx')).toBeUndefined();
+  });
+
+  test('exact root match takes priority over derivation', () => {
+    // "het" is its own root, not ge- stripped from "et"
+    const entry = lookupWord('het');
+    expect(entry).toBeDefined();
+    expect(entry!.lemmaInfo).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/dictionary.test.ts
+++ b/src/lib/__tests__/dictionary.test.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from 'vitest';
 import { lookupWord } from '../dictionary';
 
 describe('lookupWord — exact root match', () => {

--- a/src/lib/dictionary-roots.json
+++ b/src/lib/dictionary-roots.json
@@ -1,0 +1,10237 @@
+{
+  "die": {
+    "rank": 1,
+    "translation": "the",
+    "partOfSpeech": "article"
+  },
+  "en": {
+    "rank": 2,
+    "translation": "and",
+    "partOfSpeech": "conjunction"
+  },
+  "van": {
+    "rank": 3,
+    "translation": "of/from",
+    "partOfSpeech": "preposition"
+  },
+  "is": {
+    "rank": 4,
+    "translation": "is",
+    "partOfSpeech": "verb"
+  },
+  "in": {
+    "rank": 5,
+    "translation": "in",
+    "partOfSpeech": "preposition"
+  },
+  "het": {
+    "rank": 6,
+    "translation": "has/have",
+    "partOfSpeech": "verb"
+  },
+  "ek": {
+    "rank": 7,
+    "translation": "I",
+    "partOfSpeech": "pronoun"
+  },
+  "wat": {
+    "rank": 8,
+    "translation": "what/that/which",
+    "partOfSpeech": "pronoun"
+  },
+  "nie": {
+    "rank": 9,
+    "translation": "not",
+    "partOfSpeech": "adverb"
+  },
+  "om": {
+    "rank": 10,
+    "translation": "to/around",
+    "partOfSpeech": "preposition"
+  },
+  "te": {
+    "rank": 11,
+    "translation": "to",
+    "partOfSpeech": "particle"
+  },
+  "sy": {
+    "rank": 12,
+    "translation": "she/his/her",
+    "partOfSpeech": "pronoun"
+  },
+  "dit": {
+    "rank": 13,
+    "translation": "it/this",
+    "partOfSpeech": "pronoun"
+  },
+  "met": {
+    "rank": 14,
+    "translation": "with",
+    "partOfSpeech": "preposition"
+  },
+  "op": {
+    "rank": 15,
+    "translation": "on/up",
+    "partOfSpeech": "preposition"
+  },
+  "my": {
+    "rank": 16,
+    "translation": "my/me",
+    "partOfSpeech": "pronoun"
+  },
+  "was": {
+    "rank": 17,
+    "translation": "was",
+    "partOfSpeech": "verb"
+  },
+  "vir": {
+    "rank": 18,
+    "translation": "for",
+    "partOfSpeech": "preposition"
+  },
+  "hy": {
+    "rank": 19,
+    "translation": "he",
+    "partOfSpeech": "pronoun"
+  },
+  "dat": {
+    "rank": 20,
+    "translation": "that",
+    "partOfSpeech": "conjunction"
+  },
+  "jy": {
+    "rank": 21,
+    "translation": "you",
+    "partOfSpeech": "pronoun"
+  },
+  "n": {
+    "rank": 22,
+    "translation": "a/an",
+    "partOfSpeech": "article"
+  },
+  "na": {
+    "rank": 23,
+    "translation": "to/after",
+    "partOfSpeech": "preposition"
+  },
+  "maar": {
+    "rank": 24,
+    "translation": "but",
+    "partOfSpeech": "conjunction"
+  },
+  "haar": {
+    "rank": 25,
+    "translation": "her",
+    "partOfSpeech": "pronoun"
+  },
+  "kan": {
+    "rank": 26,
+    "translation": "can",
+    "partOfSpeech": "verb"
+  },
+  "sal": {
+    "rank": 27,
+    "translation": "will/shall",
+    "partOfSpeech": "verb"
+  },
+  "as": {
+    "rank": 28,
+    "translation": "if/as/when",
+    "partOfSpeech": "conjunction"
+  },
+  "toe": {
+    "rank": 29,
+    "translation": "then/when",
+    "partOfSpeech": "adverb"
+  },
+  "hulle": {
+    "rank": 30,
+    "translation": "they/them",
+    "partOfSpeech": "pronoun"
+  },
+  "of": {
+    "rank": 31,
+    "translation": "or/whether",
+    "partOfSpeech": "conjunction"
+  },
+  "hom": {
+    "rank": 32,
+    "translation": "him",
+    "partOfSpeech": "pronoun"
+  },
+  "uit": {
+    "rank": 33,
+    "translation": "out/from",
+    "partOfSpeech": "preposition"
+  },
+  "aan": {
+    "rank": 34,
+    "translation": "on/to",
+    "partOfSpeech": "preposition"
+  },
+  "jou": {
+    "rank": 35,
+    "translation": "your/you",
+    "partOfSpeech": "pronoun"
+  },
+  "ook": {
+    "rank": 36,
+    "translation": "also/too",
+    "partOfSpeech": "adverb"
+  },
+  "by": {
+    "rank": 37,
+    "translation": "at/by/near",
+    "partOfSpeech": "preposition"
+  },
+  "so": {
+    "rank": 38,
+    "translation": "so/thus",
+    "partOfSpeech": "adverb"
+  },
+  "se": {
+    "rank": 39,
+    "translation": "'s (possessive)",
+    "partOfSpeech": "particle"
+  },
+  "een": {
+    "rank": 40,
+    "translation": "one",
+    "partOfSpeech": "number",
+    "suffixes": {
+      "heid": {
+        "rank": 1577,
+        "translation": "unity",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "hoe": {
+    "rank": 41,
+    "translation": "how",
+    "partOfSpeech": "adverb"
+  },
+  "wees": {
+    "rank": 42,
+    "translation": "be",
+    "partOfSpeech": "verb"
+  },
+  "al": {
+    "rank": 43,
+    "translation": "already/all",
+    "partOfSpeech": "adverb",
+    "suffixes": {
+      "e": {
+        "rank": 581,
+        "translation": "all",
+        "partOfSpeech": "determiner"
+      }
+    }
+  },
+  "ons": {
+    "rank": 44,
+    "translation": "we/us/our",
+    "partOfSpeech": "pronoun"
+  },
+  "hier": {
+    "rank": 45,
+    "translation": "here",
+    "partOfSpeech": "adverb"
+  },
+  "daar": {
+    "rank": 46,
+    "translation": "there",
+    "partOfSpeech": "adverb"
+  },
+  "nou": {
+    "rank": 47,
+    "translation": "now",
+    "partOfSpeech": "adverb"
+  },
+  "word": {
+    "rank": 48,
+    "translation": "become/is (passive)",
+    "partOfSpeech": "verb"
+  },
+  "nog": {
+    "rank": 49,
+    "translation": "still/yet",
+    "partOfSpeech": "adverb"
+  },
+  "oor": {
+    "rank": 50,
+    "translation": "over/about",
+    "partOfSpeech": "preposition"
+  },
+  "sou": {
+    "rank": 51,
+    "translation": "would",
+    "partOfSpeech": "verb"
+  },
+  "net": {
+    "rank": 52,
+    "translation": "just/only",
+    "partOfSpeech": "adverb"
+  },
+  "sien": {
+    "rank": 53,
+    "translation": "see",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ge": {
+        "rank": 156,
+        "translation": "seen"
+      }
+    },
+    "suffixes": {
+      "ing": {
+        "rank": 1087,
+        "translation": "view",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "maak": {
+    "rank": 54,
+    "translation": "make/do",
+    "partOfSpeech": "verb"
+  },
+  "wil": {
+    "rank": 55,
+    "translation": "want/will",
+    "partOfSpeech": "verb"
+  },
+  "gaan": {
+    "rank": 56,
+    "translation": "go",
+    "partOfSpeech": "verb"
+  },
+  "kom": {
+    "rank": 57,
+    "translation": "come",
+    "partOfSpeech": "verb"
+  },
+  "meer": {
+    "rank": 58,
+    "translation": "more",
+    "partOfSpeech": "adverb"
+  },
+  "goed": {
+    "rank": 59,
+    "translation": "good/well",
+    "partOfSpeech": "adjective"
+  },
+  "doen": {
+    "rank": 60,
+    "translation": "do",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ge": {
+        "rank": 158,
+        "translation": "done"
+      }
+    }
+  },
+  "hê": {
+    "rank": 61,
+    "translation": "have",
+    "partOfSpeech": "verb"
+  },
+  "moet": {
+    "rank": 62,
+    "translation": "must",
+    "partOfSpeech": "verb"
+  },
+  "dink": {
+    "rank": 63,
+    "translation": "think",
+    "partOfSpeech": "verb"
+  },
+  "weet": {
+    "rank": 65,
+    "translation": "know",
+    "partOfSpeech": "verb"
+  },
+  "tyd": {
+    "rank": 66,
+    "translation": "time",
+    "partOfSpeech": "noun"
+  },
+  "jaar": {
+    "rank": 67,
+    "translation": "year",
+    "partOfSpeech": "noun"
+  },
+  "niks": {
+    "rank": 68,
+    "translation": "nothing",
+    "partOfSpeech": "pronoun"
+  },
+  "tot": {
+    "rank": 69,
+    "translation": "to/until",
+    "partOfSpeech": "preposition"
+  },
+  "dag": {
+    "rank": 70,
+    "translation": "day",
+    "partOfSpeech": "noun"
+  },
+  "twee": {
+    "rank": 71,
+    "translation": "two",
+    "partOfSpeech": "number"
+  },
+  "kry": {
+    "rank": 72,
+    "translation": "get",
+    "partOfSpeech": "verb"
+  },
+  "altyd": {
+    "rank": 73,
+    "translation": "always",
+    "partOfSpeech": "adverb"
+  },
+  "weer": {
+    "rank": 74,
+    "translation": "again/weather",
+    "partOfSpeech": "adverb"
+  },
+  "self": {
+    "rank": 75,
+    "translation": "self",
+    "partOfSpeech": "pronoun"
+  },
+  "gee": {
+    "rank": 76,
+    "translation": "give",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ge": {
+        "rank": 157,
+        "translation": "given"
+      }
+    }
+  },
+  "baie": {
+    "rank": 77,
+    "translation": "very/many",
+    "partOfSpeech": "adverb"
+  },
+  "laat": {
+    "rank": 78,
+    "translation": "let/late",
+    "partOfSpeech": "verb"
+  },
+  "sê": {
+    "rank": 79,
+    "translation": "say",
+    "partOfSpeech": "verb"
+  },
+  "dan": {
+    "rank": 80,
+    "translation": "then",
+    "partOfSpeech": "adverb"
+  },
+  "waar": {
+    "rank": 81,
+    "translation": "where/true",
+    "partOfSpeech": "adverb",
+    "suffixes": {
+      "de": {
+        "rank": 634,
+        "translation": "value",
+        "partOfSpeech": "noun"
+      },
+      "heid": {
+        "rank": 1095,
+        "translation": "truth",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "onder": {
+    "rank": 82,
+    "translation": "under/among",
+    "partOfSpeech": "preposition"
+  },
+  "ander": {
+    "rank": 83,
+    "translation": "other",
+    "partOfSpeech": "adjective"
+  },
+  "nuwe": {
+    "rank": 84,
+    "translation": "new",
+    "partOfSpeech": "adjective"
+  },
+  "staan": {
+    "rank": 85,
+    "translation": "stand",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ver": {
+        "rank": 382,
+        "translation": "understand"
+      },
+      "be": {
+        "rank": 995,
+        "translation": "existence",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "lê": {
+    "rank": 86,
+    "translation": "lie/lay",
+    "partOfSpeech": "verb"
+  },
+  "sit": {
+    "rank": 87,
+    "translation": "sit/put",
+    "partOfSpeech": "verb"
+  },
+  "loop": {
+    "rank": 88,
+    "translation": "walk/run",
+    "partOfSpeech": "verb"
+  },
+  "werk": {
+    "rank": 89,
+    "translation": "work",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "lik": {
+        "rank": 595,
+        "translation": "really",
+        "partOfSpeech": "adverb"
+      }
+    }
+  },
+  "hand": {
+    "rank": 90,
+    "translation": "hand",
+    "partOfSpeech": "noun"
+  },
+  "groot": {
+    "rank": 91,
+    "translation": "big/large",
+    "partOfSpeech": "adjective"
+  },
+  "man": {
+    "rank": 92,
+    "translation": "man",
+    "partOfSpeech": "noun"
+  },
+  "vrou": {
+    "rank": 93,
+    "translation": "woman/wife",
+    "partOfSpeech": "noun"
+  },
+  "kind": {
+    "rank": 94,
+    "translation": "child",
+    "partOfSpeech": "noun"
+  },
+  "lewe": {
+    "rank": 95,
+    "translation": "life/live",
+    "partOfSpeech": "noun"
+  },
+  "huis": {
+    "rank": 96,
+    "translation": "house",
+    "partOfSpeech": "noun"
+  },
+  "wêreld": {
+    "rank": 97,
+    "translation": "world",
+    "partOfSpeech": "noun"
+  },
+  "kop": {
+    "rank": 98,
+    "translation": "head",
+    "partOfSpeech": "noun"
+  },
+  "oë": {
+    "rank": 99,
+    "translation": "eyes",
+    "partOfSpeech": "noun"
+  },
+  "water": {
+    "rank": 100,
+    "translation": "water",
+    "partOfSpeech": "noun"
+  },
+  "naam": {
+    "rank": 101,
+    "translation": "name",
+    "partOfSpeech": "noun"
+  },
+  "weg": {
+    "rank": 102,
+    "translation": "away/road",
+    "partOfSpeech": "adverb"
+  },
+  "deur": {
+    "rank": 103,
+    "translation": "through/door",
+    "partOfSpeech": "preposition"
+  },
+  "terug": {
+    "rank": 104,
+    "translation": "back",
+    "partOfSpeech": "adverb"
+  },
+  "ding": {
+    "rank": 105,
+    "translation": "thing",
+    "partOfSpeech": "noun"
+  },
+  "iets": {
+    "rank": 106,
+    "translation": "something",
+    "partOfSpeech": "pronoun"
+  },
+  "saam": {
+    "rank": 107,
+    "translation": "together",
+    "partOfSpeech": "adverb"
+  },
+  "teen": {
+    "rank": 108,
+    "translation": "against",
+    "partOfSpeech": "preposition"
+  },
+  "plek": {
+    "rank": 109,
+    "translation": "place",
+    "partOfSpeech": "noun"
+  },
+  "af": {
+    "rank": 110,
+    "translation": "off/down",
+    "partOfSpeech": "adverb"
+  },
+  "voor": {
+    "rank": 111,
+    "translation": "before/front",
+    "partOfSpeech": "preposition"
+  },
+  "agter": {
+    "rank": 112,
+    "translation": "behind",
+    "partOfSpeech": "preposition"
+  },
+  "drie": {
+    "rank": 113,
+    "translation": "three",
+    "partOfSpeech": "number"
+  },
+  "soos": {
+    "rank": 114,
+    "translation": "like/as",
+    "partOfSpeech": "conjunction"
+  },
+  "nooit": {
+    "rank": 115,
+    "translation": "never",
+    "partOfSpeech": "adverb"
+  },
+  "mens": {
+    "rank": 117,
+    "translation": "person/human",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "e": {
+        "rank": 64,
+        "translation": "people"
+      }
+    }
+  },
+  "laas": {
+    "rank": 118,
+    "translation": "last",
+    "partOfSpeech": "adverb",
+    "suffixes": {
+      "te": {
+        "rank": 141,
+        "translation": "last",
+        "partOfSpeech": "adjective"
+      }
+    }
+  },
+  "tussen": {
+    "rank": 119,
+    "translation": "between",
+    "partOfSpeech": "preposition"
+  },
+  "begin": {
+    "rank": 120,
+    "translation": "begin/start",
+    "partOfSpeech": "verb"
+  },
+  "deel": {
+    "rank": 121,
+    "translation": "part/share",
+    "partOfSpeech": "noun",
+    "prefixes": {
+      "ge": {
+        "rank": 661,
+        "translation": "divided",
+        "partOfSpeech": "preposition"
+      }
+    }
+  },
+  "neem": {
+    "rank": 122,
+    "translation": "take",
+    "partOfSpeech": "verb"
+  },
+  "pad": {
+    "rank": 123,
+    "translation": "road/path",
+    "partOfSpeech": "noun"
+  },
+  "bring": {
+    "rank": 124,
+    "translation": "bring",
+    "partOfSpeech": "verb"
+  },
+  "wou": {
+    "rank": 125,
+    "translation": "wanted",
+    "partOfSpeech": "verb"
+  },
+  "ver": {
+    "rank": 126,
+    "translation": "far",
+    "partOfSpeech": "adverb"
+  },
+  "vol": {
+    "rank": 127,
+    "translation": "full",
+    "partOfSpeech": "adjective"
+  },
+  "probeer": {
+    "rank": 128,
+    "translation": "try",
+    "partOfSpeech": "verb"
+  },
+  "kon": {
+    "rank": 129,
+    "translation": "could",
+    "partOfSpeech": "verb"
+  },
+  "bly": {
+    "rank": 130,
+    "translation": "stay/happy",
+    "partOfSpeech": "verb"
+  },
+  "kyk": {
+    "rank": 131,
+    "translation": "look/watch",
+    "partOfSpeech": "verb"
+  },
+  "woord": {
+    "rank": 132,
+    "translation": "word",
+    "partOfSpeech": "noun"
+  },
+  "ou": {
+    "rank": 133,
+    "translation": "old/guy",
+    "partOfSpeech": "adjective"
+  },
+  "vra": {
+    "rank": 134,
+    "translation": "ask",
+    "partOfSpeech": "verb"
+  },
+  "wie": {
+    "rank": 135,
+    "translation": "who",
+    "partOfSpeech": "pronoun"
+  },
+  "ooit": {
+    "rank": 136,
+    "translation": "ever",
+    "partOfSpeech": "adverb"
+  },
+  "eie": {
+    "rank": 137,
+    "translation": "own",
+    "partOfSpeech": "adjective"
+  },
+  "vier": {
+    "rank": 138,
+    "translation": "four",
+    "partOfSpeech": "number",
+    "suffixes": {
+      "ing": {
+        "rank": 1037,
+        "translation": "celebration",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "volgende": {
+    "rank": 139,
+    "translation": "next/following",
+    "partOfSpeech": "adjective"
+  },
+  "hou": {
+    "rank": 140,
+    "translation": "hold/keep/like",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ont": {
+        "rank": 380,
+        "translation": "remember"
+      }
+    }
+  },
+  "soek": {
+    "rank": 142,
+    "translation": "search/look for",
+    "partOfSpeech": "verb"
+  },
+  "voel": {
+    "rank": 143,
+    "translation": "feel",
+    "partOfSpeech": "verb"
+  },
+  "liggaam": {
+    "rank": 144,
+    "translation": "body",
+    "partOfSpeech": "noun"
+  },
+  "beter": {
+    "rank": 145,
+    "translation": "better",
+    "partOfSpeech": "adjective"
+  },
+  "lees": {
+    "rank": 146,
+    "translation": "read",
+    "partOfSpeech": "verb"
+  },
+  "hierdie": {
+    "rank": 147,
+    "translation": "this/these",
+    "partOfSpeech": "determiner"
+  },
+  "binne": {
+    "rank": 148,
+    "translation": "inside",
+    "partOfSpeech": "preposition"
+  },
+  "oog": {
+    "rank": 149,
+    "translation": "eye",
+    "partOfSpeech": "noun"
+  },
+  "lig": {
+    "rank": 150,
+    "translation": "light",
+    "partOfSpeech": "noun"
+  },
+  "vyf": {
+    "rank": 151,
+    "translation": "five",
+    "partOfSpeech": "number"
+  },
+  "mooi": {
+    "rank": 152,
+    "translation": "beautiful/pretty",
+    "partOfSpeech": "adjective"
+  },
+  "hele": {
+    "rank": 153,
+    "translation": "whole/entire",
+    "partOfSpeech": "adjective"
+  },
+  "manier": {
+    "rank": 154,
+    "translation": "way/manner",
+    "partOfSpeech": "noun"
+  },
+  "stel": {
+    "rank": 155,
+    "translation": "set/put",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "her": {
+        "rank": 991,
+        "translation": "recovery",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "praat": {
+    "rank": 159,
+    "translation": "talk/speak",
+    "partOfSpeech": "verb"
+  },
+  "vraag": {
+    "rank": 160,
+    "translation": "question",
+    "partOfSpeech": "noun"
+  },
+  "rede": {
+    "rank": 161,
+    "translation": "reason",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "lik": {
+        "rank": 588,
+        "translation": "fairly/reasonable",
+        "partOfSpeech": "adverb"
+      }
+    }
+  },
+  "omdat": {
+    "rank": 162,
+    "translation": "because",
+    "partOfSpeech": "conjunction"
+  },
+  "leer": {
+    "rank": 163,
+    "translation": "learn/teach",
+    "partOfSpeech": "verb"
+  },
+  "help": {
+    "rank": 164,
+    "translation": "help",
+    "partOfSpeech": "verb"
+  },
+  "hoor": {
+    "rank": 165,
+    "translation": "hear",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ver": {
+        "rank": 1257,
+        "translation": "trial",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "ses": {
+    "rank": 166,
+    "translation": "six",
+    "partOfSpeech": "number"
+  },
+  "gebruik": {
+    "rank": 167,
+    "translation": "use",
+    "partOfSpeech": "verb"
+  },
+  "kant": {
+    "rank": 168,
+    "translation": "side",
+    "partOfSpeech": "noun"
+  },
+  "skryf": {
+    "rank": 169,
+    "translation": "write",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "be": {
+        "rank": 1906,
+        "translation": "describe"
+      }
+    }
+  },
+  "vind": {
+    "rank": 170,
+    "translation": "find",
+    "partOfSpeech": "verb"
+  },
+  "antwoord": {
+    "rank": 171,
+    "translation": "answer",
+    "partOfSpeech": "noun"
+  },
+  "dood": {
+    "rank": 172,
+    "translation": "dead/death",
+    "partOfSpeech": "noun"
+  },
+  "soort": {
+    "rank": 173,
+    "translation": "type/kind",
+    "partOfSpeech": "noun"
+  },
+  "seun": {
+    "rank": 174,
+    "translation": "son/boy",
+    "partOfSpeech": "noun"
+  },
+  "stem": {
+    "rank": 175,
+    "translation": "voice/vote",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "ing": {
+        "rank": 1203,
+        "translation": "vote/mood"
+      }
+    }
+  },
+  "glo": {
+    "rank": 176,
+    "translation": "believe",
+    "partOfSpeech": "verb"
+  },
+  "sewe": {
+    "rank": 177,
+    "translation": "seven",
+    "partOfSpeech": "number"
+  },
+  "agt": {
+    "rank": 178,
+    "translation": "eight",
+    "partOfSpeech": "number"
+  },
+  "eers": {
+    "rank": 179,
+    "translation": "first/only",
+    "partOfSpeech": "adverb",
+    "suffixes": {
+      "te": {
+        "rank": 116,
+        "translation": "first",
+        "partOfSpeech": "adjective"
+      }
+    }
+  },
+  "lank": {
+    "rank": 181,
+    "translation": "long",
+    "partOfSpeech": "adjective"
+  },
+  "boek": {
+    "rank": 182,
+    "translation": "book",
+    "partOfSpeech": "noun"
+  },
+  "elkeen": {
+    "rank": 183,
+    "translation": "everyone",
+    "partOfSpeech": "pronoun"
+  },
+  "hul": {
+    "rank": 184,
+    "translation": "their/them",
+    "partOfSpeech": "pronoun"
+  },
+  "nege": {
+    "rank": 185,
+    "translation": "nine",
+    "partOfSpeech": "number"
+  },
+  "tien": {
+    "rank": 186,
+    "translation": "ten",
+    "partOfSpeech": "number"
+  },
+  "genoeg": {
+    "rank": 187,
+    "translation": "enough",
+    "partOfSpeech": "adverb"
+  },
+  "dalk": {
+    "rank": 188,
+    "translation": "perhaps/maybe",
+    "partOfSpeech": "adverb"
+  },
+  "bed": {
+    "rank": 189,
+    "translation": "bed",
+    "partOfSpeech": "noun"
+  },
+  "klein": {
+    "rank": 190,
+    "translation": "small/little",
+    "partOfSpeech": "adjective"
+  },
+  "seker": {
+    "rank": 191,
+    "translation": "certain/sure",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1176,
+        "translation": "certainty",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "dogter": {
+    "rank": 192,
+    "translation": "daughter",
+    "partOfSpeech": "noun"
+  },
+  "lief": {
+    "rank": 193,
+    "translation": "dear/love",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "de": {
+        "rank": 441,
+        "translation": "love",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "nag": {
+    "rank": 194,
+    "translation": "night",
+    "partOfSpeech": "noun"
+  },
+  "swart": {
+    "rank": 195,
+    "translation": "black",
+    "partOfSpeech": "adjective"
+  },
+  "wit": {
+    "rank": 196,
+    "translation": "white",
+    "partOfSpeech": "adjective"
+  },
+  "stad": {
+    "rank": 197,
+    "translation": "city",
+    "partOfSpeech": "noun"
+  },
+  "roep": {
+    "rank": 198,
+    "translation": "call/shout",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "be": {
+        "rank": 1377,
+        "translation": "profession",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "slaap": {
+    "rank": 199,
+    "translation": "sleep",
+    "partOfSpeech": "verb"
+  },
+  "speel": {
+    "rank": 200,
+    "translation": "play",
+    "partOfSpeech": "verb"
+  },
+  "moeder": {
+    "rank": 201,
+    "translation": "mother",
+    "partOfSpeech": "noun"
+  },
+  "vader": {
+    "rank": 202,
+    "translation": "father",
+    "partOfSpeech": "noun"
+  },
+  "broer": {
+    "rank": 203,
+    "translation": "brother",
+    "partOfSpeech": "noun"
+  },
+  "suster": {
+    "rank": 204,
+    "translation": "sister",
+    "partOfSpeech": "noun"
+  },
+  "ouer": {
+    "rank": 205,
+    "translation": "parent/older",
+    "partOfSpeech": "noun"
+  },
+  "gesin": {
+    "rank": 206,
+    "translation": "family",
+    "partOfSpeech": "noun"
+  },
+  "familie": {
+    "rank": 1697,
+    "translation": "family",
+    "partOfSpeech": "noun"
+  },
+  "vriend": {
+    "rank": 208,
+    "translation": "friend",
+    "partOfSpeech": "noun"
+  },
+  "sterk": {
+    "rank": 209,
+    "translation": "strong",
+    "partOfSpeech": "adjective"
+  },
+  "jonk": {
+    "rank": 210,
+    "translation": "young",
+    "partOfSpeech": "adjective"
+  },
+  "nuus": {
+    "rank": 211,
+    "translation": "news",
+    "partOfSpeech": "noun"
+  },
+  "land": {
+    "rank": 212,
+    "translation": "country/land",
+    "partOfSpeech": "noun"
+  },
+  "son": {
+    "rank": 1776,
+    "translation": "sun",
+    "partOfSpeech": "noun"
+  },
+  "skool": {
+    "rank": 214,
+    "translation": "school",
+    "partOfSpeech": "noun"
+  },
+  "probleem": {
+    "rank": 215,
+    "translation": "problem",
+    "partOfSpeech": "noun"
+  },
+  "geld": {
+    "rank": 216,
+    "translation": "money",
+    "partOfSpeech": "noun"
+  },
+  "kamer": {
+    "rank": 217,
+    "translation": "room",
+    "partOfSpeech": "noun"
+  },
+  "warm": {
+    "rank": 218,
+    "translation": "warm/hot",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "te": {
+        "rank": 1584,
+        "translation": "warmth",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "koud": {
+    "rank": 219,
+    "translation": "cold",
+    "partOfSpeech": "adjective"
+  },
+  "eet": {
+    "rank": 220,
+    "translation": "eat",
+    "partOfSpeech": "verb"
+  },
+  "drink": {
+    "rank": 221,
+    "translation": "drink",
+    "partOfSpeech": "verb"
+  },
+  "sing": {
+    "rank": 222,
+    "translation": "sing",
+    "partOfSpeech": "verb"
+  },
+  "lag": {
+    "rank": 223,
+    "translation": "laugh",
+    "partOfSpeech": "verb"
+  },
+  "huil": {
+    "rank": 224,
+    "translation": "cry",
+    "partOfSpeech": "verb"
+  },
+  "hard": {
+    "rank": 225,
+    "translation": "hard/loud",
+    "partOfSpeech": "adjective"
+  },
+  "sag": {
+    "rank": 226,
+    "translation": "soft",
+    "partOfSpeech": "adjective"
+  },
+  "vinnig": {
+    "rank": 227,
+    "translation": "fast/quick",
+    "partOfSpeech": "adjective"
+  },
+  "stadig": {
+    "rank": 228,
+    "translation": "slow",
+    "partOfSpeech": "adjective"
+  },
+  "maklik": {
+    "rank": 229,
+    "translation": "easy",
+    "partOfSpeech": "adjective"
+  },
+  "moeilik": {
+    "rank": 230,
+    "translation": "difficult",
+    "partOfSpeech": "adjective"
+  },
+  "reg": {
+    "rank": 231,
+    "translation": "right/correct",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "s": {
+        "rank": 547,
+        "translation": "right",
+        "partOfSpeech": "adverb"
+      }
+    }
+  },
+  "verkeerd": {
+    "rank": 232,
+    "translation": "wrong",
+    "partOfSpeech": "adjective"
+  },
+  "ryk": {
+    "rank": 233,
+    "translation": "rich",
+    "partOfSpeech": "adjective"
+  },
+  "arm": {
+    "rank": 234,
+    "translation": "arm/poor",
+    "partOfSpeech": "noun"
+  },
+  "hond": {
+    "rank": 235,
+    "translation": "dog",
+    "partOfSpeech": "noun"
+  },
+  "kat": {
+    "rank": 236,
+    "translation": "cat",
+    "partOfSpeech": "noun"
+  },
+  "perd": {
+    "rank": 237,
+    "translation": "horse",
+    "partOfSpeech": "noun"
+  },
+  "voël": {
+    "rank": 238,
+    "translation": "bird",
+    "partOfSpeech": "noun"
+  },
+  "vis": {
+    "rank": 239,
+    "translation": "fish",
+    "partOfSpeech": "noun"
+  },
+  "boom": {
+    "rank": 240,
+    "translation": "tree",
+    "partOfSpeech": "noun"
+  },
+  "blom": {
+    "rank": 241,
+    "translation": "flower",
+    "partOfSpeech": "noun"
+  },
+  "gras": {
+    "rank": 242,
+    "translation": "grass",
+    "partOfSpeech": "noun"
+  },
+  "berg": {
+    "rank": 243,
+    "translation": "mountain",
+    "partOfSpeech": "noun"
+  },
+  "rivier": {
+    "rank": 244,
+    "translation": "river",
+    "partOfSpeech": "noun"
+  },
+  "see": {
+    "rank": 245,
+    "translation": "sea",
+    "partOfSpeech": "noun"
+  },
+  "hemel": {
+    "rank": 246,
+    "translation": "heaven/sky",
+    "partOfSpeech": "noun"
+  },
+  "grond": {
+    "rank": 247,
+    "translation": "ground/soil",
+    "partOfSpeech": "noun"
+  },
+  "klip": {
+    "rank": 248,
+    "translation": "stone/rock",
+    "partOfSpeech": "noun"
+  },
+  "sand": {
+    "rank": 249,
+    "translation": "sand",
+    "partOfSpeech": "noun"
+  },
+  "wind": {
+    "rank": 250,
+    "translation": "wind",
+    "partOfSpeech": "noun"
+  },
+  "reën": {
+    "rank": 251,
+    "translation": "rain",
+    "partOfSpeech": "noun"
+  },
+  "sneeu": {
+    "rank": 252,
+    "translation": "snow",
+    "partOfSpeech": "noun"
+  },
+  "wolk": {
+    "rank": 1868,
+    "translation": "cloud",
+    "partOfSpeech": "noun"
+  },
+  "maan": {
+    "rank": 1775,
+    "translation": "moon",
+    "partOfSpeech": "noun"
+  },
+  "ster": {
+    "rank": 1777,
+    "translation": "star",
+    "partOfSpeech": "noun"
+  },
+  "vuur": {
+    "rank": 256,
+    "translation": "fire",
+    "partOfSpeech": "noun"
+  },
+  "vlam": {
+    "rank": 257,
+    "translation": "flame",
+    "partOfSpeech": "noun"
+  },
+  "rook": {
+    "rank": 258,
+    "translation": "smoke",
+    "partOfSpeech": "noun"
+  },
+  "lug": {
+    "rank": 259,
+    "translation": "air/sky",
+    "partOfSpeech": "noun"
+  },
+  "hart": {
+    "rank": 260,
+    "translation": "heart",
+    "partOfSpeech": "noun"
+  },
+  "bloed": {
+    "rank": 261,
+    "translation": "blood",
+    "partOfSpeech": "noun"
+  },
+  "been": {
+    "rank": 262,
+    "translation": "leg/bone",
+    "partOfSpeech": "noun"
+  },
+  "voet": {
+    "rank": 263,
+    "translation": "foot",
+    "partOfSpeech": "noun"
+  },
+  "vinger": {
+    "rank": 264,
+    "translation": "finger",
+    "partOfSpeech": "noun"
+  },
+  "neus": {
+    "rank": 265,
+    "translation": "nose",
+    "partOfSpeech": "noun"
+  },
+  "mond": {
+    "rank": 266,
+    "translation": "mouth",
+    "partOfSpeech": "noun"
+  },
+  "tand": {
+    "rank": 267,
+    "translation": "tooth",
+    "partOfSpeech": "noun"
+  },
+  "tong": {
+    "rank": 268,
+    "translation": "tongue",
+    "partOfSpeech": "noun"
+  },
+  "vel": {
+    "rank": 269,
+    "translation": "skin",
+    "partOfSpeech": "noun"
+  },
+  "rug": {
+    "rank": 270,
+    "translation": "back",
+    "partOfSpeech": "noun"
+  },
+  "maag": {
+    "rank": 271,
+    "translation": "stomach",
+    "partOfSpeech": "noun"
+  },
+  "knie": {
+    "rank": 272,
+    "translation": "knee",
+    "partOfSpeech": "noun"
+  },
+  "nek": {
+    "rank": 273,
+    "translation": "neck",
+    "partOfSpeech": "noun"
+  },
+  "gesig": {
+    "rank": 274,
+    "translation": "face",
+    "partOfSpeech": "noun"
+  },
+  "kos": {
+    "rank": 275,
+    "translation": "food/cost",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "te": {
+        "rank": 633,
+        "translation": "cost"
+      }
+    }
+  },
+  "brood": {
+    "rank": 276,
+    "translation": "bread",
+    "partOfSpeech": "noun"
+  },
+  "vleis": {
+    "rank": 277,
+    "translation": "meat",
+    "partOfSpeech": "noun"
+  },
+  "vrugte": {
+    "rank": 279,
+    "translation": "fruit",
+    "partOfSpeech": "noun"
+  },
+  "melk": {
+    "rank": 280,
+    "translation": "milk",
+    "partOfSpeech": "noun"
+  },
+  "eier": {
+    "rank": 281,
+    "translation": "egg",
+    "partOfSpeech": "noun"
+  },
+  "kaas": {
+    "rank": 282,
+    "translation": "cheese",
+    "partOfSpeech": "noun"
+  },
+  "botter": {
+    "rank": 283,
+    "translation": "butter",
+    "partOfSpeech": "noun"
+  },
+  "suiker": {
+    "rank": 284,
+    "translation": "sugar",
+    "partOfSpeech": "noun"
+  },
+  "sout": {
+    "rank": 1688,
+    "translation": "salt",
+    "partOfSpeech": "noun"
+  },
+  "koffie": {
+    "rank": 286,
+    "translation": "coffee",
+    "partOfSpeech": "noun"
+  },
+  "tee": {
+    "rank": 287,
+    "translation": "tea",
+    "partOfSpeech": "noun"
+  },
+  "wyn": {
+    "rank": 288,
+    "translation": "wine",
+    "partOfSpeech": "noun"
+  },
+  "bier": {
+    "rank": 289,
+    "translation": "beer",
+    "partOfSpeech": "noun"
+  },
+  "appel": {
+    "rank": 290,
+    "translation": "apple",
+    "partOfSpeech": "noun"
+  },
+  "lemoen": {
+    "rank": 291,
+    "translation": "orange",
+    "partOfSpeech": "noun"
+  },
+  "piesang": {
+    "rank": 292,
+    "translation": "banana",
+    "partOfSpeech": "noun"
+  },
+  "tamatie": {
+    "rank": 293,
+    "translation": "tomato",
+    "partOfSpeech": "noun"
+  },
+  "aartappel": {
+    "rank": 294,
+    "translation": "potato",
+    "partOfSpeech": "noun"
+  },
+  "ui": {
+    "rank": 295,
+    "translation": "onion",
+    "partOfSpeech": "noun"
+  },
+  "klere": {
+    "rank": 296,
+    "translation": "clothes",
+    "partOfSpeech": "noun"
+  },
+  "hemp": {
+    "rank": 297,
+    "translation": "shirt",
+    "partOfSpeech": "noun"
+  },
+  "broek": {
+    "rank": 298,
+    "translation": "pants/trousers",
+    "partOfSpeech": "noun"
+  },
+  "rok": {
+    "rank": 299,
+    "translation": "dress/skirt",
+    "partOfSpeech": "noun"
+  },
+  "jas": {
+    "rank": 300,
+    "translation": "jacket/coat",
+    "partOfSpeech": "noun"
+  },
+  "skoen": {
+    "rank": 301,
+    "translation": "shoe",
+    "partOfSpeech": "noun"
+  },
+  "hoed": {
+    "rank": 302,
+    "translation": "hat",
+    "partOfSpeech": "noun"
+  },
+  "sokkie": {
+    "rank": 303,
+    "translation": "sock",
+    "partOfSpeech": "noun"
+  },
+  "das": {
+    "rank": 304,
+    "translation": "tie",
+    "partOfSpeech": "noun"
+  },
+  "motor": {
+    "rank": 1825,
+    "translation": "motor",
+    "partOfSpeech": "noun"
+  },
+  "bus": {
+    "rank": 306,
+    "translation": "bus",
+    "partOfSpeech": "noun"
+  },
+  "trein": {
+    "rank": 307,
+    "translation": "train",
+    "partOfSpeech": "noun"
+  },
+  "vliegtuig": {
+    "rank": 308,
+    "translation": "airplane",
+    "partOfSpeech": "noun"
+  },
+  "skip": {
+    "rank": 309,
+    "translation": "ship",
+    "partOfSpeech": "noun"
+  },
+  "fiets": {
+    "rank": 310,
+    "translation": "bicycle",
+    "partOfSpeech": "noun"
+  },
+  "straat": {
+    "rank": 311,
+    "translation": "street",
+    "partOfSpeech": "noun"
+  },
+  "winkel": {
+    "rank": 313,
+    "translation": "shop/store",
+    "partOfSpeech": "noun"
+  },
+  "kerk": {
+    "rank": 314,
+    "translation": "church",
+    "partOfSpeech": "noun"
+  },
+  "hospitaal": {
+    "rank": 315,
+    "translation": "hospital",
+    "partOfSpeech": "noun"
+  },
+  "kantoor": {
+    "rank": 316,
+    "translation": "office",
+    "partOfSpeech": "noun"
+  },
+  "bank": {
+    "rank": 317,
+    "translation": "bank/bench",
+    "partOfSpeech": "noun"
+  },
+  "stoel": {
+    "rank": 318,
+    "translation": "chair",
+    "partOfSpeech": "noun"
+  },
+  "tafel": {
+    "rank": 319,
+    "translation": "table",
+    "partOfSpeech": "noun"
+  },
+  "venster": {
+    "rank": 320,
+    "translation": "window",
+    "partOfSpeech": "noun"
+  },
+  "muur": {
+    "rank": 321,
+    "translation": "wall",
+    "partOfSpeech": "noun"
+  },
+  "vloer": {
+    "rank": 322,
+    "translation": "floor",
+    "partOfSpeech": "noun"
+  },
+  "dak": {
+    "rank": 323,
+    "translation": "roof",
+    "partOfSpeech": "noun"
+  },
+  "trap": {
+    "rank": 324,
+    "translation": "stair/kick",
+    "partOfSpeech": "noun"
+  },
+  "sleutel": {
+    "rank": 325,
+    "translation": "key",
+    "partOfSpeech": "noun"
+  },
+  "kas": {
+    "rank": 326,
+    "translation": "cupboard/wardrobe",
+    "partOfSpeech": "noun"
+  },
+  "spieël": {
+    "rank": 327,
+    "translation": "mirror",
+    "partOfSpeech": "noun"
+  },
+  "lamp": {
+    "rank": 328,
+    "translation": "lamp",
+    "partOfSpeech": "noun"
+  },
+  "kombers": {
+    "rank": 329,
+    "translation": "blanket",
+    "partOfSpeech": "noun"
+  },
+  "kussing": {
+    "rank": 330,
+    "translation": "pillow/cushion",
+    "partOfSpeech": "noun"
+  },
+  "stoof": {
+    "rank": 331,
+    "translation": "stove",
+    "partOfSpeech": "noun"
+  },
+  "yskas": {
+    "rank": 332,
+    "translation": "refrigerator",
+    "partOfSpeech": "noun"
+  },
+  "pot": {
+    "rank": 333,
+    "translation": "pot",
+    "partOfSpeech": "noun"
+  },
+  "pan": {
+    "rank": 334,
+    "translation": "pan",
+    "partOfSpeech": "noun"
+  },
+  "bord": {
+    "rank": 335,
+    "translation": "plate",
+    "partOfSpeech": "noun"
+  },
+  "koppie": {
+    "rank": 336,
+    "translation": "cup",
+    "partOfSpeech": "noun"
+  },
+  "glas": {
+    "rank": 337,
+    "translation": "glass",
+    "partOfSpeech": "noun"
+  },
+  "mes": {
+    "rank": 338,
+    "translation": "knife",
+    "partOfSpeech": "noun"
+  },
+  "vurk": {
+    "rank": 339,
+    "translation": "fork",
+    "partOfSpeech": "noun"
+  },
+  "lepel": {
+    "rank": 340,
+    "translation": "spoon",
+    "partOfSpeech": "noun"
+  },
+  "pen": {
+    "rank": 341,
+    "translation": "pen",
+    "partOfSpeech": "noun"
+  },
+  "potlood": {
+    "rank": 342,
+    "translation": "pencil",
+    "partOfSpeech": "noun"
+  },
+  "papier": {
+    "rank": 343,
+    "translation": "paper",
+    "partOfSpeech": "noun"
+  },
+  "brief": {
+    "rank": 344,
+    "translation": "letter",
+    "partOfSpeech": "noun"
+  },
+  "koerant": {
+    "rank": 345,
+    "translation": "newspaper",
+    "partOfSpeech": "noun"
+  },
+  "tydskrif": {
+    "rank": 346,
+    "translation": "magazine",
+    "partOfSpeech": "noun"
+  },
+  "rekenaar": {
+    "rank": 347,
+    "translation": "computer",
+    "partOfSpeech": "noun"
+  },
+  "telefoon": {
+    "rank": 348,
+    "translation": "telephone",
+    "partOfSpeech": "noun"
+  },
+  "televisie": {
+    "rank": 349,
+    "translation": "television",
+    "partOfSpeech": "noun"
+  },
+  "radio": {
+    "rank": 350,
+    "translation": "radio",
+    "partOfSpeech": "noun"
+  },
+  "foto": {
+    "rank": 351,
+    "translation": "photo",
+    "partOfSpeech": "noun"
+  },
+  "musiek": {
+    "rank": 352,
+    "translation": "music",
+    "partOfSpeech": "noun"
+  },
+  "lied": {
+    "rank": 353,
+    "translation": "song",
+    "partOfSpeech": "noun"
+  },
+  "fliek": {
+    "rank": 354,
+    "translation": "movie",
+    "partOfSpeech": "noun"
+  },
+  "speletjie": {
+    "rank": 355,
+    "translation": "game",
+    "partOfSpeech": "noun"
+  },
+  "bal": {
+    "rank": 356,
+    "translation": "ball",
+    "partOfSpeech": "noun"
+  },
+  "sport": {
+    "rank": 357,
+    "translation": "sport",
+    "partOfSpeech": "noun"
+  },
+  "sokker": {
+    "rank": 358,
+    "translation": "soccer",
+    "partOfSpeech": "noun"
+  },
+  "rugby": {
+    "rank": 359,
+    "translation": "rugby",
+    "partOfSpeech": "noun"
+  },
+  "krieket": {
+    "rank": 360,
+    "translation": "cricket",
+    "partOfSpeech": "noun"
+  },
+  "swem": {
+    "rank": 361,
+    "translation": "swim",
+    "partOfSpeech": "verb"
+  },
+  "hardloop": {
+    "rank": 362,
+    "translation": "run",
+    "partOfSpeech": "verb"
+  },
+  "stap": {
+    "rank": 363,
+    "translation": "walk/step",
+    "partOfSpeech": "verb"
+  },
+  "spring": {
+    "rank": 364,
+    "translation": "jump",
+    "partOfSpeech": "verb"
+  },
+  "klim": {
+    "rank": 365,
+    "translation": "climb",
+    "partOfSpeech": "verb"
+  },
+  "val": {
+    "rank": 366,
+    "translation": "fall",
+    "partOfSpeech": "verb"
+  },
+  "gooi": {
+    "rank": 367,
+    "translation": "throw",
+    "partOfSpeech": "verb"
+  },
+  "vang": {
+    "rank": 368,
+    "translation": "catch",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ont": {
+        "rank": 394,
+        "translation": "receive"
+      }
+    }
+  },
+  "skop": {
+    "rank": 369,
+    "translation": "kick",
+    "partOfSpeech": "verb"
+  },
+  "slaan": {
+    "rank": 370,
+    "translation": "hit",
+    "partOfSpeech": "verb"
+  },
+  "druk": {
+    "rank": 1671,
+    "translation": "pressure",
+    "partOfSpeech": "noun"
+  },
+  "trek": {
+    "rank": 372,
+    "translation": "pull",
+    "partOfSpeech": "verb"
+  },
+  "oop": {
+    "rank": 373,
+    "translation": "open",
+    "partOfSpeech": "adjective"
+  },
+  "ry": {
+    "rank": 374,
+    "translation": "drive/ride",
+    "partOfSpeech": "verb"
+  },
+  "vlieg": {
+    "rank": 375,
+    "translation": "fly",
+    "partOfSpeech": "verb"
+  },
+  "reis": {
+    "rank": 376,
+    "translation": "travel",
+    "partOfSpeech": "verb"
+  },
+  "draai": {
+    "rank": 377,
+    "translation": "turn",
+    "partOfSpeech": "verb"
+  },
+  "stop": {
+    "rank": 378,
+    "translation": "stop",
+    "partOfSpeech": "verb"
+  },
+  "wag": {
+    "rank": 379,
+    "translation": "wait",
+    "partOfSpeech": "verb"
+  },
+  "vergeet": {
+    "rank": 381,
+    "translation": "forget",
+    "partOfSpeech": "verb"
+  },
+  "ken": {
+    "rank": 383,
+    "translation": "know (person)",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "her": {
+        "rank": 384,
+        "translation": "recognize"
+      }
+    }
+  },
+  "kies": {
+    "rank": 385,
+    "translation": "choose",
+    "partOfSpeech": "verb"
+  },
+  "besluit": {
+    "rank": 386,
+    "translation": "decide",
+    "partOfSpeech": "verb"
+  },
+  "verander": {
+    "rank": 387,
+    "translation": "change",
+    "partOfSpeech": "verb",
+    "suffixes": {
+      "lik": {
+        "rank": 822,
+        "translation": "changeable",
+        "partOfSpeech": "adjective"
+      },
+      "ing": {
+        "rank": 934,
+        "translation": "change",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "bou": {
+    "rank": 388,
+    "translation": "build",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ge": {
+        "rank": 312,
+        "translation": "building",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "breek": {
+    "rank": 389,
+    "translation": "break",
+    "partOfSpeech": "verb"
+  },
+  "koop": {
+    "rank": 391,
+    "translation": "buy",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ver": {
+        "rank": 390,
+        "translation": "sell"
+      }
+    }
+  },
+  "betaal": {
+    "rank": 392,
+    "translation": "pay",
+    "partOfSpeech": "verb"
+  },
+  "leen": {
+    "rank": 393,
+    "translation": "lend/borrow",
+    "partOfSpeech": "verb"
+  },
+  "stuur": {
+    "rank": 395,
+    "translation": "send",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "be": {
+        "rank": 1471,
+        "translation": "board/management",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "haal": {
+    "rank": 396,
+    "translation": "fetch/get",
+    "partOfSpeech": "verb"
+  },
+  "dra": {
+    "rank": 397,
+    "translation": "carry/wear",
+    "partOfSpeech": "verb"
+  },
+  "hang": {
+    "rank": 398,
+    "translation": "hang",
+    "partOfSpeech": "verb"
+  },
+  "los": {
+    "rank": 399,
+    "translation": "let go/loose",
+    "partOfSpeech": "verb"
+  },
+  "tel": {
+    "rank": 400,
+    "translation": "count/pick up",
+    "partOfSpeech": "verb",
+    "prefixes": {
+      "ver": {
+        "rank": 180,
+        "translation": "tell"
+      }
+    },
+    "suffixes": {
+      "ing": {
+        "rank": 1371,
+        "translation": "score",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "meet": {
+    "rank": 401,
+    "translation": "measure",
+    "partOfSpeech": "verb"
+  },
+  "weeg": {
+    "rank": 402,
+    "translation": "weigh",
+    "partOfSpeech": "verb"
+  },
+  "sny": {
+    "rank": 403,
+    "translation": "cut",
+    "partOfSpeech": "verb"
+  },
+  "meng": {
+    "rank": 404,
+    "translation": "mix",
+    "partOfSpeech": "verb"
+  },
+  "bak": {
+    "rank": 405,
+    "translation": "bake/fry",
+    "partOfSpeech": "verb"
+  },
+  "kook": {
+    "rank": 406,
+    "translation": "cook/boil",
+    "partOfSpeech": "verb"
+  },
+  "braai": {
+    "rank": 407,
+    "translation": "barbecue/roast",
+    "partOfSpeech": "verb"
+  },
+  "droog": {
+    "rank": 408,
+    "translation": "dry",
+    "partOfSpeech": "verb",
+    "suffixes": {
+      "te": {
+        "rank": 1746,
+        "translation": "drought",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "vee": {
+    "rank": 409,
+    "translation": "wipe",
+    "partOfSpeech": "verb"
+  },
+  "skoonmaak": {
+    "rank": 410,
+    "translation": "clean",
+    "partOfSpeech": "verb"
+  },
+  "stryk": {
+    "rank": 411,
+    "translation": "iron",
+    "partOfSpeech": "verb"
+  },
+  "naai": {
+    "rank": 412,
+    "translation": "sew",
+    "partOfSpeech": "verb"
+  },
+  "verf": {
+    "rank": 413,
+    "translation": "paint",
+    "partOfSpeech": "verb"
+  },
+  "teken": {
+    "rank": 414,
+    "translation": "draw/sign",
+    "partOfSpeech": "verb"
+  },
+  "dans": {
+    "rank": 415,
+    "translation": "dance",
+    "partOfSpeech": "verb"
+  },
+  "rus": {
+    "rank": 416,
+    "translation": "rest",
+    "partOfSpeech": "verb"
+  },
+  "leef": {
+    "rank": 417,
+    "translation": "live",
+    "partOfSpeech": "verb"
+  },
+  "sterf": {
+    "rank": 418,
+    "translation": "die",
+    "partOfSpeech": "verb"
+  },
+  "groei": {
+    "rank": 419,
+    "translation": "grow",
+    "partOfSpeech": "verb"
+  },
+  "plant": {
+    "rank": 420,
+    "translation": "plant",
+    "partOfSpeech": "verb"
+  },
+  "oes": {
+    "rank": 421,
+    "translation": "harvest",
+    "partOfSpeech": "verb"
+  },
+  "jag": {
+    "rank": 422,
+    "translation": "hunt",
+    "partOfSpeech": "verb"
+  },
+  "visvang": {
+    "rank": 423,
+    "translation": "fish",
+    "partOfSpeech": "verb"
+  },
+  "wen": {
+    "rank": 424,
+    "translation": "win",
+    "partOfSpeech": "verb"
+  },
+  "verloor": {
+    "rank": 425,
+    "translation": "lose",
+    "partOfSpeech": "verb"
+  },
+  "eindig": {
+    "rank": 426,
+    "translation": "end",
+    "partOfSpeech": "verb"
+  },
+  "voortgaan": {
+    "rank": 427,
+    "translation": "continue",
+    "partOfSpeech": "verb"
+  },
+  "ophou": {
+    "rank": 428,
+    "translation": "stop (cease)",
+    "partOfSpeech": "verb"
+  },
+  "wakker": {
+    "rank": 429,
+    "translation": "awake",
+    "partOfSpeech": "adjective"
+  },
+  "moeg": {
+    "rank": 430,
+    "translation": "tired",
+    "partOfSpeech": "adjective"
+  },
+  "siek": {
+    "rank": 431,
+    "translation": "sick",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "te": {
+        "rank": 967,
+        "translation": "illness",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "gesond": {
+    "rank": 432,
+    "translation": "healthy",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 966,
+        "translation": "health",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "honger": {
+    "rank": 433,
+    "translation": "hunger",
+    "partOfSpeech": "noun"
+  },
+  "dors": {
+    "rank": 434,
+    "translation": "thirst",
+    "partOfSpeech": "noun"
+  },
+  "pyn": {
+    "rank": 435,
+    "translation": "pain",
+    "partOfSpeech": "noun"
+  },
+  "vreugde": {
+    "rank": 436,
+    "translation": "joy",
+    "partOfSpeech": "noun"
+  },
+  "hartseer": {
+    "rank": 437,
+    "translation": "sadness",
+    "partOfSpeech": "noun"
+  },
+  "woede": {
+    "rank": 438,
+    "translation": "anger",
+    "partOfSpeech": "noun"
+  },
+  "vrees": {
+    "rank": 439,
+    "translation": "fear",
+    "partOfSpeech": "noun"
+  },
+  "hoop": {
+    "rank": 440,
+    "translation": "hope",
+    "partOfSpeech": "noun"
+  },
+  "haat": {
+    "rank": 442,
+    "translation": "hate",
+    "partOfSpeech": "noun"
+  },
+  "trots": {
+    "rank": 443,
+    "translation": "proud",
+    "partOfSpeech": "adjective"
+  },
+  "skaam": {
+    "rank": 444,
+    "translation": "ashamed/shy",
+    "partOfSpeech": "adjective"
+  },
+  "gelukkig": {
+    "rank": 445,
+    "translation": "happy/lucky",
+    "partOfSpeech": "adjective"
+  },
+  "treurig": {
+    "rank": 446,
+    "translation": "sad",
+    "partOfSpeech": "adjective"
+  },
+  "kwaad": {
+    "rank": 447,
+    "translation": "angry",
+    "partOfSpeech": "adjective"
+  },
+  "bang": {
+    "rank": 448,
+    "translation": "scared",
+    "partOfSpeech": "adjective"
+  },
+  "dapper": {
+    "rank": 449,
+    "translation": "brave",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1565,
+        "translation": "bravery",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "slim": {
+    "rank": 450,
+    "translation": "clever/smart",
+    "partOfSpeech": "adjective"
+  },
+  "dom": {
+    "rank": 451,
+    "translation": "stupid",
+    "partOfSpeech": "adjective"
+  },
+  "wys": {
+    "rank": 452,
+    "translation": "wise/show",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1070,
+        "translation": "wisdom",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "vriendelik": {
+    "rank": 454,
+    "translation": "friendly",
+    "partOfSpeech": "adjective"
+  },
+  "lekker": {
+    "rank": 455,
+    "translation": "nice/tasty",
+    "partOfSpeech": "adjective"
+  },
+  "sleg": {
+    "rank": 456,
+    "translation": "bad",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "te": {
+        "rank": 678,
+        "translation": "bad"
+      }
+    }
+  },
+  "pragtig": {
+    "rank": 457,
+    "translation": "beautiful/magnificent",
+    "partOfSpeech": "adjective"
+  },
+  "lelik": {
+    "rank": 458,
+    "translation": "ugly",
+    "partOfSpeech": "adjective"
+  },
+  "skoon": {
+    "rank": 459,
+    "translation": "clean",
+    "partOfSpeech": "adjective"
+  },
+  "vuil": {
+    "rank": 460,
+    "translation": "dirty",
+    "partOfSpeech": "adjective"
+  },
+  "nat": {
+    "rank": 461,
+    "translation": "wet",
+    "partOfSpeech": "adjective"
+  },
+  "vars": {
+    "rank": 462,
+    "translation": "fresh",
+    "partOfSpeech": "adjective"
+  },
+  "oud": {
+    "rank": 463,
+    "translation": "old",
+    "partOfSpeech": "adjective"
+  },
+  "nuut": {
+    "rank": 464,
+    "translation": "new",
+    "partOfSpeech": "adjective"
+  },
+  "snaaks": {
+    "rank": 465,
+    "translation": "funny/strange",
+    "partOfSpeech": "adjective"
+  },
+  "ernstig": {
+    "rank": 466,
+    "translation": "serious",
+    "partOfSpeech": "adjective"
+  },
+  "belangrik": {
+    "rank": 467,
+    "translation": "important",
+    "partOfSpeech": "adjective"
+  },
+  "noodsaaklik": {
+    "rank": 468,
+    "translation": "necessary",
+    "partOfSpeech": "adjective"
+  },
+  "moontlik": {
+    "rank": 469,
+    "translation": "possible",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 956,
+        "translation": "possibility",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "onmoontlik": {
+    "rank": 470,
+    "translation": "impossible",
+    "partOfSpeech": "adjective"
+  },
+  "veilig": {
+    "rank": 472,
+    "translation": "safe",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 965,
+        "translation": "safety",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "besig": {
+    "rank": 473,
+    "translation": "busy",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 846,
+        "translation": "business",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "vry": {
+    "rank": 474,
+    "translation": "free",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1499,
+        "translation": "freedom",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "gereed": {
+    "rank": 475,
+    "translation": "ready",
+    "partOfSpeech": "adjective"
+  },
+  "klaar": {
+    "rank": 476,
+    "translation": "finished/ready",
+    "partOfSpeech": "adjective"
+  },
+  "leeg": {
+    "rank": 477,
+    "translation": "empty",
+    "partOfSpeech": "adjective"
+  },
+  "swaar": {
+    "rank": 478,
+    "translation": "heavy",
+    "partOfSpeech": "adjective"
+  },
+  "dik": {
+    "rank": 479,
+    "translation": "thick/fat",
+    "partOfSpeech": "adjective"
+  },
+  "dun": {
+    "rank": 480,
+    "translation": "thin",
+    "partOfSpeech": "adjective"
+  },
+  "breed": {
+    "rank": 481,
+    "translation": "wide",
+    "partOfSpeech": "adjective"
+  },
+  "hoog": {
+    "rank": 482,
+    "translation": "high/tall",
+    "partOfSpeech": "adjective"
+  },
+  "laag": {
+    "rank": 483,
+    "translation": "low",
+    "partOfSpeech": "adjective"
+  },
+  "diep": {
+    "rank": 484,
+    "translation": "deep",
+    "partOfSpeech": "adjective"
+  },
+  "vlak": {
+    "rank": 1657,
+    "translation": "plane/level",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "te": {
+        "rank": 1735,
+        "translation": "plain"
+      }
+    }
+  },
+  "rond": {
+    "rank": 486,
+    "translation": "round",
+    "partOfSpeech": "adjective"
+  },
+  "reguit": {
+    "rank": 487,
+    "translation": "straight",
+    "partOfSpeech": "adjective"
+  },
+  "krom": {
+    "rank": 488,
+    "translation": "crooked/bent",
+    "partOfSpeech": "adjective"
+  },
+  "plat": {
+    "rank": 489,
+    "translation": "flat",
+    "partOfSpeech": "adjective"
+  },
+  "skerp": {
+    "rank": 490,
+    "translation": "sharp",
+    "partOfSpeech": "adjective"
+  },
+  "stomp": {
+    "rank": 491,
+    "translation": "blunt",
+    "partOfSpeech": "adjective"
+  },
+  "glad": {
+    "rank": 492,
+    "translation": "smooth/slippery",
+    "partOfSpeech": "adjective"
+  },
+  "grof": {
+    "rank": 493,
+    "translation": "rough/coarse",
+    "partOfSpeech": "adjective"
+  },
+  "helder": {
+    "rank": 494,
+    "translation": "clear/bright",
+    "partOfSpeech": "adjective"
+  },
+  "donker": {
+    "rank": 495,
+    "translation": "dark",
+    "partOfSpeech": "adjective"
+  },
+  "rooi": {
+    "rank": 496,
+    "translation": "red",
+    "partOfSpeech": "adjective"
+  },
+  "blou": {
+    "rank": 497,
+    "translation": "blue",
+    "partOfSpeech": "adjective"
+  },
+  "groen": {
+    "rank": 498,
+    "translation": "green",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "te": {
+        "rank": 278,
+        "translation": "vegetables",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "geel": {
+    "rank": 499,
+    "translation": "yellow",
+    "partOfSpeech": "adjective"
+  },
+  "oranje": {
+    "rank": 500,
+    "translation": "orange",
+    "partOfSpeech": "adjective"
+  },
+  "pers": {
+    "rank": 501,
+    "translation": "purple",
+    "partOfSpeech": "adjective"
+  },
+  "pienk": {
+    "rank": 502,
+    "translation": "pink",
+    "partOfSpeech": "adjective"
+  },
+  "bruin": {
+    "rank": 503,
+    "translation": "brown",
+    "partOfSpeech": "adjective"
+  },
+  "grys": {
+    "rank": 504,
+    "translation": "grey",
+    "partOfSpeech": "adjective"
+  },
+  "môre": {
+    "rank": 505,
+    "translation": "tomorrow/morning",
+    "partOfSpeech": "noun"
+  },
+  "gister": {
+    "rank": 506,
+    "translation": "yesterday",
+    "partOfSpeech": "adverb"
+  },
+  "vandag": {
+    "rank": 507,
+    "translation": "today",
+    "partOfSpeech": "adverb"
+  },
+  "vanaand": {
+    "rank": 508,
+    "translation": "tonight",
+    "partOfSpeech": "adverb"
+  },
+  "oggend": {
+    "rank": 509,
+    "translation": "morning",
+    "partOfSpeech": "noun"
+  },
+  "middag": {
+    "rank": 1760,
+    "translation": "noon",
+    "partOfSpeech": "noun"
+  },
+  "aand": {
+    "rank": 511,
+    "translation": "evening",
+    "partOfSpeech": "noun"
+  },
+  "week": {
+    "rank": 512,
+    "translation": "week",
+    "partOfSpeech": "noun"
+  },
+  "maand": {
+    "rank": 513,
+    "translation": "month",
+    "partOfSpeech": "noun"
+  },
+  "eeu": {
+    "rank": 514,
+    "translation": "century",
+    "partOfSpeech": "noun"
+  },
+  "uur": {
+    "rank": 515,
+    "translation": "hour",
+    "partOfSpeech": "noun"
+  },
+  "minuut": {
+    "rank": 516,
+    "translation": "minute",
+    "partOfSpeech": "noun"
+  },
+  "sekonde": {
+    "rank": 517,
+    "translation": "second",
+    "partOfSpeech": "noun"
+  },
+  "oomblik": {
+    "rank": 518,
+    "translation": "moment",
+    "partOfSpeech": "noun"
+  },
+  "sondag": {
+    "rank": 519,
+    "translation": "Sunday",
+    "partOfSpeech": "noun"
+  },
+  "maandag": {
+    "rank": 520,
+    "translation": "Monday",
+    "partOfSpeech": "noun"
+  },
+  "dinsdag": {
+    "rank": 521,
+    "translation": "Tuesday",
+    "partOfSpeech": "noun"
+  },
+  "woensdag": {
+    "rank": 522,
+    "translation": "Wednesday",
+    "partOfSpeech": "noun"
+  },
+  "donderdag": {
+    "rank": 523,
+    "translation": "Thursday",
+    "partOfSpeech": "noun"
+  },
+  "vrydag": {
+    "rank": 524,
+    "translation": "Friday",
+    "partOfSpeech": "noun"
+  },
+  "saterdag": {
+    "rank": 525,
+    "translation": "Saturday",
+    "partOfSpeech": "noun"
+  },
+  "januarie": {
+    "rank": 526,
+    "translation": "January",
+    "partOfSpeech": "noun"
+  },
+  "februarie": {
+    "rank": 527,
+    "translation": "February",
+    "partOfSpeech": "noun"
+  },
+  "maart": {
+    "rank": 528,
+    "translation": "March",
+    "partOfSpeech": "noun"
+  },
+  "april": {
+    "rank": 529,
+    "translation": "April",
+    "partOfSpeech": "noun"
+  },
+  "mei": {
+    "rank": 530,
+    "translation": "May",
+    "partOfSpeech": "noun"
+  },
+  "junie": {
+    "rank": 531,
+    "translation": "June",
+    "partOfSpeech": "noun"
+  },
+  "julie": {
+    "rank": 532,
+    "translation": "July",
+    "partOfSpeech": "noun"
+  },
+  "augustus": {
+    "rank": 533,
+    "translation": "August",
+    "partOfSpeech": "noun"
+  },
+  "september": {
+    "rank": 534,
+    "translation": "September",
+    "partOfSpeech": "noun"
+  },
+  "oktober": {
+    "rank": 535,
+    "translation": "October",
+    "partOfSpeech": "noun"
+  },
+  "november": {
+    "rank": 536,
+    "translation": "November",
+    "partOfSpeech": "noun"
+  },
+  "desember": {
+    "rank": 537,
+    "translation": "December",
+    "partOfSpeech": "noun"
+  },
+  "lente": {
+    "rank": 538,
+    "translation": "spring",
+    "partOfSpeech": "noun"
+  },
+  "somer": {
+    "rank": 539,
+    "translation": "summer",
+    "partOfSpeech": "noun"
+  },
+  "herfs": {
+    "rank": 540,
+    "translation": "autumn",
+    "partOfSpeech": "noun"
+  },
+  "winter": {
+    "rank": 541,
+    "translation": "winter",
+    "partOfSpeech": "noun"
+  },
+  "noord": {
+    "rank": 542,
+    "translation": "north",
+    "partOfSpeech": "noun"
+  },
+  "suid": {
+    "rank": 543,
+    "translation": "south",
+    "partOfSpeech": "noun"
+  },
+  "oos": {
+    "rank": 544,
+    "translation": "east",
+    "partOfSpeech": "noun"
+  },
+  "wes": {
+    "rank": 545,
+    "translation": "west",
+    "partOfSpeech": "noun"
+  },
+  "links": {
+    "rank": 546,
+    "translation": "left",
+    "partOfSpeech": "adverb"
+  },
+  "bo": {
+    "rank": 548,
+    "translation": "above/up",
+    "partOfSpeech": "adverb"
+  },
+  "langs": {
+    "rank": 549,
+    "translation": "beside/next to",
+    "partOfSpeech": "preposition"
+  },
+  "naby": {
+    "rank": 550,
+    "translation": "near",
+    "partOfSpeech": "adverb"
+  },
+  "oral": {
+    "rank": 551,
+    "translation": "everywhere",
+    "partOfSpeech": "adverb"
+  },
+  "nêrens": {
+    "rank": 552,
+    "translation": "nowhere",
+    "partOfSpeech": "adverb"
+  },
+  "iewers": {
+    "rank": 553,
+    "translation": "somewhere",
+    "partOfSpeech": "adverb"
+  },
+  "buite": {
+    "rank": 554,
+    "translation": "outside",
+    "partOfSpeech": "adverb"
+  },
+  "tuis": {
+    "rank": 555,
+    "translation": "at home",
+    "partOfSpeech": "adverb",
+    "suffixes": {
+      "te": {
+        "rank": 1587,
+        "translation": "home",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "sonder": {
+    "rank": 556,
+    "translation": "without",
+    "partOfSpeech": "preposition",
+    "prefixes": {
+      "be": {
+        "rank": 775,
+        "translation": "special",
+        "partOfSpeech": "adjective"
+      }
+    }
+  },
+  "behalwe": {
+    "rank": 557,
+    "translation": "except",
+    "partOfSpeech": "preposition"
+  },
+  "volgens": {
+    "rank": 558,
+    "translation": "according to",
+    "partOfSpeech": "preposition"
+  },
+  "tydens": {
+    "rank": 559,
+    "translation": "during",
+    "partOfSpeech": "preposition"
+  },
+  "sedert": {
+    "rank": 560,
+    "translation": "since",
+    "partOfSpeech": "preposition"
+  },
+  "rondom": {
+    "rank": 561,
+    "translation": "around",
+    "partOfSpeech": "preposition"
+  },
+  "teenoor": {
+    "rank": 562,
+    "translation": "opposite",
+    "partOfSpeech": "preposition"
+  },
+  "namens": {
+    "rank": 563,
+    "translation": "on behalf of",
+    "partOfSpeech": "preposition"
+  },
+  "weens": {
+    "rank": 564,
+    "translation": "because of",
+    "partOfSpeech": "preposition"
+  },
+  "ondanks": {
+    "rank": 565,
+    "translation": "despite",
+    "partOfSpeech": "preposition"
+  },
+  "alhoewel": {
+    "rank": 566,
+    "translation": "although",
+    "partOfSpeech": "conjunction"
+  },
+  "terwyl": {
+    "rank": 567,
+    "translation": "while",
+    "partOfSpeech": "conjunction"
+  },
+  "totdat": {
+    "rank": 568,
+    "translation": "until",
+    "partOfSpeech": "conjunction"
+  },
+  "tensy": {
+    "rank": 569,
+    "translation": "unless",
+    "partOfSpeech": "conjunction"
+  },
+  "aangesien": {
+    "rank": 570,
+    "translation": "since/because",
+    "partOfSpeech": "conjunction"
+  },
+  "mits": {
+    "rank": 571,
+    "translation": "provided that",
+    "partOfSpeech": "conjunction"
+  },
+  "sodat": {
+    "rank": 572,
+    "translation": "so that",
+    "partOfSpeech": "conjunction"
+  },
+  "indien": {
+    "rank": 573,
+    "translation": "if",
+    "partOfSpeech": "conjunction"
+  },
+  "waarom": {
+    "rank": 574,
+    "translation": "why",
+    "partOfSpeech": "adverb"
+  },
+  "hoekom": {
+    "rank": 575,
+    "translation": "why",
+    "partOfSpeech": "adverb"
+  },
+  "wanneer": {
+    "rank": 576,
+    "translation": "when",
+    "partOfSpeech": "adverb"
+  },
+  "hoeveel": {
+    "rank": 577,
+    "translation": "how much/many",
+    "partOfSpeech": "adverb"
+  },
+  "watter": {
+    "rank": 578,
+    "translation": "which",
+    "partOfSpeech": "determiner"
+  },
+  "daardie": {
+    "rank": 579,
+    "translation": "that/those",
+    "partOfSpeech": "determiner"
+  },
+  "elke": {
+    "rank": 580,
+    "translation": "each/every",
+    "partOfSpeech": "determiner"
+  },
+  "geen": {
+    "rank": 582,
+    "translation": "no/none",
+    "partOfSpeech": "determiner"
+  },
+  "party": {
+    "rank": 583,
+    "translation": "some",
+    "partOfSpeech": "determiner",
+    "suffixes": {
+      "tjie": {
+        "rank": 1035,
+        "translation": "party",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "enigste": {
+    "rank": 584,
+    "translation": "only",
+    "partOfSpeech": "adjective"
+  },
+  "dieselfde": {
+    "rank": 585,
+    "translation": "the same",
+    "partOfSpeech": "determiner"
+  },
+  "sulke": {
+    "rank": 586,
+    "translation": "such",
+    "partOfSpeech": "determiner"
+  },
+  "heel": {
+    "rank": 587,
+    "translation": "quite/whole",
+    "partOfSpeech": "adverb"
+  },
+  "nogal": {
+    "rank": 589,
+    "translation": "rather/quite",
+    "partOfSpeech": "adverb"
+  },
+  "amper": {
+    "rank": 590,
+    "translation": "almost",
+    "partOfSpeech": "adverb"
+  },
+  "byna": {
+    "rank": 591,
+    "translation": "nearly",
+    "partOfSpeech": "adverb"
+  },
+  "heeltemal": {
+    "rank": 592,
+    "translation": "completely",
+    "partOfSpeech": "adverb"
+  },
+  "absoluut": {
+    "rank": 593,
+    "translation": "absolutely",
+    "partOfSpeech": "adverb"
+  },
+  "beslis": {
+    "rank": 594,
+    "translation": "definitely",
+    "partOfSpeech": "adverb"
+  },
+  "eintlik": {
+    "rank": 596,
+    "translation": "actually",
+    "partOfSpeech": "adverb"
+  },
+  "regtig": {
+    "rank": 597,
+    "translation": "really/truly",
+    "partOfSpeech": "adverb"
+  },
+  "waarskynlik": {
+    "rank": 598,
+    "translation": "probably",
+    "partOfSpeech": "adverb",
+    "suffixes": {
+      "heid": {
+        "rank": 1175,
+        "translation": "probability",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "miskien": {
+    "rank": 599,
+    "translation": "maybe",
+    "partOfSpeech": "adverb"
+  },
+  "hopelik": {
+    "rank": 600,
+    "translation": "hopefully",
+    "partOfSpeech": "adverb"
+  },
+  "ongelukkig": {
+    "rank": 601,
+    "translation": "unfortunately",
+    "partOfSpeech": "adverb"
+  },
+  "selfs": {
+    "rank": 602,
+    "translation": "even",
+    "partOfSpeech": "adverb"
+  },
+  "slegs": {
+    "rank": 603,
+    "translation": "only",
+    "partOfSpeech": "adverb"
+  },
+  "veral": {
+    "rank": 604,
+    "translation": "especially",
+    "partOfSpeech": "adverb"
+  },
+  "dikwels": {
+    "rank": 606,
+    "translation": "often",
+    "partOfSpeech": "adverb"
+  },
+  "soms": {
+    "rank": 607,
+    "translation": "sometimes",
+    "partOfSpeech": "adverb"
+  },
+  "selde": {
+    "rank": 608,
+    "translation": "seldom",
+    "partOfSpeech": "adverb"
+  },
+  "reeds": {
+    "rank": 609,
+    "translation": "already",
+    "partOfSpeech": "adverb"
+  },
+  "steeds": {
+    "rank": 610,
+    "translation": "still",
+    "partOfSpeech": "adverb"
+  },
+  "bietjie": {
+    "rank": 611,
+    "translation": "a little",
+    "partOfSpeech": "adverb"
+  },
+  "gou": {
+    "rank": 612,
+    "translation": "quickly/soon",
+    "partOfSpeech": "adverb"
+  },
+  "graag": {
+    "rank": 613,
+    "translation": "gladly",
+    "partOfSpeech": "adverb"
+  },
+  "asseblief": {
+    "rank": 614,
+    "translation": "please",
+    "partOfSpeech": "adverb"
+  },
+  "dankie": {
+    "rank": 615,
+    "translation": "thank you",
+    "partOfSpeech": "interjection"
+  },
+  "ja": {
+    "rank": 616,
+    "translation": "yes",
+    "partOfSpeech": "interjection"
+  },
+  "nee": {
+    "rank": 617,
+    "translation": "no",
+    "partOfSpeech": "interjection"
+  },
+  "hallo": {
+    "rank": 618,
+    "translation": "hello",
+    "partOfSpeech": "interjection"
+  },
+  "totsiens": {
+    "rank": 619,
+    "translation": "goodbye",
+    "partOfSpeech": "interjection"
+  },
+  "goeiemore": {
+    "rank": 620,
+    "translation": "good morning",
+    "partOfSpeech": "interjection"
+  },
+  "goeiemiddag": {
+    "rank": 621,
+    "translation": "good afternoon",
+    "partOfSpeech": "interjection"
+  },
+  "goeienag": {
+    "rank": 622,
+    "translation": "good night",
+    "partOfSpeech": "interjection"
+  },
+  "jammer": {
+    "rank": 623,
+    "translation": "sorry",
+    "partOfSpeech": "adjective"
+  },
+  "ekskuus": {
+    "rank": 624,
+    "translation": "excuse me",
+    "partOfSpeech": "interjection"
+  },
+  "geluk": {
+    "rank": 625,
+    "translation": "happiness/luck/congratulations",
+    "partOfSpeech": "noun"
+  },
+  "welkom": {
+    "rank": 626,
+    "translation": "welcome",
+    "partOfSpeech": "adjective"
+  },
+  "verbode": {
+    "rank": 627,
+    "translation": "forbidden",
+    "partOfSpeech": "adjective"
+  },
+  "toegelaat": {
+    "rank": 628,
+    "translation": "allowed",
+    "partOfSpeech": "adjective"
+  },
+  "gratis": {
+    "rank": 629,
+    "translation": "free (no cost)",
+    "partOfSpeech": "adjective"
+  },
+  "duur": {
+    "rank": 630,
+    "translation": "expensive",
+    "partOfSpeech": "adjective"
+  },
+  "goedkoop": {
+    "rank": 631,
+    "translation": "cheap",
+    "partOfSpeech": "adjective"
+  },
+  "prys": {
+    "rank": 632,
+    "translation": "price",
+    "partOfSpeech": "noun"
+  },
+  "bedrag": {
+    "rank": 635,
+    "translation": "amount",
+    "partOfSpeech": "noun"
+  },
+  "totaal": {
+    "rank": 636,
+    "translation": "total",
+    "partOfSpeech": "noun"
+  },
+  "gemiddeld": {
+    "rank": 637,
+    "translation": "average",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "e": {
+        "rank": 1630,
+        "translation": "average",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "minimum": {
+    "rank": 638,
+    "translation": "minimum",
+    "partOfSpeech": "noun"
+  },
+  "maksimum": {
+    "rank": 639,
+    "translation": "maximum",
+    "partOfSpeech": "noun"
+  },
+  "persentasie": {
+    "rank": 640,
+    "translation": "percentage",
+    "partOfSpeech": "noun"
+  },
+  "helfte": {
+    "rank": 641,
+    "translation": "half",
+    "partOfSpeech": "noun"
+  },
+  "kwart": {
+    "rank": 642,
+    "translation": "quarter",
+    "partOfSpeech": "noun"
+  },
+  "derde": {
+    "rank": 643,
+    "translation": "third",
+    "partOfSpeech": "adjective"
+  },
+  "dubbel": {
+    "rank": 644,
+    "translation": "double",
+    "partOfSpeech": "adjective"
+  },
+  "paar": {
+    "rank": 645,
+    "translation": "pair/few",
+    "partOfSpeech": "noun"
+  },
+  "dosyn": {
+    "rank": 646,
+    "translation": "dozen",
+    "partOfSpeech": "noun"
+  },
+  "honderd": {
+    "rank": 647,
+    "translation": "hundred",
+    "partOfSpeech": "number"
+  },
+  "duisend": {
+    "rank": 648,
+    "translation": "thousand",
+    "partOfSpeech": "number"
+  },
+  "miljoen": {
+    "rank": 649,
+    "translation": "million",
+    "partOfSpeech": "number"
+  },
+  "miljard": {
+    "rank": 650,
+    "translation": "billion",
+    "partOfSpeech": "number"
+  },
+  "nul": {
+    "rank": 651,
+    "translation": "zero",
+    "partOfSpeech": "number"
+  },
+  "punt": {
+    "rank": 652,
+    "translation": "point/full stop",
+    "partOfSpeech": "noun"
+  },
+  "komma": {
+    "rank": 653,
+    "translation": "comma",
+    "partOfSpeech": "noun"
+  },
+  "getal": {
+    "rank": 654,
+    "translation": "number",
+    "partOfSpeech": "noun"
+  },
+  "nommer": {
+    "rank": 655,
+    "translation": "number",
+    "partOfSpeech": "noun"
+  },
+  "syfer": {
+    "rank": 656,
+    "translation": "digit/figure",
+    "partOfSpeech": "noun"
+  },
+  "som": {
+    "rank": 657,
+    "translation": "sum",
+    "partOfSpeech": "noun"
+  },
+  "plus": {
+    "rank": 658,
+    "translation": "plus",
+    "partOfSpeech": "preposition"
+  },
+  "minus": {
+    "rank": 659,
+    "translation": "minus",
+    "partOfSpeech": "preposition"
+  },
+  "maal": {
+    "rank": 660,
+    "translation": "times",
+    "partOfSpeech": "preposition"
+  },
+  "gelyk": {
+    "rank": 662,
+    "translation": "equal",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1498,
+        "translation": "equality",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "minder": {
+    "rank": 663,
+    "translation": "less",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1481,
+        "translation": "minority",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "meeste": {
+    "rank": 664,
+    "translation": "most",
+    "partOfSpeech": "adjective"
+  },
+  "minste": {
+    "rank": 665,
+    "translation": "least",
+    "partOfSpeech": "adjective"
+  },
+  "beste": {
+    "rank": 666,
+    "translation": "best",
+    "partOfSpeech": "adjective"
+  },
+  "ergste": {
+    "rank": 667,
+    "translation": "worst",
+    "partOfSpeech": "adjective"
+  },
+  "groter": {
+    "rank": 668,
+    "translation": "bigger",
+    "partOfSpeech": "adjective"
+  },
+  "kleiner": {
+    "rank": 669,
+    "translation": "smaller",
+    "partOfSpeech": "adjective"
+  },
+  "langer": {
+    "rank": 670,
+    "translation": "longer",
+    "partOfSpeech": "adjective"
+  },
+  "korter": {
+    "rank": 671,
+    "translation": "shorter",
+    "partOfSpeech": "adjective"
+  },
+  "hoër": {
+    "rank": 672,
+    "translation": "higher",
+    "partOfSpeech": "adjective"
+  },
+  "laer": {
+    "rank": 673,
+    "translation": "lower",
+    "partOfSpeech": "adjective"
+  },
+  "jonger": {
+    "rank": 674,
+    "translation": "younger",
+    "partOfSpeech": "adjective"
+  },
+  "nader": {
+    "rank": 675,
+    "translation": "closer",
+    "partOfSpeech": "adjective"
+  },
+  "verder": {
+    "rank": 676,
+    "translation": "further",
+    "partOfSpeech": "adjective"
+  },
+  "goeie": {
+    "rank": 677,
+    "translation": "good",
+    "partOfSpeech": "adjective"
+  },
+  "kort": {
+    "rank": 679,
+    "translation": "short",
+    "partOfSpeech": "adjective"
+  },
+  "wyd": {
+    "rank": 680,
+    "translation": "wide",
+    "partOfSpeech": "adjective"
+  },
+  "smal": {
+    "rank": 681,
+    "translation": "narrow",
+    "partOfSpeech": "adjective"
+  },
+  "swak": {
+    "rank": 682,
+    "translation": "weak",
+    "partOfSpeech": "adjective"
+  },
+  "lewendig": {
+    "rank": 683,
+    "translation": "alive",
+    "partOfSpeech": "adjective"
+  },
+  "vaak": {
+    "rank": 684,
+    "translation": "sleepy",
+    "partOfSpeech": "adjective"
+  },
+  "sat": {
+    "rank": 685,
+    "translation": "full (eaten)",
+    "partOfSpeech": "adjective"
+  },
+  "uitgerus": {
+    "rank": 686,
+    "translation": "rested",
+    "partOfSpeech": "adjective"
+  },
+  "bekommerd": {
+    "rank": 687,
+    "translation": "worried",
+    "partOfSpeech": "adjective"
+  },
+  "opgewonde": {
+    "rank": 688,
+    "translation": "excited",
+    "partOfSpeech": "adjective"
+  },
+  "verras": {
+    "rank": 689,
+    "translation": "surprised",
+    "partOfSpeech": "adjective"
+  },
+  "teleurgestel": {
+    "rank": 690,
+    "translation": "disappointed",
+    "partOfSpeech": "adjective"
+  },
+  "verveeld": {
+    "rank": 691,
+    "translation": "bored",
+    "partOfSpeech": "adjective"
+  },
+  "interessant": {
+    "rank": 692,
+    "translation": "interesting",
+    "partOfSpeech": "adjective"
+  },
+  "vervelig": {
+    "rank": 693,
+    "translation": "boring",
+    "partOfSpeech": "adjective"
+  },
+  "onbelangrik": {
+    "rank": 694,
+    "translation": "unimportant",
+    "partOfSpeech": "adjective"
+  },
+  "eenvoudig": {
+    "rank": 695,
+    "translation": "simple",
+    "partOfSpeech": "adjective"
+  },
+  "ingewikkeld": {
+    "rank": 696,
+    "translation": "complicated",
+    "partOfSpeech": "adjective"
+  },
+  "duidelik": {
+    "rank": 697,
+    "translation": "clear/obvious",
+    "partOfSpeech": "adjective"
+  },
+  "onduidelik": {
+    "rank": 698,
+    "translation": "unclear",
+    "partOfSpeech": "adjective"
+  },
+  "onseker": {
+    "rank": 699,
+    "translation": "unsure",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1177,
+        "translation": "uncertainty",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "vals": {
+    "rank": 700,
+    "translation": "false",
+    "partOfSpeech": "adjective"
+  },
+  "nodig": {
+    "rank": 701,
+    "translation": "necessary",
+    "partOfSpeech": "adjective"
+  },
+  "onnodig": {
+    "rank": 702,
+    "translation": "unnecessary",
+    "partOfSpeech": "adjective"
+  },
+  "nuttig": {
+    "rank": 703,
+    "translation": "useful",
+    "partOfSpeech": "adjective"
+  },
+  "nutteloos": {
+    "rank": 704,
+    "translation": "useless",
+    "partOfSpeech": "adjective"
+  },
+  "openbaar": {
+    "rank": 705,
+    "translation": "public",
+    "partOfSpeech": "adjective"
+  },
+  "privaat": {
+    "rank": 706,
+    "translation": "private",
+    "partOfSpeech": "adjective"
+  },
+  "algemeen": {
+    "rank": 707,
+    "translation": "general/common",
+    "partOfSpeech": "adjective"
+  },
+  "spesifiek": {
+    "rank": 708,
+    "translation": "specific",
+    "partOfSpeech": "adjective"
+  },
+  "gewoon": {
+    "rank": 709,
+    "translation": "ordinary/usual",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "lik": {
+        "rank": 605,
+        "translation": "usually",
+        "partOfSpeech": "adverb"
+      },
+      "te": {
+        "rank": 1019,
+        "translation": "habit",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "ongewoon": {
+    "rank": 710,
+    "translation": "unusual",
+    "partOfSpeech": "adjective"
+  },
+  "normaal": {
+    "rank": 711,
+    "translation": "normal",
+    "partOfSpeech": "adjective"
+  },
+  "abnormaal": {
+    "rank": 712,
+    "translation": "abnormal",
+    "partOfSpeech": "adjective"
+  },
+  "kunsmatig": {
+    "rank": 714,
+    "translation": "artificial",
+    "partOfSpeech": "adjective"
+  },
+  "plaaslik": {
+    "rank": 715,
+    "translation": "local",
+    "partOfSpeech": "adjective"
+  },
+  "nasionaal": {
+    "rank": 716,
+    "translation": "national",
+    "partOfSpeech": "adjective"
+  },
+  "internasionaal": {
+    "rank": 717,
+    "translation": "international",
+    "partOfSpeech": "adjective"
+  },
+  "wêreldwyd": {
+    "rank": 718,
+    "translation": "worldwide",
+    "partOfSpeech": "adjective"
+  },
+  "moderne": {
+    "rank": 719,
+    "translation": "modern",
+    "partOfSpeech": "adjective"
+  },
+  "tradisioneel": {
+    "rank": 720,
+    "translation": "traditional",
+    "partOfSpeech": "adjective"
+  },
+  "populêr": {
+    "rank": 721,
+    "translation": "popular",
+    "partOfSpeech": "adjective"
+  },
+  "beroemd": {
+    "rank": 722,
+    "translation": "famous",
+    "partOfSpeech": "adjective"
+  },
+  "onbekend": {
+    "rank": 723,
+    "translation": "unknown",
+    "partOfSpeech": "adjective"
+  },
+  "bekend": {
+    "rank": 724,
+    "translation": "known/famous",
+    "partOfSpeech": "adjective"
+  },
+  "gewild": {
+    "rank": 725,
+    "translation": "popular/wanted",
+    "partOfSpeech": "adjective"
+  },
+  "skaars": {
+    "rank": 726,
+    "translation": "scarce/rare",
+    "partOfSpeech": "adjective"
+  },
+  "volop": {
+    "rank": 727,
+    "translation": "plentiful",
+    "partOfSpeech": "adjective"
+  },
+  "rustig": {
+    "rank": 728,
+    "translation": "calm/peaceful",
+    "partOfSpeech": "adjective"
+  },
+  "stil": {
+    "rank": 729,
+    "translation": "quiet",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "te": {
+        "rank": 1592,
+        "translation": "silence",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "luidrugtig": {
+    "rank": 730,
+    "translation": "noisy",
+    "partOfSpeech": "adjective"
+  },
+  "vreedsaam": {
+    "rank": 731,
+    "translation": "peaceful",
+    "partOfSpeech": "adjective"
+  },
+  "gewelddadig": {
+    "rank": 732,
+    "translation": "violent",
+    "partOfSpeech": "adjective"
+  },
+  "onvriendelik": {
+    "rank": 733,
+    "translation": "unfriendly",
+    "partOfSpeech": "adjective"
+  },
+  "behulpsaam": {
+    "rank": 734,
+    "translation": "helpful",
+    "partOfSpeech": "adjective"
+  },
+  "beleefd": {
+    "rank": 735,
+    "translation": "polite",
+    "partOfSpeech": "adjective"
+  },
+  "onbeleefd": {
+    "rank": 736,
+    "translation": "impolite",
+    "partOfSpeech": "adjective"
+  },
+  "oneerlik": {
+    "rank": 737,
+    "translation": "dishonest",
+    "partOfSpeech": "adjective"
+  },
+  "getrou": {
+    "rank": 738,
+    "translation": "faithful",
+    "partOfSpeech": "adjective"
+  },
+  "ontrou": {
+    "rank": 739,
+    "translation": "unfaithful",
+    "partOfSpeech": "adjective"
+  },
+  "dwaas": {
+    "rank": 740,
+    "translation": "foolish",
+    "partOfSpeech": "adjective"
+  },
+  "lafhartig": {
+    "rank": 741,
+    "translation": "cowardly",
+    "partOfSpeech": "adjective"
+  },
+  "geduldig": {
+    "rank": 742,
+    "translation": "patient",
+    "partOfSpeech": "adjective"
+  },
+  "ongeduldig": {
+    "rank": 743,
+    "translation": "impatient",
+    "partOfSpeech": "adjective"
+  },
+  "versigtig": {
+    "rank": 744,
+    "translation": "careful",
+    "partOfSpeech": "adjective"
+  },
+  "onversigtig": {
+    "rank": 745,
+    "translation": "careless",
+    "partOfSpeech": "adjective"
+  },
+  "hardwerkend": {
+    "rank": 746,
+    "translation": "hardworking",
+    "partOfSpeech": "adjective"
+  },
+  "lui": {
+    "rank": 747,
+    "translation": "lazy",
+    "partOfSpeech": "adjective"
+  },
+  "aktief": {
+    "rank": 748,
+    "translation": "active",
+    "partOfSpeech": "adjective"
+  },
+  "passief": {
+    "rank": 749,
+    "translation": "passive",
+    "partOfSpeech": "adjective"
+  },
+  "optimisties": {
+    "rank": 750,
+    "translation": "optimistic",
+    "partOfSpeech": "adjective"
+  },
+  "pessimisties": {
+    "rank": 751,
+    "translation": "pessimistic",
+    "partOfSpeech": "adjective"
+  },
+  "selfversekerd": {
+    "rank": 752,
+    "translation": "confident",
+    "partOfSpeech": "adjective"
+  },
+  "skugter": {
+    "rank": 753,
+    "translation": "shy",
+    "partOfSpeech": "adjective"
+  },
+  "onafhanklik": {
+    "rank": 754,
+    "translation": "independent",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1500,
+        "translation": "independence",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "afhanklik": {
+    "rank": 755,
+    "translation": "dependent",
+    "partOfSpeech": "adjective"
+  },
+  "verantwoordelik": {
+    "rank": 756,
+    "translation": "responsible",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 881,
+        "translation": "responsibility",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "onverantwoordelik": {
+    "rank": 757,
+    "translation": "irresponsible",
+    "partOfSpeech": "adjective"
+  },
+  "suksesvol": {
+    "rank": 758,
+    "translation": "successful",
+    "partOfSpeech": "adjective"
+  },
+  "onsuksesvol": {
+    "rank": 759,
+    "translation": "unsuccessful",
+    "partOfSpeech": "adjective"
+  },
+  "welvarend": {
+    "rank": 760,
+    "translation": "prosperous",
+    "partOfSpeech": "adjective"
+  },
+  "behoeftig": {
+    "rank": 761,
+    "translation": "needy",
+    "partOfSpeech": "adjective"
+  },
+  "magtig": {
+    "rank": 762,
+    "translation": "powerful",
+    "partOfSpeech": "adjective"
+  },
+  "magteloos": {
+    "rank": 763,
+    "translation": "powerless",
+    "partOfSpeech": "adjective"
+  },
+  "invloedryk": {
+    "rank": 764,
+    "translation": "influential",
+    "partOfSpeech": "adjective"
+  },
+  "betekenisvol": {
+    "rank": 765,
+    "translation": "meaningful",
+    "partOfSpeech": "adjective"
+  },
+  "betekenisloos": {
+    "rank": 766,
+    "translation": "meaningless",
+    "partOfSpeech": "adjective"
+  },
+  "waardevol": {
+    "rank": 767,
+    "translation": "valuable",
+    "partOfSpeech": "adjective"
+  },
+  "waardeloos": {
+    "rank": 768,
+    "translation": "worthless",
+    "partOfSpeech": "adjective"
+  },
+  "perfek": {
+    "rank": 769,
+    "translation": "perfect",
+    "partOfSpeech": "adjective"
+  },
+  "onvolmaak": {
+    "rank": 770,
+    "translation": "imperfect",
+    "partOfSpeech": "adjective"
+  },
+  "ideaal": {
+    "rank": 771,
+    "translation": "ideal",
+    "partOfSpeech": "adjective"
+  },
+  "tipies": {
+    "rank": 772,
+    "translation": "typical",
+    "partOfSpeech": "adjective"
+  },
+  "uniek": {
+    "rank": 773,
+    "translation": "unique",
+    "partOfSpeech": "adjective"
+  },
+  "alledaags": {
+    "rank": 774,
+    "translation": "everyday",
+    "partOfSpeech": "adjective"
+  },
+  "uitsonderlik": {
+    "rank": 776,
+    "translation": "exceptional",
+    "partOfSpeech": "adjective"
+  },
+  "uitstekend": {
+    "rank": 777,
+    "translation": "excellent",
+    "partOfSpeech": "adjective"
+  },
+  "wonderlik": {
+    "rank": 778,
+    "translation": "wonderful",
+    "partOfSpeech": "adjective"
+  },
+  "fantasties": {
+    "rank": 779,
+    "translation": "fantastic",
+    "partOfSpeech": "adjective"
+  },
+  "ongelooflik": {
+    "rank": 780,
+    "translation": "incredible",
+    "partOfSpeech": "adjective"
+  },
+  "verbasend": {
+    "rank": 781,
+    "translation": "amazing",
+    "partOfSpeech": "adjective"
+  },
+  "indrukwekkend": {
+    "rank": 782,
+    "translation": "impressive",
+    "partOfSpeech": "adjective"
+  },
+  "teleurstellend": {
+    "rank": 783,
+    "translation": "disappointing",
+    "partOfSpeech": "adjective"
+  },
+  "aanvaarbaar": {
+    "rank": 784,
+    "translation": "acceptable",
+    "partOfSpeech": "adjective"
+  },
+  "onaanvaarbaar": {
+    "rank": 785,
+    "translation": "unacceptable",
+    "partOfSpeech": "adjective"
+  },
+  "gepas": {
+    "rank": 786,
+    "translation": "appropriate",
+    "partOfSpeech": "adjective"
+  },
+  "ongepas": {
+    "rank": 787,
+    "translation": "inappropriate",
+    "partOfSpeech": "adjective"
+  },
+  "geskik": {
+    "rank": 788,
+    "translation": "suitable",
+    "partOfSpeech": "adjective"
+  },
+  "ongeskik": {
+    "rank": 789,
+    "translation": "unsuitable",
+    "partOfSpeech": "adjective"
+  },
+  "beskikbaar": {
+    "rank": 790,
+    "translation": "available",
+    "partOfSpeech": "adjective"
+  },
+  "onbeskikbaar": {
+    "rank": 791,
+    "translation": "unavailable",
+    "partOfSpeech": "adjective"
+  },
+  "sigbaar": {
+    "rank": 792,
+    "translation": "visible",
+    "partOfSpeech": "adjective"
+  },
+  "onsigbaar": {
+    "rank": 793,
+    "translation": "invisible",
+    "partOfSpeech": "adjective"
+  },
+  "hoorbaar": {
+    "rank": 794,
+    "translation": "audible",
+    "partOfSpeech": "adjective"
+  },
+  "onhoorbaar": {
+    "rank": 795,
+    "translation": "inaudible",
+    "partOfSpeech": "adjective"
+  },
+  "leesbaar": {
+    "rank": 796,
+    "translation": "readable",
+    "partOfSpeech": "adjective"
+  },
+  "onleesbaar": {
+    "rank": 797,
+    "translation": "unreadable",
+    "partOfSpeech": "adjective"
+  },
+  "eetbaar": {
+    "rank": 798,
+    "translation": "edible",
+    "partOfSpeech": "adjective"
+  },
+  "drinkbaar": {
+    "rank": 799,
+    "translation": "drinkable",
+    "partOfSpeech": "adjective"
+  },
+  "giftig": {
+    "rank": 800,
+    "translation": "poisonous",
+    "partOfSpeech": "adjective"
+  },
+  "skadelik": {
+    "rank": 801,
+    "translation": "harmful",
+    "partOfSpeech": "adjective"
+  },
+  "onskadelik": {
+    "rank": 802,
+    "translation": "harmless",
+    "partOfSpeech": "adjective"
+  },
+  "dodelik": {
+    "rank": 803,
+    "translation": "deadly",
+    "partOfSpeech": "adjective"
+  },
+  "aansteeklik": {
+    "rank": 804,
+    "translation": "contagious",
+    "partOfSpeech": "adjective"
+  },
+  "ongesond": {
+    "rank": 805,
+    "translation": "unhealthy",
+    "partOfSpeech": "adjective"
+  },
+  "organiese": {
+    "rank": 806,
+    "translation": "organic",
+    "partOfSpeech": "adjective"
+  },
+  "sintetiese": {
+    "rank": 807,
+    "translation": "synthetic",
+    "partOfSpeech": "adjective"
+  },
+  "volhoubaar": {
+    "rank": 808,
+    "translation": "sustainable",
+    "partOfSpeech": "adjective",
+    "suffixes": {
+      "heid": {
+        "rank": 1720,
+        "translation": "sustainability",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "hernubaar": {
+    "rank": 809,
+    "translation": "renewable",
+    "partOfSpeech": "adjective"
+  },
+  "digitaal": {
+    "rank": 810,
+    "translation": "digital",
+    "partOfSpeech": "adjective"
+  },
+  "elektronies": {
+    "rank": 811,
+    "translation": "electronic",
+    "partOfSpeech": "adjective"
+  },
+  "outomaties": {
+    "rank": 812,
+    "translation": "automatic",
+    "partOfSpeech": "adjective"
+  },
+  "handmatig": {
+    "rank": 813,
+    "translation": "manual",
+    "partOfSpeech": "adjective"
+  },
+  "draagbaar": {
+    "rank": 814,
+    "translation": "portable",
+    "partOfSpeech": "adjective"
+  },
+  "permanent": {
+    "rank": 815,
+    "translation": "permanent",
+    "partOfSpeech": "adjective"
+  },
+  "tydelik": {
+    "rank": 816,
+    "translation": "temporary",
+    "partOfSpeech": "adjective"
+  },
+  "deurlopend": {
+    "rank": 817,
+    "translation": "ongoing",
+    "partOfSpeech": "adjective"
+  },
+  "onmiddellik": {
+    "rank": 818,
+    "translation": "immediate",
+    "partOfSpeech": "adjective"
+  },
+  "geleidelik": {
+    "rank": 819,
+    "translation": "gradual",
+    "partOfSpeech": "adjective"
+  },
+  "skielik": {
+    "rank": 820,
+    "translation": "sudden",
+    "partOfSpeech": "adjective"
+  },
+  "konstant": {
+    "rank": 821,
+    "translation": "constant",
+    "partOfSpeech": "adjective"
+  },
+  "stabiel": {
+    "rank": 823,
+    "translation": "stable",
+    "partOfSpeech": "adjective"
+  },
+  "onstabiel": {
+    "rank": 824,
+    "translation": "unstable",
+    "partOfSpeech": "adjective"
+  },
+  "balans": {
+    "rank": 825,
+    "translation": "balance",
+    "partOfSpeech": "noun"
+  },
+  "verbinding": {
+    "rank": 1897,
+    "translation": "connection",
+    "partOfSpeech": "noun"
+  },
+  "verband": {
+    "rank": 828,
+    "translation": "connection/bandage",
+    "partOfSpeech": "noun"
+  },
+  "skakel": {
+    "rank": 1863,
+    "translation": "link",
+    "partOfSpeech": "noun"
+  },
+  "netwerk": {
+    "rank": 1850,
+    "translation": "network",
+    "partOfSpeech": "noun"
+  },
+  "stelsel": {
+    "rank": 831,
+    "translation": "system",
+    "partOfSpeech": "noun"
+  },
+  "struktuur": {
+    "rank": 832,
+    "translation": "structure",
+    "partOfSpeech": "noun"
+  },
+  "vorm": {
+    "rank": 833,
+    "translation": "form/shape",
+    "partOfSpeech": "noun"
+  },
+  "patroon": {
+    "rank": 834,
+    "translation": "pattern",
+    "partOfSpeech": "noun"
+  },
+  "ontwerp": {
+    "rank": 835,
+    "translation": "design",
+    "partOfSpeech": "noun"
+  },
+  "model": {
+    "rank": 836,
+    "translation": "model",
+    "partOfSpeech": "noun"
+  },
+  "tipe": {
+    "rank": 837,
+    "translation": "type",
+    "partOfSpeech": "noun"
+  },
+  "kategorie": {
+    "rank": 838,
+    "translation": "category",
+    "partOfSpeech": "noun"
+  },
+  "klas": {
+    "rank": 1699,
+    "translation": "class",
+    "partOfSpeech": "noun"
+  },
+  "groep": {
+    "rank": 840,
+    "translation": "group",
+    "partOfSpeech": "noun"
+  },
+  "span": {
+    "rank": 841,
+    "translation": "team",
+    "partOfSpeech": "noun"
+  },
+  "vereniging": {
+    "rank": 842,
+    "translation": "association",
+    "partOfSpeech": "noun"
+  },
+  "organisasie": {
+    "rank": 843,
+    "translation": "organization",
+    "partOfSpeech": "noun"
+  },
+  "instelling": {
+    "rank": 844,
+    "translation": "institution",
+    "partOfSpeech": "noun"
+  },
+  "maatskappy": {
+    "rank": 845,
+    "translation": "company",
+    "partOfSpeech": "noun"
+  },
+  "onderneming": {
+    "rank": 847,
+    "translation": "enterprise",
+    "partOfSpeech": "noun"
+  },
+  "nywerheid": {
+    "rank": 848,
+    "translation": "industry",
+    "partOfSpeech": "noun"
+  },
+  "handel": {
+    "rank": 849,
+    "translation": "trade",
+    "partOfSpeech": "noun"
+  },
+  "ekonomie": {
+    "rank": 850,
+    "translation": "economy",
+    "partOfSpeech": "noun"
+  },
+  "mark": {
+    "rank": 851,
+    "translation": "market",
+    "partOfSpeech": "noun"
+  },
+  "produk": {
+    "rank": 852,
+    "translation": "product",
+    "partOfSpeech": "noun"
+  },
+  "diens": {
+    "rank": 853,
+    "translation": "service",
+    "partOfSpeech": "noun"
+  },
+  "kliënt": {
+    "rank": 1867,
+    "translation": "client",
+    "partOfSpeech": "noun"
+  },
+  "klant": {
+    "rank": 855,
+    "translation": "customer",
+    "partOfSpeech": "noun"
+  },
+  "verbruiker": {
+    "rank": 856,
+    "translation": "consumer",
+    "partOfSpeech": "noun"
+  },
+  "verskaffer": {
+    "rank": 857,
+    "translation": "supplier",
+    "partOfSpeech": "noun"
+  },
+  "invoer": {
+    "rank": 858,
+    "translation": "import",
+    "partOfSpeech": "noun"
+  },
+  "uitvoer": {
+    "rank": 859,
+    "translation": "export",
+    "partOfSpeech": "noun"
+  },
+  "belegging": {
+    "rank": 860,
+    "translation": "investment",
+    "partOfSpeech": "noun"
+  },
+  "wins": {
+    "rank": 861,
+    "translation": "profit",
+    "partOfSpeech": "noun"
+  },
+  "verlies": {
+    "rank": 862,
+    "translation": "loss",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "e": {
+        "rank": 1309,
+        "translation": "casualties"
+      }
+    }
+  },
+  "omset": {
+    "rank": 863,
+    "translation": "turnover",
+    "partOfSpeech": "noun"
+  },
+  "inkomste": {
+    "rank": 864,
+    "translation": "income",
+    "partOfSpeech": "noun"
+  },
+  "uitgawe": {
+    "rank": 865,
+    "translation": "expense",
+    "partOfSpeech": "noun"
+  },
+  "begroting": {
+    "rank": 866,
+    "translation": "budget",
+    "partOfSpeech": "noun"
+  },
+  "belasting": {
+    "rank": 867,
+    "translation": "tax",
+    "partOfSpeech": "noun"
+  },
+  "skuld": {
+    "rank": 868,
+    "translation": "debt",
+    "partOfSpeech": "noun"
+  },
+  "lening": {
+    "rank": 869,
+    "translation": "loan",
+    "partOfSpeech": "noun"
+  },
+  "rente": {
+    "rank": 870,
+    "translation": "interest",
+    "partOfSpeech": "noun"
+  },
+  "salaris": {
+    "rank": 871,
+    "translation": "salary",
+    "partOfSpeech": "noun"
+  },
+  "loon": {
+    "rank": 872,
+    "translation": "wage",
+    "partOfSpeech": "noun"
+  },
+  "bonus": {
+    "rank": 873,
+    "translation": "bonus",
+    "partOfSpeech": "noun"
+  },
+  "pensioen": {
+    "rank": 874,
+    "translation": "pension",
+    "partOfSpeech": "noun"
+  },
+  "versekering": {
+    "rank": 875,
+    "translation": "insurance",
+    "partOfSpeech": "noun"
+  },
+  "kontrak": {
+    "rank": 876,
+    "translation": "contract",
+    "partOfSpeech": "noun"
+  },
+  "ooreenkoms": {
+    "rank": 877,
+    "translation": "agreement",
+    "partOfSpeech": "noun"
+  },
+  "voorwaarde": {
+    "rank": 878,
+    "translation": "condition",
+    "partOfSpeech": "noun"
+  },
+  "bepaling": {
+    "rank": 879,
+    "translation": "provision",
+    "partOfSpeech": "noun"
+  },
+  "plig": {
+    "rank": 880,
+    "translation": "duty",
+    "partOfSpeech": "noun"
+  },
+  "wet": {
+    "rank": 882,
+    "translation": "law",
+    "partOfSpeech": "noun"
+  },
+  "regulasie": {
+    "rank": 883,
+    "translation": "regulation",
+    "partOfSpeech": "noun"
+  },
+  "beleid": {
+    "rank": 884,
+    "translation": "policy",
+    "partOfSpeech": "noun"
+  },
+  "prosedure": {
+    "rank": 885,
+    "translation": "procedure",
+    "partOfSpeech": "noun"
+  },
+  "metode": {
+    "rank": 886,
+    "translation": "method",
+    "partOfSpeech": "noun"
+  },
+  "tegniek": {
+    "rank": 887,
+    "translation": "technique",
+    "partOfSpeech": "noun"
+  },
+  "strategie": {
+    "rank": 888,
+    "translation": "strategy",
+    "partOfSpeech": "noun"
+  },
+  "plan": {
+    "rank": 889,
+    "translation": "plan",
+    "partOfSpeech": "noun"
+  },
+  "projek": {
+    "rank": 890,
+    "translation": "project",
+    "partOfSpeech": "noun"
+  },
+  "program": {
+    "rank": 1845,
+    "translation": "program",
+    "partOfSpeech": "noun"
+  },
+  "skedule": {
+    "rank": 892,
+    "translation": "schedule",
+    "partOfSpeech": "noun"
+  },
+  "doelwit": {
+    "rank": 893,
+    "translation": "goal/target",
+    "partOfSpeech": "noun"
+  },
+  "mikpunt": {
+    "rank": 894,
+    "translation": "aim/target",
+    "partOfSpeech": "noun"
+  },
+  "prioriteit": {
+    "rank": 895,
+    "translation": "priority",
+    "partOfSpeech": "noun"
+  },
+  "uitdaging": {
+    "rank": 896,
+    "translation": "challenge",
+    "partOfSpeech": "noun"
+  },
+  "navorsing": {
+    "rank": 898,
+    "translation": "research",
+    "partOfSpeech": "noun"
+  },
+  "studie": {
+    "rank": 899,
+    "translation": "study",
+    "partOfSpeech": "noun"
+  },
+  "ondersoek": {
+    "rank": 1922,
+    "translation": "examine/investigate",
+    "partOfSpeech": "verb"
+  },
+  "analise": {
+    "rank": 901,
+    "translation": "analysis",
+    "partOfSpeech": "noun"
+  },
+  "evaluasie": {
+    "rank": 902,
+    "translation": "evaluation",
+    "partOfSpeech": "noun"
+  },
+  "assessering": {
+    "rank": 903,
+    "translation": "assessment",
+    "partOfSpeech": "noun"
+  },
+  "toets": {
+    "rank": 904,
+    "translation": "test",
+    "partOfSpeech": "noun"
+  },
+  "eksamen": {
+    "rank": 905,
+    "translation": "exam",
+    "partOfSpeech": "noun"
+  },
+  "resultaat": {
+    "rank": 906,
+    "translation": "result",
+    "partOfSpeech": "noun"
+  },
+  "uitslag": {
+    "rank": 907,
+    "translation": "result/outcome",
+    "partOfSpeech": "noun"
+  },
+  "gevolg": {
+    "rank": 908,
+    "translation": "consequence",
+    "partOfSpeech": "noun"
+  },
+  "impak": {
+    "rank": 909,
+    "translation": "impact",
+    "partOfSpeech": "noun"
+  },
+  "effek": {
+    "rank": 910,
+    "translation": "effect",
+    "partOfSpeech": "noun"
+  },
+  "invloed": {
+    "rank": 911,
+    "translation": "influence",
+    "partOfSpeech": "noun"
+  },
+  "bydrae": {
+    "rank": 912,
+    "translation": "contribution",
+    "partOfSpeech": "noun"
+  },
+  "deelname": {
+    "rank": 913,
+    "translation": "participation",
+    "partOfSpeech": "noun"
+  },
+  "samewerking": {
+    "rank": 914,
+    "translation": "cooperation",
+    "partOfSpeech": "noun"
+  },
+  "mededinging": {
+    "rank": 915,
+    "translation": "competition",
+    "partOfSpeech": "noun"
+  },
+  "stryd": {
+    "rank": 916,
+    "translation": "struggle",
+    "partOfSpeech": "noun"
+  },
+  "konflik": {
+    "rank": 917,
+    "translation": "conflict",
+    "partOfSpeech": "noun"
+  },
+  "spanning": {
+    "rank": 1818,
+    "translation": "voltage",
+    "partOfSpeech": "noun",
+    "prefixes": {
+      "ont": {
+        "rank": 1030,
+        "translation": "relaxation"
+      }
+    }
+  },
+  "krisis": {
+    "rank": 919,
+    "translation": "crisis",
+    "partOfSpeech": "noun"
+  },
+  "noodgeval": {
+    "rank": 920,
+    "translation": "emergency",
+    "partOfSpeech": "noun"
+  },
+  "ramp": {
+    "rank": 921,
+    "translation": "disaster",
+    "partOfSpeech": "noun"
+  },
+  "ongeluk": {
+    "rank": 922,
+    "translation": "accident",
+    "partOfSpeech": "noun"
+  },
+  "fout": {
+    "rank": 923,
+    "translation": "error/mistake",
+    "partOfSpeech": "noun"
+  },
+  "mislukking": {
+    "rank": 924,
+    "translation": "failure",
+    "partOfSpeech": "noun"
+  },
+  "sukses": {
+    "rank": 925,
+    "translation": "success",
+    "partOfSpeech": "noun"
+  },
+  "prestasie": {
+    "rank": 926,
+    "translation": "achievement",
+    "partOfSpeech": "noun"
+  },
+  "oorwinning": {
+    "rank": 927,
+    "translation": "victory",
+    "partOfSpeech": "noun"
+  },
+  "nederlaag": {
+    "rank": 928,
+    "translation": "defeat",
+    "partOfSpeech": "noun"
+  },
+  "rekord": {
+    "rank": 929,
+    "translation": "record",
+    "partOfSpeech": "noun"
+  },
+  "mylpaal": {
+    "rank": 930,
+    "translation": "milestone",
+    "partOfSpeech": "noun"
+  },
+  "vordering": {
+    "rank": 931,
+    "translation": "progress",
+    "partOfSpeech": "noun",
+    "prefixes": {
+      "be": {
+        "rank": 1379,
+        "translation": "promotion"
+      }
+    }
+  },
+  "ontwikkeling": {
+    "rank": 932,
+    "translation": "development",
+    "partOfSpeech": "noun"
+  },
+  "uitbreiding": {
+    "rank": 933,
+    "translation": "expansion",
+    "partOfSpeech": "noun"
+  },
+  "verbetering": {
+    "rank": 935,
+    "translation": "improvement",
+    "partOfSpeech": "noun"
+  },
+  "vernuwing": {
+    "rank": 936,
+    "translation": "renewal",
+    "partOfSpeech": "noun"
+  },
+  "hervorming": {
+    "rank": 937,
+    "translation": "reform",
+    "partOfSpeech": "noun"
+  },
+  "revolusie": {
+    "rank": 938,
+    "translation": "revolution",
+    "partOfSpeech": "noun"
+  },
+  "evolusie": {
+    "rank": 1712,
+    "translation": "evolution",
+    "partOfSpeech": "noun"
+  },
+  "transformasie": {
+    "rank": 940,
+    "translation": "transformation",
+    "partOfSpeech": "noun"
+  },
+  "oorgang": {
+    "rank": 941,
+    "translation": "transition",
+    "partOfSpeech": "noun"
+  },
+  "aanpassing": {
+    "rank": 1714,
+    "translation": "adaptation",
+    "partOfSpeech": "noun"
+  },
+  "integrasie": {
+    "rank": 943,
+    "translation": "integration",
+    "partOfSpeech": "noun"
+  },
+  "skeiding": {
+    "rank": 944,
+    "translation": "separation",
+    "partOfSpeech": "noun"
+  },
+  "verdeling": {
+    "rank": 945,
+    "translation": "division",
+    "partOfSpeech": "noun"
+  },
+  "verspreiding": {
+    "rank": 946,
+    "translation": "distribution",
+    "partOfSpeech": "noun"
+  },
+  "konsentrasie": {
+    "rank": 947,
+    "translation": "concentration",
+    "partOfSpeech": "noun"
+  },
+  "samestelling": {
+    "rank": 948,
+    "translation": "composition",
+    "partOfSpeech": "noun"
+  },
+  "mengsel": {
+    "rank": 1684,
+    "translation": "mixture",
+    "partOfSpeech": "noun"
+  },
+  "kombinasie": {
+    "rank": 950,
+    "translation": "combination",
+    "partOfSpeech": "noun"
+  },
+  "variasie": {
+    "rank": 951,
+    "translation": "variation",
+    "partOfSpeech": "noun"
+  },
+  "verskeidenheid": {
+    "rank": 952,
+    "translation": "variety",
+    "partOfSpeech": "noun"
+  },
+  "keuse": {
+    "rank": 953,
+    "translation": "choice",
+    "partOfSpeech": "noun"
+  },
+  "alternatief": {
+    "rank": 954,
+    "translation": "alternative",
+    "partOfSpeech": "noun"
+  },
+  "opsie": {
+    "rank": 955,
+    "translation": "option",
+    "partOfSpeech": "noun"
+  },
+  "geleentheid": {
+    "rank": 957,
+    "translation": "opportunity",
+    "partOfSpeech": "noun"
+  },
+  "voordeel": {
+    "rank": 958,
+    "translation": "advantage",
+    "partOfSpeech": "noun"
+  },
+  "nadeel": {
+    "rank": 959,
+    "translation": "disadvantage",
+    "partOfSpeech": "noun"
+  },
+  "risiko": {
+    "rank": 960,
+    "translation": "risk",
+    "partOfSpeech": "noun"
+  },
+  "gevaar": {
+    "rank": 961,
+    "translation": "danger",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "lik": {
+        "rank": 471,
+        "translation": "dangerous",
+        "partOfSpeech": "adjective"
+      }
+    }
+  },
+  "bedreiging": {
+    "rank": 962,
+    "translation": "threat",
+    "partOfSpeech": "noun"
+  },
+  "beskerming": {
+    "rank": 963,
+    "translation": "protection",
+    "partOfSpeech": "noun"
+  },
+  "sekuriteit": {
+    "rank": 1875,
+    "translation": "security",
+    "partOfSpeech": "noun"
+  },
+  "infeksie": {
+    "rank": 968,
+    "translation": "infection",
+    "partOfSpeech": "noun"
+  },
+  "virus": {
+    "rank": 1871,
+    "translation": "virus",
+    "partOfSpeech": "noun"
+  },
+  "bakterie": {
+    "rank": 970,
+    "translation": "bacteria",
+    "partOfSpeech": "noun"
+  },
+  "simptoom": {
+    "rank": 971,
+    "translation": "symptom",
+    "partOfSpeech": "noun"
+  },
+  "diagnose": {
+    "rank": 972,
+    "translation": "diagnosis",
+    "partOfSpeech": "noun"
+  },
+  "behandeling": {
+    "rank": 973,
+    "translation": "treatment",
+    "partOfSpeech": "noun"
+  },
+  "operasie": {
+    "rank": 974,
+    "translation": "operation",
+    "partOfSpeech": "noun"
+  },
+  "terapie": {
+    "rank": 975,
+    "translation": "therapy",
+    "partOfSpeech": "noun"
+  },
+  "medikasie": {
+    "rank": 976,
+    "translation": "medication",
+    "partOfSpeech": "noun"
+  },
+  "pil": {
+    "rank": 977,
+    "translation": "pill",
+    "partOfSpeech": "noun"
+  },
+  "inspuiting": {
+    "rank": 978,
+    "translation": "injection",
+    "partOfSpeech": "noun"
+  },
+  "wond": {
+    "rank": 979,
+    "translation": "wound",
+    "partOfSpeech": "noun"
+  },
+  "koors": {
+    "rank": 980,
+    "translation": "fever",
+    "partOfSpeech": "noun"
+  },
+  "hoofpyn": {
+    "rank": 981,
+    "translation": "headache",
+    "partOfSpeech": "noun"
+  },
+  "griep": {
+    "rank": 983,
+    "translation": "flu",
+    "partOfSpeech": "noun"
+  },
+  "allergie": {
+    "rank": 984,
+    "translation": "allergy",
+    "partOfSpeech": "noun"
+  },
+  "gestremdheid": {
+    "rank": 985,
+    "translation": "disability",
+    "partOfSpeech": "noun"
+  },
+  "geheue": {
+    "rank": 1840,
+    "translation": "memory",
+    "partOfSpeech": "noun"
+  },
+  "depressie": {
+    "rank": 987,
+    "translation": "depression",
+    "partOfSpeech": "noun"
+  },
+  "angs": {
+    "rank": 988,
+    "translation": "anxiety",
+    "partOfSpeech": "noun"
+  },
+  "stres": {
+    "rank": 989,
+    "translation": "stress",
+    "partOfSpeech": "noun"
+  },
+  "trauma": {
+    "rank": 990,
+    "translation": "trauma",
+    "partOfSpeech": "noun"
+  },
+  "agteruitgang": {
+    "rank": 992,
+    "translation": "decline",
+    "partOfSpeech": "noun"
+  },
+  "veroudering": {
+    "rank": 993,
+    "translation": "aging",
+    "partOfSpeech": "noun"
+  },
+  "geboorte": {
+    "rank": 994,
+    "translation": "birth",
+    "partOfSpeech": "noun"
+  },
+  "oorlewing": {
+    "rank": 996,
+    "translation": "survival",
+    "partOfSpeech": "noun"
+  },
+  "toekoms": {
+    "rank": 997,
+    "translation": "future",
+    "partOfSpeech": "noun"
+  },
+  "verlede": {
+    "rank": 998,
+    "translation": "past",
+    "partOfSpeech": "noun"
+  },
+  "hede": {
+    "rank": 999,
+    "translation": "present",
+    "partOfSpeech": "noun"
+  },
+  "geskiedenis": {
+    "rank": 1000,
+    "translation": "history",
+    "partOfSpeech": "noun"
+  },
+  "herinnering": {
+    "rank": 1001,
+    "translation": "memory/remembrance",
+    "partOfSpeech": "noun"
+  },
+  "tradisie": {
+    "rank": 1002,
+    "translation": "tradition",
+    "partOfSpeech": "noun"
+  },
+  "kultuur": {
+    "rank": 1003,
+    "translation": "culture",
+    "partOfSpeech": "noun"
+  },
+  "erfenis": {
+    "rank": 1004,
+    "translation": "heritage",
+    "partOfSpeech": "noun"
+  },
+  "oorsprong": {
+    "rank": 1005,
+    "translation": "origin",
+    "partOfSpeech": "noun"
+  },
+  "identiteit": {
+    "rank": 1006,
+    "translation": "identity",
+    "partOfSpeech": "noun"
+  },
+  "karakter": {
+    "rank": 1007,
+    "translation": "character",
+    "partOfSpeech": "noun"
+  },
+  "persoonlikheid": {
+    "rank": 1008,
+    "translation": "personality",
+    "partOfSpeech": "noun"
+  },
+  "houding": {
+    "rank": 1009,
+    "translation": "attitude",
+    "partOfSpeech": "noun",
+    "prefixes": {
+      "ver": {
+        "rank": 1638,
+        "translation": "ratio"
+      }
+    }
+  },
+  "gedrag": {
+    "rank": 1010,
+    "translation": "behavior",
+    "partOfSpeech": "noun"
+  },
+  "optrede": {
+    "rank": 1011,
+    "translation": "action/performance",
+    "partOfSpeech": "noun"
+  },
+  "reaksie": {
+    "rank": 1685,
+    "translation": "reaction",
+    "partOfSpeech": "noun"
+  },
+  "respons": {
+    "rank": 1013,
+    "translation": "response",
+    "partOfSpeech": "noun"
+  },
+  "voorkeur": {
+    "rank": 1014,
+    "translation": "preference",
+    "partOfSpeech": "noun"
+  },
+  "smaak": {
+    "rank": 1015,
+    "translation": "taste",
+    "partOfSpeech": "noun"
+  },
+  "styl": {
+    "rank": 1969,
+    "translation": "style",
+    "partOfSpeech": "noun"
+  },
+  "mode": {
+    "rank": 1017,
+    "translation": "fashion",
+    "partOfSpeech": "noun"
+  },
+  "neiging": {
+    "rank": 1018,
+    "translation": "tendency",
+    "partOfSpeech": "noun"
+  },
+  "roetine": {
+    "rank": 1020,
+    "translation": "routine",
+    "partOfSpeech": "noun"
+  },
+  "ritme": {
+    "rank": 1967,
+    "translation": "rhythm",
+    "partOfSpeech": "noun"
+  },
+  "tempo": {
+    "rank": 1022,
+    "translation": "tempo",
+    "partOfSpeech": "noun"
+  },
+  "spoed": {
+    "rank": 1899,
+    "translation": "speed",
+    "partOfSpeech": "noun"
+  },
+  "beweging": {
+    "rank": 1024,
+    "translation": "movement",
+    "partOfSpeech": "noun"
+  },
+  "aksie": {
+    "rank": 1025,
+    "translation": "action",
+    "partOfSpeech": "noun"
+  },
+  "aktiwiteit": {
+    "rank": 1026,
+    "translation": "activity",
+    "partOfSpeech": "noun"
+  },
+  "oefening": {
+    "rank": 1027,
+    "translation": "exercise",
+    "partOfSpeech": "noun"
+  },
+  "wedstryd": {
+    "rank": 1028,
+    "translation": "match/competition",
+    "partOfSpeech": "noun"
+  },
+  "spel": {
+    "rank": 1029,
+    "translation": "game",
+    "partOfSpeech": "noun"
+  },
+  "vakansie": {
+    "rank": 1031,
+    "translation": "vacation",
+    "partOfSpeech": "noun"
+  },
+  "toer": {
+    "rank": 1032,
+    "translation": "tour",
+    "partOfSpeech": "noun"
+  },
+  "avontuur": {
+    "rank": 1033,
+    "translation": "adventure",
+    "partOfSpeech": "noun"
+  },
+  "ontdekking": {
+    "rank": 1034,
+    "translation": "discovery",
+    "partOfSpeech": "noun"
+  },
+  "fees": {
+    "rank": 1036,
+    "translation": "festival",
+    "partOfSpeech": "noun"
+  },
+  "seremonie": {
+    "rank": 1038,
+    "translation": "ceremony",
+    "partOfSpeech": "noun"
+  },
+  "huwelik": {
+    "rank": 1039,
+    "translation": "marriage",
+    "partOfSpeech": "noun"
+  },
+  "troue": {
+    "rank": 1040,
+    "translation": "wedding",
+    "partOfSpeech": "noun",
+    "prefixes": {
+      "ver": {
+        "rank": 1179,
+        "translation": "trust"
+      }
+    }
+  },
+  "begrafnis": {
+    "rank": 1041,
+    "translation": "funeral",
+    "partOfSpeech": "noun"
+  },
+  "doop": {
+    "rank": 1042,
+    "translation": "baptism",
+    "partOfSpeech": "noun"
+  },
+  "verjaarsdag": {
+    "rank": 1043,
+    "translation": "birthday",
+    "partOfSpeech": "noun"
+  },
+  "kersfees": {
+    "rank": 1044,
+    "translation": "Christmas",
+    "partOfSpeech": "noun"
+  },
+  "paasfees": {
+    "rank": 1045,
+    "translation": "Easter",
+    "partOfSpeech": "noun"
+  },
+  "nuwejaar": {
+    "rank": 1046,
+    "translation": "New Year",
+    "partOfSpeech": "noun"
+  },
+  "ritueel": {
+    "rank": 1047,
+    "translation": "ritual",
+    "partOfSpeech": "noun"
+  },
+  "gebed": {
+    "rank": 1049,
+    "translation": "prayer",
+    "partOfSpeech": "noun"
+  },
+  "godsdiens": {
+    "rank": 1050,
+    "translation": "religion",
+    "partOfSpeech": "noun"
+  },
+  "geloof": {
+    "rank": 1051,
+    "translation": "faith",
+    "partOfSpeech": "noun"
+  },
+  "tempel": {
+    "rank": 1052,
+    "translation": "temple",
+    "partOfSpeech": "noun"
+  },
+  "moskee": {
+    "rank": 1053,
+    "translation": "mosque",
+    "partOfSpeech": "noun"
+  },
+  "predikant": {
+    "rank": 1054,
+    "translation": "minister",
+    "partOfSpeech": "noun"
+  },
+  "priester": {
+    "rank": 1055,
+    "translation": "priest",
+    "partOfSpeech": "noun"
+  },
+  "god": {
+    "rank": 1056,
+    "translation": "god",
+    "partOfSpeech": "noun"
+  },
+  "bybel": {
+    "rank": 1057,
+    "translation": "Bible",
+    "partOfSpeech": "noun"
+  },
+  "hel": {
+    "rank": 1058,
+    "translation": "hell",
+    "partOfSpeech": "noun"
+  },
+  "siel": {
+    "rank": 1059,
+    "translation": "soul",
+    "partOfSpeech": "noun"
+  },
+  "gees": {
+    "rank": 1060,
+    "translation": "spirit",
+    "partOfSpeech": "noun"
+  },
+  "engel": {
+    "rank": 1061,
+    "translation": "angel",
+    "partOfSpeech": "noun"
+  },
+  "duiwel": {
+    "rank": 1062,
+    "translation": "devil",
+    "partOfSpeech": "noun"
+  },
+  "sonde": {
+    "rank": 1063,
+    "translation": "sin",
+    "partOfSpeech": "noun"
+  },
+  "vergifnis": {
+    "rank": 1064,
+    "translation": "forgiveness",
+    "partOfSpeech": "noun"
+  },
+  "redding": {
+    "rank": 1065,
+    "translation": "salvation",
+    "partOfSpeech": "noun"
+  },
+  "ewigheid": {
+    "rank": 1066,
+    "translation": "eternity",
+    "partOfSpeech": "noun"
+  },
+  "meditasie": {
+    "rank": 1067,
+    "translation": "meditation",
+    "partOfSpeech": "noun"
+  },
+  "aanbidding": {
+    "rank": 1068,
+    "translation": "worship",
+    "partOfSpeech": "noun"
+  },
+  "dankbaarheid": {
+    "rank": 1069,
+    "translation": "gratitude",
+    "partOfSpeech": "noun"
+  },
+  "kennis": {
+    "rank": 1071,
+    "translation": "knowledge",
+    "partOfSpeech": "noun"
+  },
+  "begrip": {
+    "rank": 1072,
+    "translation": "understanding",
+    "partOfSpeech": "noun"
+  },
+  "insig": {
+    "rank": 1073,
+    "translation": "insight",
+    "partOfSpeech": "noun"
+  },
+  "bewustheid": {
+    "rank": 1074,
+    "translation": "awareness",
+    "partOfSpeech": "noun"
+  },
+  "waarneming": {
+    "rank": 1624,
+    "translation": "observation",
+    "partOfSpeech": "noun"
+  },
+  "observasie": {
+    "rank": 1076,
+    "translation": "observation",
+    "partOfSpeech": "noun"
+  },
+  "interpretasie": {
+    "rank": 1077,
+    "translation": "interpretation",
+    "partOfSpeech": "noun"
+  },
+  "beskrywing": {
+    "rank": 1079,
+    "translation": "description",
+    "partOfSpeech": "noun"
+  },
+  "definisie": {
+    "rank": 1080,
+    "translation": "definition",
+    "partOfSpeech": "noun"
+  },
+  "betekenis": {
+    "rank": 1081,
+    "translation": "meaning",
+    "partOfSpeech": "noun"
+  },
+  "sin": {
+    "rank": 1082,
+    "translation": "sense/sentence",
+    "partOfSpeech": "noun"
+  },
+  "konsep": {
+    "rank": 1083,
+    "translation": "concept",
+    "partOfSpeech": "noun"
+  },
+  "idee": {
+    "rank": 1084,
+    "translation": "idea",
+    "partOfSpeech": "noun"
+  },
+  "gedagte": {
+    "rank": 1085,
+    "translation": "thought",
+    "partOfSpeech": "noun"
+  },
+  "mening": {
+    "rank": 1086,
+    "translation": "opinion",
+    "partOfSpeech": "noun"
+  },
+  "perspektief": {
+    "rank": 1088,
+    "translation": "perspective",
+    "partOfSpeech": "noun"
+  },
+  "standpunt": {
+    "rank": 1089,
+    "translation": "viewpoint",
+    "partOfSpeech": "noun"
+  },
+  "argument": {
+    "rank": 1090,
+    "translation": "argument",
+    "partOfSpeech": "noun"
+  },
+  "logika": {
+    "rank": 1091,
+    "translation": "logic",
+    "partOfSpeech": "noun"
+  },
+  "bewys": {
+    "rank": 1092,
+    "translation": "proof",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "e": {
+        "rank": 1626,
+        "translation": "evidence"
+      }
+    }
+  },
+  "getuienis": {
+    "rank": 1093,
+    "translation": "testimony",
+    "partOfSpeech": "noun"
+  },
+  "feit": {
+    "rank": 1094,
+    "translation": "fact",
+    "partOfSpeech": "noun"
+  },
+  "leuen": {
+    "rank": 1096,
+    "translation": "lie",
+    "partOfSpeech": "noun"
+  },
+  "bedrog": {
+    "rank": 1097,
+    "translation": "deceit",
+    "partOfSpeech": "noun"
+  },
+  "misleiding": {
+    "rank": 1098,
+    "translation": "deception",
+    "partOfSpeech": "noun"
+  },
+  "illusie": {
+    "rank": 1099,
+    "translation": "illusion",
+    "partOfSpeech": "noun"
+  },
+  "fantasie": {
+    "rank": 1100,
+    "translation": "fantasy",
+    "partOfSpeech": "noun"
+  },
+  "verbeelding": {
+    "rank": 1101,
+    "translation": "imagination",
+    "partOfSpeech": "noun"
+  },
+  "kreatiwiteit": {
+    "rank": 1102,
+    "translation": "creativity",
+    "partOfSpeech": "noun"
+  },
+  "innovasie": {
+    "rank": 1103,
+    "translation": "innovation",
+    "partOfSpeech": "noun"
+  },
+  "uitvinding": {
+    "rank": 1104,
+    "translation": "invention",
+    "partOfSpeech": "noun"
+  },
+  "wetenskap": {
+    "rank": 1105,
+    "translation": "science",
+    "partOfSpeech": "noun"
+  },
+  "tegnologie": {
+    "rank": 1106,
+    "translation": "technology",
+    "partOfSpeech": "noun"
+  },
+  "wiskunde": {
+    "rank": 1107,
+    "translation": "mathematics",
+    "partOfSpeech": "noun"
+  },
+  "fisika": {
+    "rank": 1108,
+    "translation": "physics",
+    "partOfSpeech": "noun"
+  },
+  "chemie": {
+    "rank": 1109,
+    "translation": "chemistry",
+    "partOfSpeech": "noun"
+  },
+  "biologie": {
+    "rank": 1110,
+    "translation": "biology",
+    "partOfSpeech": "noun"
+  },
+  "geografie": {
+    "rank": 1111,
+    "translation": "geography",
+    "partOfSpeech": "noun"
+  },
+  "ekologie": {
+    "rank": 1112,
+    "translation": "ecology",
+    "partOfSpeech": "noun"
+  },
+  "omgewing": {
+    "rank": 1113,
+    "translation": "environment",
+    "partOfSpeech": "noun"
+  },
+  "natuur": {
+    "rank": 1114,
+    "translation": "nature",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "lik": {
+        "rank": 713,
+        "translation": "natural",
+        "partOfSpeech": "adjective"
+      }
+    }
+  },
+  "klimaat": {
+    "rank": 1115,
+    "translation": "climate",
+    "partOfSpeech": "noun"
+  },
+  "temperatuur": {
+    "rank": 1672,
+    "translation": "temperature",
+    "partOfSpeech": "noun"
+  },
+  "storm": {
+    "rank": 1117,
+    "translation": "storm",
+    "partOfSpeech": "noun"
+  },
+  "donderstorm": {
+    "rank": 1118,
+    "translation": "thunderstorm",
+    "partOfSpeech": "noun"
+  },
+  "bliksem": {
+    "rank": 1119,
+    "translation": "lightning",
+    "partOfSpeech": "noun"
+  },
+  "aardbewing": {
+    "rank": 1742,
+    "translation": "earthquake",
+    "partOfSpeech": "noun"
+  },
+  "vloed": {
+    "rank": 1747,
+    "translation": "flood",
+    "partOfSpeech": "noun"
+  },
+  "besoedeling": {
+    "rank": 1718,
+    "translation": "pollution",
+    "partOfSpeech": "noun"
+  },
+  "afval": {
+    "rank": 1124,
+    "translation": "waste",
+    "partOfSpeech": "noun"
+  },
+  "rommel": {
+    "rank": 1125,
+    "translation": "rubbish",
+    "partOfSpeech": "noun"
+  },
+  "herwinning": {
+    "rank": 1719,
+    "translation": "recycling",
+    "partOfSpeech": "noun"
+  },
+  "bewaring": {
+    "rank": 1717,
+    "translation": "conservation",
+    "partOfSpeech": "noun"
+  },
+  "energie": {
+    "rank": 1128,
+    "translation": "energy",
+    "partOfSpeech": "noun"
+  },
+  "elektrisiteit": {
+    "rank": 1129,
+    "translation": "electricity",
+    "partOfSpeech": "noun"
+  },
+  "krag": {
+    "rank": 1669,
+    "translation": "force",
+    "partOfSpeech": "noun"
+  },
+  "brandstof": {
+    "rank": 1131,
+    "translation": "fuel",
+    "partOfSpeech": "noun"
+  },
+  "olie": {
+    "rank": 1132,
+    "translation": "oil",
+    "partOfSpeech": "noun"
+  },
+  "gas": {
+    "rank": 1677,
+    "translation": "gas",
+    "partOfSpeech": "noun"
+  },
+  "steenkool": {
+    "rank": 1134,
+    "translation": "coal",
+    "partOfSpeech": "noun"
+  },
+  "hulpbron": {
+    "rank": 1135,
+    "translation": "resource",
+    "partOfSpeech": "noun"
+  },
+  "mineraal": {
+    "rank": 1136,
+    "translation": "mineral",
+    "partOfSpeech": "noun"
+  },
+  "metaal": {
+    "rank": 1137,
+    "translation": "metal",
+    "partOfSpeech": "noun"
+  },
+  "goud": {
+    "rank": 1138,
+    "translation": "gold",
+    "partOfSpeech": "noun"
+  },
+  "silwer": {
+    "rank": 1139,
+    "translation": "silver",
+    "partOfSpeech": "noun"
+  },
+  "yster": {
+    "rank": 1140,
+    "translation": "iron",
+    "partOfSpeech": "noun"
+  },
+  "koper": {
+    "rank": 1141,
+    "translation": "copper",
+    "partOfSpeech": "noun"
+  },
+  "diamant": {
+    "rank": 1142,
+    "translation": "diamond",
+    "partOfSpeech": "noun"
+  },
+  "juweel": {
+    "rank": 1143,
+    "translation": "jewel",
+    "partOfSpeech": "noun"
+  },
+  "ring": {
+    "rank": 1144,
+    "translation": "ring",
+    "partOfSpeech": "noun"
+  },
+  "halssnoer": {
+    "rank": 1145,
+    "translation": "necklace",
+    "partOfSpeech": "noun"
+  },
+  "armband": {
+    "rank": 1146,
+    "translation": "bracelet",
+    "partOfSpeech": "noun"
+  },
+  "oorbel": {
+    "rank": 1147,
+    "translation": "earring",
+    "partOfSpeech": "noun"
+  },
+  "horlosie": {
+    "rank": 1148,
+    "translation": "watch",
+    "partOfSpeech": "noun"
+  },
+  "klok": {
+    "rank": 1149,
+    "translation": "clock",
+    "partOfSpeech": "noun"
+  },
+  "alarm": {
+    "rank": 1150,
+    "translation": "alarm",
+    "partOfSpeech": "noun"
+  },
+  "nota": {
+    "rank": 1151,
+    "translation": "note",
+    "partOfSpeech": "noun"
+  },
+  "lys": {
+    "rank": 1152,
+    "translation": "list",
+    "partOfSpeech": "noun"
+  },
+  "rooster": {
+    "rank": 1153,
+    "translation": "schedule/grid",
+    "partOfSpeech": "noun"
+  },
+  "kalender": {
+    "rank": 1154,
+    "translation": "calendar",
+    "partOfSpeech": "noun"
+  },
+  "dagboek": {
+    "rank": 1155,
+    "translation": "diary",
+    "partOfSpeech": "noun"
+  },
+  "joernaal": {
+    "rank": 1156,
+    "translation": "journal",
+    "partOfSpeech": "noun"
+  },
+  "verslag": {
+    "rank": 1157,
+    "translation": "report",
+    "partOfSpeech": "noun"
+  },
+  "dokument": {
+    "rank": 1158,
+    "translation": "document",
+    "partOfSpeech": "noun"
+  },
+  "sertifikaat": {
+    "rank": 1159,
+    "translation": "certificate",
+    "partOfSpeech": "noun"
+  },
+  "diploma": {
+    "rank": 1160,
+    "translation": "diploma",
+    "partOfSpeech": "noun"
+  },
+  "graad": {
+    "rank": 1161,
+    "translation": "degree",
+    "partOfSpeech": "noun"
+  },
+  "kwalifikasie": {
+    "rank": 1162,
+    "translation": "qualification",
+    "partOfSpeech": "noun"
+  },
+  "ervaring": {
+    "rank": 1163,
+    "translation": "experience",
+    "partOfSpeech": "noun"
+  },
+  "vaardigheid": {
+    "rank": 1164,
+    "translation": "skill",
+    "partOfSpeech": "noun"
+  },
+  "talent": {
+    "rank": 1165,
+    "translation": "talent",
+    "partOfSpeech": "noun"
+  },
+  "gawe": {
+    "rank": 1166,
+    "translation": "gift/talent",
+    "partOfSpeech": "noun"
+  },
+  "vermoë": {
+    "rank": 1167,
+    "translation": "ability",
+    "partOfSpeech": "noun"
+  },
+  "kapasiteit": {
+    "rank": 1168,
+    "translation": "capacity",
+    "partOfSpeech": "noun"
+  },
+  "potensiaal": {
+    "rank": 1169,
+    "translation": "potential",
+    "partOfSpeech": "noun"
+  },
+  "sterkpunt": {
+    "rank": 1170,
+    "translation": "strength",
+    "partOfSpeech": "noun"
+  },
+  "swakpunt": {
+    "rank": 1171,
+    "translation": "weakness",
+    "partOfSpeech": "noun"
+  },
+  "beperking": {
+    "rank": 1172,
+    "translation": "limitation",
+    "partOfSpeech": "noun"
+  },
+  "struikelblok": {
+    "rank": 1173,
+    "translation": "obstacle",
+    "partOfSpeech": "noun"
+  },
+  "hindernis": {
+    "rank": 1174,
+    "translation": "hindrance",
+    "partOfSpeech": "noun"
+  },
+  "twyfel": {
+    "rank": 1178,
+    "translation": "doubt",
+    "partOfSpeech": "noun"
+  },
+  "oortuiging": {
+    "rank": 1180,
+    "translation": "conviction",
+    "partOfSpeech": "noun"
+  },
+  "beginsel": {
+    "rank": 1181,
+    "translation": "principle",
+    "partOfSpeech": "noun"
+  },
+  "norm": {
+    "rank": 1182,
+    "translation": "norm",
+    "partOfSpeech": "noun"
+  },
+  "standaard": {
+    "rank": 1183,
+    "translation": "standard",
+    "partOfSpeech": "noun"
+  },
+  "maatstaf": {
+    "rank": 1184,
+    "translation": "criterion",
+    "partOfSpeech": "noun"
+  },
+  "reël": {
+    "rank": 1185,
+    "translation": "rule",
+    "partOfSpeech": "noun"
+  },
+  "grondwet": {
+    "rank": 1186,
+    "translation": "constitution",
+    "partOfSpeech": "noun"
+  },
+  "verdrag": {
+    "rank": 1187,
+    "translation": "treaty",
+    "partOfSpeech": "noun"
+  },
+  "protokol": {
+    "rank": 1188,
+    "translation": "protocol",
+    "partOfSpeech": "noun"
+  },
+  "afspraak": {
+    "rank": 1189,
+    "translation": "appointment/agreement",
+    "partOfSpeech": "noun"
+  },
+  "vergadering": {
+    "rank": 1190,
+    "translation": "meeting",
+    "partOfSpeech": "noun"
+  },
+  "konferensie": {
+    "rank": 1191,
+    "translation": "conference",
+    "partOfSpeech": "noun"
+  },
+  "seminaar": {
+    "rank": 1192,
+    "translation": "seminar",
+    "partOfSpeech": "noun"
+  },
+  "toespraak": {
+    "rank": 1194,
+    "translation": "speech",
+    "partOfSpeech": "noun"
+  },
+  "aankondiging": {
+    "rank": 1195,
+    "translation": "announcement",
+    "partOfSpeech": "noun"
+  },
+  "verklaring": {
+    "rank": 1196,
+    "translation": "statement",
+    "partOfSpeech": "noun"
+  },
+  "kommunikasie": {
+    "rank": 1197,
+    "translation": "communication",
+    "partOfSpeech": "noun"
+  },
+  "gesprek": {
+    "rank": 1198,
+    "translation": "conversation",
+    "partOfSpeech": "noun"
+  },
+  "dialoog": {
+    "rank": 1199,
+    "translation": "dialogue",
+    "partOfSpeech": "noun"
+  },
+  "debat": {
+    "rank": 1200,
+    "translation": "debate",
+    "partOfSpeech": "noun"
+  },
+  "onderhandeling": {
+    "rank": 1201,
+    "translation": "negotiation",
+    "partOfSpeech": "noun"
+  },
+  "kompromie": {
+    "rank": 1202,
+    "translation": "compromise",
+    "partOfSpeech": "noun"
+  },
+  "verkiesing": {
+    "rank": 1204,
+    "translation": "election",
+    "partOfSpeech": "noun"
+  },
+  "referendum": {
+    "rank": 1205,
+    "translation": "referendum",
+    "partOfSpeech": "noun"
+  },
+  "demokrasie": {
+    "rank": 1206,
+    "translation": "democracy",
+    "partOfSpeech": "noun"
+  },
+  "regering": {
+    "rank": 1207,
+    "translation": "government",
+    "partOfSpeech": "noun"
+  },
+  "parlement": {
+    "rank": 1208,
+    "translation": "parliament",
+    "partOfSpeech": "noun"
+  },
+  "kabinet": {
+    "rank": 1209,
+    "translation": "cabinet",
+    "partOfSpeech": "noun"
+  },
+  "president": {
+    "rank": 1210,
+    "translation": "president",
+    "partOfSpeech": "noun"
+  },
+  "minister": {
+    "rank": 1211,
+    "translation": "minister",
+    "partOfSpeech": "noun"
+  },
+  "premier": {
+    "rank": 1212,
+    "translation": "premier",
+    "partOfSpeech": "noun"
+  },
+  "burgemeester": {
+    "rank": 1213,
+    "translation": "mayor",
+    "partOfSpeech": "noun"
+  },
+  "raadslid": {
+    "rank": 1214,
+    "translation": "councillor",
+    "partOfSpeech": "noun"
+  },
+  "politikus": {
+    "rank": 1215,
+    "translation": "politician",
+    "partOfSpeech": "noun"
+  },
+  "opposisie": {
+    "rank": 1216,
+    "translation": "opposition",
+    "partOfSpeech": "noun"
+  },
+  "koalisie": {
+    "rank": 1217,
+    "translation": "coalition",
+    "partOfSpeech": "noun"
+  },
+  "wetgewing": {
+    "rank": 1218,
+    "translation": "legislation",
+    "partOfSpeech": "noun"
+  },
+  "administrasie": {
+    "rank": 1219,
+    "translation": "administration",
+    "partOfSpeech": "noun"
+  },
+  "burokrasie": {
+    "rank": 1220,
+    "translation": "bureaucracy",
+    "partOfSpeech": "noun"
+  },
+  "departement": {
+    "rank": 1221,
+    "translation": "department",
+    "partOfSpeech": "noun"
+  },
+  "munisipaliteit": {
+    "rank": 1222,
+    "translation": "municipality",
+    "partOfSpeech": "noun"
+  },
+  "provinsie": {
+    "rank": 1223,
+    "translation": "province",
+    "partOfSpeech": "noun"
+  },
+  "distrik": {
+    "rank": 1224,
+    "translation": "district",
+    "partOfSpeech": "noun"
+  },
+  "streek": {
+    "rank": 1225,
+    "translation": "region",
+    "partOfSpeech": "noun"
+  },
+  "gebied": {
+    "rank": 1226,
+    "translation": "area",
+    "partOfSpeech": "noun"
+  },
+  "wyk": {
+    "rank": 1227,
+    "translation": "ward/neighbourhood",
+    "partOfSpeech": "noun"
+  },
+  "voorstad": {
+    "rank": 1228,
+    "translation": "suburb",
+    "partOfSpeech": "noun"
+  },
+  "dorp": {
+    "rank": 1229,
+    "translation": "town",
+    "partOfSpeech": "noun"
+  },
+  "dorpie": {
+    "rank": 1230,
+    "translation": "village",
+    "partOfSpeech": "noun"
+  },
+  "nedersetting": {
+    "rank": 1231,
+    "translation": "settlement",
+    "partOfSpeech": "noun"
+  },
+  "gemeenskap": {
+    "rank": 1232,
+    "translation": "community",
+    "partOfSpeech": "noun"
+  },
+  "bevolking": {
+    "rank": 1233,
+    "translation": "population",
+    "partOfSpeech": "noun"
+  },
+  "inwoner": {
+    "rank": 1234,
+    "translation": "resident",
+    "partOfSpeech": "noun"
+  },
+  "burger": {
+    "rank": 1235,
+    "translation": "citizen",
+    "partOfSpeech": "noun"
+  },
+  "vreemdeling": {
+    "rank": 1236,
+    "translation": "stranger/foreigner",
+    "partOfSpeech": "noun"
+  },
+  "immigrant": {
+    "rank": 1237,
+    "translation": "immigrant",
+    "partOfSpeech": "noun"
+  },
+  "vlugteling": {
+    "rank": 1238,
+    "translation": "refugee",
+    "partOfSpeech": "noun"
+  },
+  "nasionaliteit": {
+    "rank": 1239,
+    "translation": "nationality",
+    "partOfSpeech": "noun"
+  },
+  "burgerskap": {
+    "rank": 1240,
+    "translation": "citizenship",
+    "partOfSpeech": "noun"
+  },
+  "paspoort": {
+    "rank": 1241,
+    "translation": "passport",
+    "partOfSpeech": "noun"
+  },
+  "visum": {
+    "rank": 1242,
+    "translation": "visa",
+    "partOfSpeech": "noun"
+  },
+  "permit": {
+    "rank": 1243,
+    "translation": "permit",
+    "partOfSpeech": "noun"
+  },
+  "lisensie": {
+    "rank": 1244,
+    "translation": "license",
+    "partOfSpeech": "noun"
+  },
+  "registrasie": {
+    "rank": 1245,
+    "translation": "registration",
+    "partOfSpeech": "noun"
+  },
+  "aansoek": {
+    "rank": 1246,
+    "translation": "application",
+    "partOfSpeech": "noun"
+  },
+  "testament": {
+    "rank": 1247,
+    "translation": "will",
+    "partOfSpeech": "noun"
+  },
+  "boedel": {
+    "rank": 1248,
+    "translation": "estate",
+    "partOfSpeech": "noun"
+  },
+  "erfgenaam": {
+    "rank": 1249,
+    "translation": "heir",
+    "partOfSpeech": "noun"
+  },
+  "begunstigde": {
+    "rank": 1250,
+    "translation": "beneficiary",
+    "partOfSpeech": "noun"
+  },
+  "voog": {
+    "rank": 1251,
+    "translation": "guardian",
+    "partOfSpeech": "noun"
+  },
+  "verteenwoordiger": {
+    "rank": 1252,
+    "translation": "representative",
+    "partOfSpeech": "noun"
+  },
+  "prokureur": {
+    "rank": 1253,
+    "translation": "attorney",
+    "partOfSpeech": "noun"
+  },
+  "advokaat": {
+    "rank": 1254,
+    "translation": "advocate",
+    "partOfSpeech": "noun"
+  },
+  "regter": {
+    "rank": 1255,
+    "translation": "judge",
+    "partOfSpeech": "noun"
+  },
+  "hof": {
+    "rank": 1256,
+    "translation": "court",
+    "partOfSpeech": "noun"
+  },
+  "saak": {
+    "rank": 1258,
+    "translation": "case",
+    "partOfSpeech": "noun"
+  },
+  "aanklag": {
+    "rank": 1259,
+    "translation": "charge",
+    "partOfSpeech": "noun"
+  },
+  "skuldigbevinding": {
+    "rank": 1260,
+    "translation": "conviction",
+    "partOfSpeech": "noun"
+  },
+  "vonnis": {
+    "rank": 1956,
+    "translation": "sentence",
+    "partOfSpeech": "noun"
+  },
+  "straf": {
+    "rank": 1262,
+    "translation": "punishment",
+    "partOfSpeech": "noun"
+  },
+  "boete": {
+    "rank": 1263,
+    "translation": "fine",
+    "partOfSpeech": "noun"
+  },
+  "tronkstraf": {
+    "rank": 1264,
+    "translation": "imprisonment",
+    "partOfSpeech": "noun"
+  },
+  "gevangenis": {
+    "rank": 1265,
+    "translation": "prison",
+    "partOfSpeech": "noun"
+  },
+  "misdaad": {
+    "rank": 1266,
+    "translation": "crime",
+    "partOfSpeech": "noun"
+  },
+  "misdadiger": {
+    "rank": 1267,
+    "translation": "criminal",
+    "partOfSpeech": "noun"
+  },
+  "dief": {
+    "rank": 1268,
+    "translation": "thief",
+    "partOfSpeech": "noun"
+  },
+  "rower": {
+    "rank": 1269,
+    "translation": "robber",
+    "partOfSpeech": "noun"
+  },
+  "moordenaar": {
+    "rank": 1270,
+    "translation": "murderer",
+    "partOfSpeech": "noun"
+  },
+  "slagoffer": {
+    "rank": 1271,
+    "translation": "victim",
+    "partOfSpeech": "noun"
+  },
+  "getuie": {
+    "rank": 1272,
+    "translation": "witness",
+    "partOfSpeech": "noun"
+  },
+  "speurder": {
+    "rank": 1273,
+    "translation": "detective",
+    "partOfSpeech": "noun"
+  },
+  "polisie": {
+    "rank": 1274,
+    "translation": "police",
+    "partOfSpeech": "noun"
+  },
+  "polisieman": {
+    "rank": 1275,
+    "translation": "policeman",
+    "partOfSpeech": "noun"
+  },
+  "arrestasie": {
+    "rank": 1276,
+    "translation": "arrest",
+    "partOfSpeech": "noun"
+  },
+  "aanhouding": {
+    "rank": 1277,
+    "translation": "detention",
+    "partOfSpeech": "noun"
+  },
+  "vingerafdruk": {
+    "rank": 1278,
+    "translation": "fingerprint",
+    "partOfSpeech": "noun"
+  },
+  "moord": {
+    "rank": 1279,
+    "translation": "murder",
+    "partOfSpeech": "noun"
+  },
+  "selfmoord": {
+    "rank": 1280,
+    "translation": "suicide",
+    "partOfSpeech": "noun"
+  },
+  "ambulans": {
+    "rank": 1281,
+    "translation": "ambulance",
+    "partOfSpeech": "noun"
+  },
+  "brandweer": {
+    "rank": 1282,
+    "translation": "fire department",
+    "partOfSpeech": "noun"
+  },
+  "reddingsdiens": {
+    "rank": 1283,
+    "translation": "rescue service",
+    "partOfSpeech": "noun"
+  },
+  "hulp": {
+    "rank": 1284,
+    "translation": "help",
+    "partOfSpeech": "noun"
+  },
+  "bystand": {
+    "rank": 1285,
+    "translation": "assistance",
+    "partOfSpeech": "noun"
+  },
+  "ondersteuning": {
+    "rank": 1286,
+    "translation": "support",
+    "partOfSpeech": "noun"
+  },
+  "verdediging": {
+    "rank": 1287,
+    "translation": "defense",
+    "partOfSpeech": "noun"
+  },
+  "weermag": {
+    "rank": 1288,
+    "translation": "military",
+    "partOfSpeech": "noun"
+  },
+  "leër": {
+    "rank": 1289,
+    "translation": "army",
+    "partOfSpeech": "noun"
+  },
+  "vloot": {
+    "rank": 1290,
+    "translation": "navy",
+    "partOfSpeech": "noun"
+  },
+  "lugmag": {
+    "rank": 1291,
+    "translation": "air force",
+    "partOfSpeech": "noun"
+  },
+  "soldaat": {
+    "rank": 1292,
+    "translation": "soldier",
+    "partOfSpeech": "noun"
+  },
+  "offisier": {
+    "rank": 1293,
+    "translation": "officer",
+    "partOfSpeech": "noun"
+  },
+  "generaal": {
+    "rank": 1294,
+    "translation": "general",
+    "partOfSpeech": "noun"
+  },
+  "kolonel": {
+    "rank": 1295,
+    "translation": "colonel",
+    "partOfSpeech": "noun"
+  },
+  "majoor": {
+    "rank": 1296,
+    "translation": "major",
+    "partOfSpeech": "noun"
+  },
+  "kaptein": {
+    "rank": 1297,
+    "translation": "captain",
+    "partOfSpeech": "noun"
+  },
+  "luitenant": {
+    "rank": 1298,
+    "translation": "lieutenant",
+    "partOfSpeech": "noun"
+  },
+  "sersant": {
+    "rank": 1299,
+    "translation": "sergeant",
+    "partOfSpeech": "noun"
+  },
+  "korporaal": {
+    "rank": 1300,
+    "translation": "corporal",
+    "partOfSpeech": "noun"
+  },
+  "oorlog": {
+    "rank": 1301,
+    "translation": "war",
+    "partOfSpeech": "noun"
+  },
+  "vrede": {
+    "rank": 1302,
+    "translation": "peace",
+    "partOfSpeech": "noun"
+  },
+  "wapenstilstand": {
+    "rank": 1303,
+    "translation": "ceasefire",
+    "partOfSpeech": "noun"
+  },
+  "bondgenoot": {
+    "rank": 1304,
+    "translation": "ally",
+    "partOfSpeech": "noun"
+  },
+  "vyand": {
+    "rank": 1305,
+    "translation": "enemy",
+    "partOfSpeech": "noun"
+  },
+  "geveg": {
+    "rank": 1306,
+    "translation": "battle",
+    "partOfSpeech": "noun"
+  },
+  "aanval": {
+    "rank": 1307,
+    "translation": "attack",
+    "partOfSpeech": "noun"
+  },
+  "terugtog": {
+    "rank": 1308,
+    "translation": "retreat",
+    "partOfSpeech": "noun"
+  },
+  "wapen": {
+    "rank": 1310,
+    "translation": "weapon",
+    "partOfSpeech": "noun"
+  },
+  "geweer": {
+    "rank": 1311,
+    "translation": "rifle",
+    "partOfSpeech": "noun"
+  },
+  "pistool": {
+    "rank": 1312,
+    "translation": "pistol",
+    "partOfSpeech": "noun"
+  },
+  "bom": {
+    "rank": 1313,
+    "translation": "bomb",
+    "partOfSpeech": "noun"
+  },
+  "tenk": {
+    "rank": 1314,
+    "translation": "tank",
+    "partOfSpeech": "noun"
+  },
+  "helikopter": {
+    "rank": 1315,
+    "translation": "helicopter",
+    "partOfSpeech": "noun"
+  },
+  "missiel": {
+    "rank": 1316,
+    "translation": "missile",
+    "partOfSpeech": "noun"
+  },
+  "bevel": {
+    "rank": 1317,
+    "translation": "command",
+    "partOfSpeech": "noun"
+  },
+  "taktiek": {
+    "rank": 1318,
+    "translation": "tactics",
+    "partOfSpeech": "noun"
+  },
+  "missie": {
+    "rank": 1319,
+    "translation": "mission",
+    "partOfSpeech": "noun"
+  },
+  "taak": {
+    "rank": 1320,
+    "translation": "task",
+    "partOfSpeech": "noun"
+  },
+  "opdrag": {
+    "rank": 1321,
+    "translation": "assignment",
+    "partOfSpeech": "noun"
+  },
+  "voorbereiding": {
+    "rank": 1322,
+    "translation": "preparation",
+    "partOfSpeech": "noun"
+  },
+  "opleiding": {
+    "rank": 1323,
+    "translation": "training",
+    "partOfSpeech": "noun"
+  },
+  "praktyk": {
+    "rank": 1324,
+    "translation": "practice",
+    "partOfSpeech": "noun"
+  },
+  "teorie": {
+    "rank": 1621,
+    "translation": "theory",
+    "partOfSpeech": "noun"
+  },
+  "voorbeeld": {
+    "rank": 1326,
+    "translation": "example",
+    "partOfSpeech": "noun"
+  },
+  "geval": {
+    "rank": 1327,
+    "translation": "case",
+    "partOfSpeech": "noun"
+  },
+  "situasie": {
+    "rank": 1328,
+    "translation": "situation",
+    "partOfSpeech": "noun"
+  },
+  "omstandighede": {
+    "rank": 1329,
+    "translation": "circumstances",
+    "partOfSpeech": "noun"
+  },
+  "konteks": {
+    "rank": 1330,
+    "translation": "context",
+    "partOfSpeech": "noun"
+  },
+  "agtergrond": {
+    "rank": 1331,
+    "translation": "background",
+    "partOfSpeech": "noun"
+  },
+  "kroniek": {
+    "rank": 1332,
+    "translation": "chronicle",
+    "partOfSpeech": "noun"
+  },
+  "storie": {
+    "rank": 1333,
+    "translation": "story",
+    "partOfSpeech": "noun"
+  },
+  "verhaal": {
+    "rank": 1334,
+    "translation": "tale",
+    "partOfSpeech": "noun"
+  },
+  "anekdote": {
+    "rank": 1335,
+    "translation": "anecdote",
+    "partOfSpeech": "noun"
+  },
+  "mite": {
+    "rank": 1336,
+    "translation": "myth",
+    "partOfSpeech": "noun"
+  },
+  "legende": {
+    "rank": 1337,
+    "translation": "legend",
+    "partOfSpeech": "noun"
+  },
+  "roman": {
+    "rank": 1338,
+    "translation": "novel",
+    "partOfSpeech": "noun"
+  },
+  "kortverhaal": {
+    "rank": 1339,
+    "translation": "short story",
+    "partOfSpeech": "noun"
+  },
+  "gedig": {
+    "rank": 1340,
+    "translation": "poem",
+    "partOfSpeech": "noun"
+  },
+  "poësie": {
+    "rank": 1341,
+    "translation": "poetry",
+    "partOfSpeech": "noun"
+  },
+  "literatuur": {
+    "rank": 1342,
+    "translation": "literature",
+    "partOfSpeech": "noun"
+  },
+  "drama": {
+    "rank": 1343,
+    "translation": "drama",
+    "partOfSpeech": "noun"
+  },
+  "toneelstuk": {
+    "rank": 1344,
+    "translation": "play",
+    "partOfSpeech": "noun"
+  },
+  "verhoog": {
+    "rank": 1345,
+    "translation": "stage",
+    "partOfSpeech": "noun"
+  },
+  "teater": {
+    "rank": 1346,
+    "translation": "theater",
+    "partOfSpeech": "noun"
+  },
+  "akteur": {
+    "rank": 1347,
+    "translation": "actor",
+    "partOfSpeech": "noun"
+  },
+  "aktrise": {
+    "rank": 1348,
+    "translation": "actress",
+    "partOfSpeech": "noun"
+  },
+  "regisseur": {
+    "rank": 1349,
+    "translation": "director",
+    "partOfSpeech": "noun"
+  },
+  "produsent": {
+    "rank": 1350,
+    "translation": "producer",
+    "partOfSpeech": "noun"
+  },
+  "draaiboek": {
+    "rank": 1351,
+    "translation": "screenplay",
+    "partOfSpeech": "noun"
+  },
+  "toneel": {
+    "rank": 1352,
+    "translation": "scene",
+    "partOfSpeech": "noun"
+  },
+  "hoofkarakter": {
+    "rank": 1353,
+    "translation": "main character",
+    "partOfSpeech": "noun"
+  },
+  "skurk": {
+    "rank": 1354,
+    "translation": "villain",
+    "partOfSpeech": "noun"
+  },
+  "held": {
+    "rank": 1355,
+    "translation": "hero",
+    "partOfSpeech": "noun"
+  },
+  "heldin": {
+    "rank": 1356,
+    "translation": "heroine",
+    "partOfSpeech": "noun"
+  },
+  "intrige": {
+    "rank": 1357,
+    "translation": "plot",
+    "partOfSpeech": "noun"
+  },
+  "klimaks": {
+    "rank": 1358,
+    "translation": "climax",
+    "partOfSpeech": "noun"
+  },
+  "einde": {
+    "rank": 1359,
+    "translation": "ending",
+    "partOfSpeech": "noun"
+  },
+  "slot": {
+    "rank": 1360,
+    "translation": "conclusion",
+    "partOfSpeech": "noun"
+  },
+  "tema": {
+    "rank": 1361,
+    "translation": "theme",
+    "partOfSpeech": "noun"
+  },
+  "boodskap": {
+    "rank": 1362,
+    "translation": "message",
+    "partOfSpeech": "noun"
+  },
+  "moraal": {
+    "rank": 1363,
+    "translation": "moral",
+    "partOfSpeech": "noun"
+  },
+  "les": {
+    "rank": 1364,
+    "translation": "lesson",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "ing": {
+        "rank": 1193,
+        "translation": "lecture"
+      }
+    }
+  },
+  "kritiek": {
+    "rank": 1365,
+    "translation": "criticism",
+    "partOfSpeech": "noun"
+  },
+  "resensie": {
+    "rank": 1366,
+    "translation": "review",
+    "partOfSpeech": "noun"
+  },
+  "kommentaar": {
+    "rank": 1367,
+    "translation": "commentary",
+    "partOfSpeech": "noun"
+  },
+  "oordeel": {
+    "rank": 1368,
+    "translation": "judgment",
+    "partOfSpeech": "noun"
+  },
+  "beoordeling": {
+    "rank": 1369,
+    "translation": "assessment",
+    "partOfSpeech": "noun"
+  },
+  "gradering": {
+    "rank": 1370,
+    "translation": "grading",
+    "partOfSpeech": "noun"
+  },
+  "poging": {
+    "rank": 1372,
+    "translation": "attempt",
+    "partOfSpeech": "noun"
+  },
+  "inspanning": {
+    "rank": 1373,
+    "translation": "effort",
+    "partOfSpeech": "noun"
+  },
+  "arbeid": {
+    "rank": 1374,
+    "translation": "labor",
+    "partOfSpeech": "noun"
+  },
+  "pos": {
+    "rank": 1375,
+    "translation": "post/job",
+    "partOfSpeech": "noun"
+  },
+  "betrekking": {
+    "rank": 1376,
+    "translation": "position",
+    "partOfSpeech": "noun"
+  },
+  "loopbaan": {
+    "rank": 1378,
+    "translation": "career",
+    "partOfSpeech": "noun"
+  },
+  "afdanking": {
+    "rank": 1380,
+    "translation": "dismissal",
+    "partOfSpeech": "noun"
+  },
+  "aftrede": {
+    "rank": 1381,
+    "translation": "retirement",
+    "partOfSpeech": "noun"
+  },
+  "werkgewer": {
+    "rank": 1382,
+    "translation": "employer",
+    "partOfSpeech": "noun"
+  },
+  "werknemer": {
+    "rank": 1383,
+    "translation": "employee",
+    "partOfSpeech": "noun"
+  },
+  "personeel": {
+    "rank": 1384,
+    "translation": "staff",
+    "partOfSpeech": "noun"
+  },
+  "kollega": {
+    "rank": 1385,
+    "translation": "colleague",
+    "partOfSpeech": "noun"
+  },
+  "baas": {
+    "rank": 1386,
+    "translation": "boss",
+    "partOfSpeech": "noun"
+  },
+  "bestuurder": {
+    "rank": 1387,
+    "translation": "manager",
+    "partOfSpeech": "noun"
+  },
+  "direkteur": {
+    "rank": 1388,
+    "translation": "director",
+    "partOfSpeech": "noun"
+  },
+  "sekretaris": {
+    "rank": 1389,
+    "translation": "secretary",
+    "partOfSpeech": "noun"
+  },
+  "assistent": {
+    "rank": 1390,
+    "translation": "assistant",
+    "partOfSpeech": "noun"
+  },
+  "adviseur": {
+    "rank": 1391,
+    "translation": "advisor",
+    "partOfSpeech": "noun"
+  },
+  "konsultant": {
+    "rank": 1392,
+    "translation": "consultant",
+    "partOfSpeech": "noun"
+  },
+  "spesialis": {
+    "rank": 1393,
+    "translation": "specialist",
+    "partOfSpeech": "noun"
+  },
+  "deskundige": {
+    "rank": 1394,
+    "translation": "expert",
+    "partOfSpeech": "noun"
+  },
+  "tegnikus": {
+    "rank": 1395,
+    "translation": "technician",
+    "partOfSpeech": "noun"
+  },
+  "ingenieur": {
+    "rank": 1396,
+    "translation": "engineer",
+    "partOfSpeech": "noun"
+  },
+  "argitek": {
+    "rank": 1397,
+    "translation": "architect",
+    "partOfSpeech": "noun"
+  },
+  "ontwerper": {
+    "rank": 1398,
+    "translation": "designer",
+    "partOfSpeech": "noun"
+  },
+  "kunstenaar": {
+    "rank": 1399,
+    "translation": "artist",
+    "partOfSpeech": "noun"
+  },
+  "skilder": {
+    "rank": 1400,
+    "translation": "painter",
+    "partOfSpeech": "noun"
+  },
+  "beeldhouer": {
+    "rank": 1401,
+    "translation": "sculptor",
+    "partOfSpeech": "noun"
+  },
+  "fotograaf": {
+    "rank": 1402,
+    "translation": "photographer",
+    "partOfSpeech": "noun"
+  },
+  "musikant": {
+    "rank": 1403,
+    "translation": "musician",
+    "partOfSpeech": "noun"
+  },
+  "sanger": {
+    "rank": 1404,
+    "translation": "singer",
+    "partOfSpeech": "noun"
+  },
+  "komponis": {
+    "rank": 1405,
+    "translation": "composer",
+    "partOfSpeech": "noun"
+  },
+  "dirigent": {
+    "rank": 1406,
+    "translation": "conductor",
+    "partOfSpeech": "noun"
+  },
+  "danser": {
+    "rank": 1407,
+    "translation": "dancer",
+    "partOfSpeech": "noun"
+  },
+  "skrywer": {
+    "rank": 1408,
+    "translation": "writer",
+    "partOfSpeech": "noun"
+  },
+  "outeur": {
+    "rank": 1990,
+    "translation": "author",
+    "partOfSpeech": "noun"
+  },
+  "joernalis": {
+    "rank": 1410,
+    "translation": "journalist",
+    "partOfSpeech": "noun"
+  },
+  "verslaggewer": {
+    "rank": 1411,
+    "translation": "reporter",
+    "partOfSpeech": "noun"
+  },
+  "redakteur": {
+    "rank": 1992,
+    "translation": "editor",
+    "partOfSpeech": "noun"
+  },
+  "uitgewer": {
+    "rank": 1991,
+    "translation": "publisher",
+    "partOfSpeech": "noun"
+  },
+  "vertaler": {
+    "rank": 1414,
+    "translation": "translator",
+    "partOfSpeech": "noun"
+  },
+  "tolk": {
+    "rank": 1415,
+    "translation": "interpreter",
+    "partOfSpeech": "noun"
+  },
+  "onderwyser": {
+    "rank": 1416,
+    "translation": "teacher",
+    "partOfSpeech": "noun"
+  },
+  "dosent": {
+    "rank": 1417,
+    "translation": "lecturer",
+    "partOfSpeech": "noun"
+  },
+  "professor": {
+    "rank": 1418,
+    "translation": "professor",
+    "partOfSpeech": "noun"
+  },
+  "navorser": {
+    "rank": 1419,
+    "translation": "researcher",
+    "partOfSpeech": "noun"
+  },
+  "wetenskaplike": {
+    "rank": 1420,
+    "translation": "scientist",
+    "partOfSpeech": "noun"
+  },
+  "dokter": {
+    "rank": 1421,
+    "translation": "doctor",
+    "partOfSpeech": "noun"
+  },
+  "geneesheer": {
+    "rank": 1422,
+    "translation": "physician",
+    "partOfSpeech": "noun"
+  },
+  "chirurg": {
+    "rank": 1423,
+    "translation": "surgeon",
+    "partOfSpeech": "noun"
+  },
+  "verpleegster": {
+    "rank": 1424,
+    "translation": "nurse",
+    "partOfSpeech": "noun"
+  },
+  "apteek": {
+    "rank": 1425,
+    "translation": "pharmacy",
+    "partOfSpeech": "noun"
+  },
+  "apteker": {
+    "rank": 1426,
+    "translation": "pharmacist",
+    "partOfSpeech": "noun"
+  },
+  "tandarts": {
+    "rank": 1427,
+    "translation": "dentist",
+    "partOfSpeech": "noun"
+  },
+  "oogarts": {
+    "rank": 1428,
+    "translation": "ophthalmologist",
+    "partOfSpeech": "noun"
+  },
+  "psigiater": {
+    "rank": 1429,
+    "translation": "psychiatrist",
+    "partOfSpeech": "noun"
+  },
+  "sielkundige": {
+    "rank": 1430,
+    "translation": "psychologist",
+    "partOfSpeech": "noun"
+  },
+  "terapeut": {
+    "rank": 1431,
+    "translation": "therapist",
+    "partOfSpeech": "noun"
+  },
+  "fisioterapeut": {
+    "rank": 1432,
+    "translation": "physiotherapist",
+    "partOfSpeech": "noun"
+  },
+  "dieetkundige": {
+    "rank": 1433,
+    "translation": "dietician",
+    "partOfSpeech": "noun"
+  },
+  "veearts": {
+    "rank": 1434,
+    "translation": "veterinarian",
+    "partOfSpeech": "noun"
+  },
+  "boer": {
+    "rank": 1435,
+    "translation": "farmer",
+    "partOfSpeech": "noun"
+  },
+  "tuinier": {
+    "rank": 1436,
+    "translation": "gardener",
+    "partOfSpeech": "noun"
+  },
+  "visser": {
+    "rank": 1437,
+    "translation": "fisherman",
+    "partOfSpeech": "noun"
+  },
+  "jagter": {
+    "rank": 1438,
+    "translation": "hunter",
+    "partOfSpeech": "noun"
+  },
+  "mynwerker": {
+    "rank": 1439,
+    "translation": "miner",
+    "partOfSpeech": "noun"
+  },
+  "fabriekswerker": {
+    "rank": 1440,
+    "translation": "factory worker",
+    "partOfSpeech": "noun"
+  },
+  "ambagsman": {
+    "rank": 1441,
+    "translation": "craftsman",
+    "partOfSpeech": "noun"
+  },
+  "skrynwerker": {
+    "rank": 1442,
+    "translation": "carpenter",
+    "partOfSpeech": "noun"
+  },
+  "loodgieter": {
+    "rank": 1443,
+    "translation": "plumber",
+    "partOfSpeech": "noun"
+  },
+  "elektrisiën": {
+    "rank": 1444,
+    "translation": "electrician",
+    "partOfSpeech": "noun"
+  },
+  "meganieker": {
+    "rank": 1445,
+    "translation": "mechanic",
+    "partOfSpeech": "noun"
+  },
+  "bouer": {
+    "rank": 1446,
+    "translation": "builder",
+    "partOfSpeech": "noun"
+  },
+  "metselaar": {
+    "rank": 1447,
+    "translation": "mason",
+    "partOfSpeech": "noun"
+  },
+  "kleremaker": {
+    "rank": 1448,
+    "translation": "tailor",
+    "partOfSpeech": "noun"
+  },
+  "skoenmaker": {
+    "rank": 1449,
+    "translation": "shoemaker",
+    "partOfSpeech": "noun"
+  },
+  "bakker": {
+    "rank": 1450,
+    "translation": "baker",
+    "partOfSpeech": "noun"
+  },
+  "slagter": {
+    "rank": 1451,
+    "translation": "butcher",
+    "partOfSpeech": "noun"
+  },
+  "kok": {
+    "rank": 1452,
+    "translation": "cook",
+    "partOfSpeech": "noun"
+  },
+  "sjef": {
+    "rank": 1453,
+    "translation": "chef",
+    "partOfSpeech": "noun"
+  },
+  "kelner": {
+    "rank": 1454,
+    "translation": "waiter",
+    "partOfSpeech": "noun"
+  },
+  "kelnerin": {
+    "rank": 1455,
+    "translation": "waitress",
+    "partOfSpeech": "noun"
+  },
+  "barman": {
+    "rank": 1456,
+    "translation": "bartender",
+    "partOfSpeech": "noun"
+  },
+  "resepsionist": {
+    "rank": 1457,
+    "translation": "receptionist",
+    "partOfSpeech": "noun"
+  },
+  "gids": {
+    "rank": 1848,
+    "translation": "folder/directory",
+    "partOfSpeech": "noun"
+  },
+  "vlieënier": {
+    "rank": 1459,
+    "translation": "pilot",
+    "partOfSpeech": "noun"
+  },
+  "matroos": {
+    "rank": 1460,
+    "translation": "sailor",
+    "partOfSpeech": "noun"
+  },
+  "kondukteur": {
+    "rank": 1461,
+    "translation": "conductor",
+    "partOfSpeech": "noun"
+  },
+  "bankier": {
+    "rank": 1462,
+    "translation": "banker",
+    "partOfSpeech": "noun"
+  },
+  "rekenmeester": {
+    "rank": 1463,
+    "translation": "accountant",
+    "partOfSpeech": "noun"
+  },
+  "ekonoom": {
+    "rank": 1464,
+    "translation": "economist",
+    "partOfSpeech": "noun"
+  },
+  "makelaar": {
+    "rank": 1465,
+    "translation": "broker",
+    "partOfSpeech": "noun"
+  },
+  "sakeman": {
+    "rank": 1466,
+    "translation": "businessman",
+    "partOfSpeech": "noun"
+  },
+  "entrepreneur": {
+    "rank": 1467,
+    "translation": "entrepreneur",
+    "partOfSpeech": "noun"
+  },
+  "belegger": {
+    "rank": 1468,
+    "translation": "investor",
+    "partOfSpeech": "noun"
+  },
+  "aandeelhouer": {
+    "rank": 1469,
+    "translation": "shareholder",
+    "partOfSpeech": "noun"
+  },
+  "voorsitter": {
+    "rank": 1470,
+    "translation": "chairman",
+    "partOfSpeech": "noun"
+  },
+  "raad": {
+    "rank": 1472,
+    "translation": "council",
+    "partOfSpeech": "noun"
+  },
+  "komitee": {
+    "rank": 1473,
+    "translation": "committee",
+    "partOfSpeech": "noun"
+  },
+  "lid": {
+    "rank": 1474,
+    "translation": "member",
+    "partOfSpeech": "noun"
+  },
+  "tesourier": {
+    "rank": 1475,
+    "translation": "treasurer",
+    "partOfSpeech": "noun"
+  },
+  "notule": {
+    "rank": 1476,
+    "translation": "minutes",
+    "partOfSpeech": "noun"
+  },
+  "agenda": {
+    "rank": 1477,
+    "translation": "agenda",
+    "partOfSpeech": "noun"
+  },
+  "voorstel": {
+    "rank": 1478,
+    "translation": "proposal",
+    "partOfSpeech": "noun"
+  },
+  "resolusie": {
+    "rank": 1479,
+    "translation": "resolution",
+    "partOfSpeech": "noun"
+  },
+  "meerderheid": {
+    "rank": 1480,
+    "translation": "majority",
+    "partOfSpeech": "noun"
+  },
+  "konsensus": {
+    "rank": 1482,
+    "translation": "consensus",
+    "partOfSpeech": "noun"
+  },
+  "akkoord": {
+    "rank": 1483,
+    "translation": "agreement",
+    "partOfSpeech": "noun"
+  },
+  "dispuut": {
+    "rank": 1484,
+    "translation": "dispute",
+    "partOfSpeech": "noun"
+  },
+  "geskil": {
+    "rank": 1485,
+    "translation": "dispute",
+    "partOfSpeech": "noun"
+  },
+  "botsing": {
+    "rank": 1486,
+    "translation": "clash",
+    "partOfSpeech": "noun"
+  },
+  "noodtoestand": {
+    "rank": 1487,
+    "translation": "emergency",
+    "partOfSpeech": "noun"
+  },
+  "chaos": {
+    "rank": 1488,
+    "translation": "chaos",
+    "partOfSpeech": "noun"
+  },
+  "verwarring": {
+    "rank": 1489,
+    "translation": "confusion",
+    "partOfSpeech": "noun"
+  },
+  "wanorde": {
+    "rank": 1490,
+    "translation": "disorder",
+    "partOfSpeech": "noun"
+  },
+  "onstabiliteit": {
+    "rank": 1491,
+    "translation": "instability",
+    "partOfSpeech": "noun"
+  },
+  "oproer": {
+    "rank": 1492,
+    "translation": "riot",
+    "partOfSpeech": "noun"
+  },
+  "opstand": {
+    "rank": 1493,
+    "translation": "uprising",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "ing": {
+        "rank": 1540,
+        "translation": "resurrection"
+      }
+    }
+  },
+  "staatsgreep": {
+    "rank": 1494,
+    "translation": "coup",
+    "partOfSpeech": "noun"
+  },
+  "versoening": {
+    "rank": 1495,
+    "translation": "reconciliation",
+    "partOfSpeech": "noun"
+  },
+  "geregtigheid": {
+    "rank": 1496,
+    "translation": "justice",
+    "partOfSpeech": "noun"
+  },
+  "billikheid": {
+    "rank": 1497,
+    "translation": "fairness",
+    "partOfSpeech": "noun"
+  },
+  "soewereiniteit": {
+    "rank": 1501,
+    "translation": "sovereignty",
+    "partOfSpeech": "noun"
+  },
+  "outonomie": {
+    "rank": 1502,
+    "translation": "autonomy",
+    "partOfSpeech": "noun"
+  },
+  "selfbeskikking": {
+    "rank": 1503,
+    "translation": "self-determination",
+    "partOfSpeech": "noun"
+  },
+  "menseregte": {
+    "rank": 1504,
+    "translation": "human rights",
+    "partOfSpeech": "noun"
+  },
+  "diktatuur": {
+    "rank": 1505,
+    "translation": "dictatorship",
+    "partOfSpeech": "noun"
+  },
+  "tirannie": {
+    "rank": 1506,
+    "translation": "tyranny",
+    "partOfSpeech": "noun"
+  },
+  "onderdrukking": {
+    "rank": 1507,
+    "translation": "oppression",
+    "partOfSpeech": "noun"
+  },
+  "diskriminasie": {
+    "rank": 1508,
+    "translation": "discrimination",
+    "partOfSpeech": "noun"
+  },
+  "vooroordeel": {
+    "rank": 1509,
+    "translation": "prejudice",
+    "partOfSpeech": "noun"
+  },
+  "rassisme": {
+    "rank": 1510,
+    "translation": "racism",
+    "partOfSpeech": "noun"
+  },
+  "verdraagsaamheid": {
+    "rank": 1511,
+    "translation": "tolerance",
+    "partOfSpeech": "noun"
+  },
+  "respek": {
+    "rank": 1512,
+    "translation": "respect",
+    "partOfSpeech": "noun"
+  },
+  "waardigheid": {
+    "rank": 1513,
+    "translation": "dignity",
+    "partOfSpeech": "noun"
+  },
+  "eer": {
+    "rank": 1514,
+    "translation": "honor",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "lik": {
+        "rank": 453,
+        "translation": "honest",
+        "partOfSpeech": "adjective"
+      }
+    }
+  },
+  "integriteit": {
+    "rank": 1515,
+    "translation": "integrity",
+    "partOfSpeech": "noun"
+  },
+  "lojaliteit": {
+    "rank": 1516,
+    "translation": "loyalty",
+    "partOfSpeech": "noun"
+  },
+  "aanspreeklikheid": {
+    "rank": 1517,
+    "translation": "accountability",
+    "partOfSpeech": "noun"
+  },
+  "deursigtigheid": {
+    "rank": 1518,
+    "translation": "transparency",
+    "partOfSpeech": "noun"
+  },
+  "korrupsie": {
+    "rank": 1519,
+    "translation": "corruption",
+    "partOfSpeech": "noun"
+  },
+  "onreg": {
+    "rank": 1520,
+    "translation": "injustice",
+    "partOfSpeech": "noun"
+  },
+  "mishandeling": {
+    "rank": 1521,
+    "translation": "abuse",
+    "partOfSpeech": "noun"
+  },
+  "geweld": {
+    "rank": 1522,
+    "translation": "violence",
+    "partOfSpeech": "noun"
+  },
+  "aggressie": {
+    "rank": 1523,
+    "translation": "aggression",
+    "partOfSpeech": "noun"
+  },
+  "intimidasie": {
+    "rank": 1524,
+    "translation": "intimidation",
+    "partOfSpeech": "noun"
+  },
+  "teistering": {
+    "rank": 1525,
+    "translation": "harassment",
+    "partOfSpeech": "noun"
+  },
+  "vervolging": {
+    "rank": 1526,
+    "translation": "persecution",
+    "partOfSpeech": "noun"
+  },
+  "marteling": {
+    "rank": 1527,
+    "translation": "torture",
+    "partOfSpeech": "noun"
+  },
+  "lyding": {
+    "rank": 1528,
+    "translation": "suffering",
+    "partOfSpeech": "noun"
+  },
+  "skok": {
+    "rank": 1529,
+    "translation": "shock",
+    "partOfSpeech": "noun"
+  },
+  "wanhoop": {
+    "rank": 1530,
+    "translation": "despair",
+    "partOfSpeech": "noun"
+  },
+  "rou": {
+    "rank": 1531,
+    "translation": "mourning",
+    "partOfSpeech": "noun"
+  },
+  "afskeid": {
+    "rank": 1532,
+    "translation": "farewell",
+    "partOfSpeech": "noun"
+  },
+  "sterfgeval": {
+    "rank": 1533,
+    "translation": "death case",
+    "partOfSpeech": "noun"
+  },
+  "roudiens": {
+    "rank": 1534,
+    "translation": "memorial service",
+    "partOfSpeech": "noun"
+  },
+  "begraafplaas": {
+    "rank": 1535,
+    "translation": "cemetery",
+    "partOfSpeech": "noun"
+  },
+  "graf": {
+    "rank": 1536,
+    "translation": "grave",
+    "partOfSpeech": "noun"
+  },
+  "grafsteen": {
+    "rank": 1537,
+    "translation": "gravestone",
+    "partOfSpeech": "noun"
+  },
+  "hiernamaals": {
+    "rank": 1538,
+    "translation": "afterlife",
+    "partOfSpeech": "noun"
+  },
+  "paradys": {
+    "rank": 1539,
+    "translation": "paradise",
+    "partOfSpeech": "noun"
+  },
+  "verlossing": {
+    "rank": 1541,
+    "translation": "redemption",
+    "partOfSpeech": "noun"
+  },
+  "genade": {
+    "rank": 1542,
+    "translation": "grace",
+    "partOfSpeech": "noun"
+  },
+  "seën": {
+    "rank": 1543,
+    "translation": "blessing",
+    "partOfSpeech": "noun",
+    "suffixes": {
+      "ing": {
+        "rank": 1048,
+        "translation": "blessing"
+      }
+    }
+  },
+  "voorspoed": {
+    "rank": 1544,
+    "translation": "prosperity",
+    "partOfSpeech": "noun"
+  },
+  "welvaart": {
+    "rank": 1545,
+    "translation": "wealth",
+    "partOfSpeech": "noun"
+  },
+  "rykdom": {
+    "rank": 1546,
+    "translation": "riches",
+    "partOfSpeech": "noun"
+  },
+  "oorvloed": {
+    "rank": 1547,
+    "translation": "abundance",
+    "partOfSpeech": "noun"
+  },
+  "tevredenheid": {
+    "rank": 1548,
+    "translation": "contentment",
+    "partOfSpeech": "noun"
+  },
+  "waardering": {
+    "rank": 1549,
+    "translation": "appreciation",
+    "partOfSpeech": "noun"
+  },
+  "erkenning": {
+    "rank": 1550,
+    "translation": "recognition",
+    "partOfSpeech": "noun"
+  },
+  "lof": {
+    "rank": 1551,
+    "translation": "praise",
+    "partOfSpeech": "noun"
+  },
+  "kompliment": {
+    "rank": 1552,
+    "translation": "compliment",
+    "partOfSpeech": "noun"
+  },
+  "aanmoediging": {
+    "rank": 1553,
+    "translation": "encouragement",
+    "partOfSpeech": "noun"
+  },
+  "inspirasie": {
+    "rank": 1554,
+    "translation": "inspiration",
+    "partOfSpeech": "noun"
+  },
+  "motivering": {
+    "rank": 1555,
+    "translation": "motivation",
+    "partOfSpeech": "noun"
+  },
+  "entoesiasme": {
+    "rank": 1556,
+    "translation": "enthusiasm",
+    "partOfSpeech": "noun"
+  },
+  "passie": {
+    "rank": 1557,
+    "translation": "passion",
+    "partOfSpeech": "noun"
+  },
+  "toewyding": {
+    "rank": 1558,
+    "translation": "dedication",
+    "partOfSpeech": "noun"
+  },
+  "verbintenis": {
+    "rank": 1559,
+    "translation": "commitment",
+    "partOfSpeech": "noun"
+  },
+  "vasberadenheid": {
+    "rank": 1560,
+    "translation": "determination",
+    "partOfSpeech": "noun"
+  },
+  "deursettingsvermoë": {
+    "rank": 1561,
+    "translation": "perseverance",
+    "partOfSpeech": "noun"
+  },
+  "volharding": {
+    "rank": 1562,
+    "translation": "persistence",
+    "partOfSpeech": "noun"
+  },
+  "geduld": {
+    "rank": 1563,
+    "translation": "patience",
+    "partOfSpeech": "noun"
+  },
+  "moed": {
+    "rank": 1564,
+    "translation": "courage",
+    "partOfSpeech": "noun"
+  },
+  "heldedaad": {
+    "rank": 1566,
+    "translation": "heroism",
+    "partOfSpeech": "noun"
+  },
+  "opoffering": {
+    "rank": 1567,
+    "translation": "sacrifice",
+    "partOfSpeech": "noun"
+  },
+  "onselfsugtigheid": {
+    "rank": 1568,
+    "translation": "selflessness",
+    "partOfSpeech": "noun"
+  },
+  "vrygewigheid": {
+    "rank": 1569,
+    "translation": "generosity",
+    "partOfSpeech": "noun"
+  },
+  "goedhartigheid": {
+    "rank": 1570,
+    "translation": "kindness",
+    "partOfSpeech": "noun"
+  },
+  "empatie": {
+    "rank": 1571,
+    "translation": "empathy",
+    "partOfSpeech": "noun"
+  },
+  "medelye": {
+    "rank": 1572,
+    "translation": "compassion",
+    "partOfSpeech": "noun"
+  },
+  "simpatie": {
+    "rank": 1573,
+    "translation": "sympathy",
+    "partOfSpeech": "noun"
+  },
+  "aanvaarding": {
+    "rank": 1574,
+    "translation": "acceptance",
+    "partOfSpeech": "noun"
+  },
+  "insluiting": {
+    "rank": 1575,
+    "translation": "inclusion",
+    "partOfSpeech": "noun"
+  },
+  "saamhorigheid": {
+    "rank": 1576,
+    "translation": "togetherness",
+    "partOfSpeech": "noun"
+  },
+  "solidariteit": {
+    "rank": 1578,
+    "translation": "solidarity",
+    "partOfSpeech": "noun"
+  },
+  "broederskap": {
+    "rank": 1579,
+    "translation": "brotherhood",
+    "partOfSpeech": "noun"
+  },
+  "vriendskap": {
+    "rank": 1580,
+    "translation": "friendship",
+    "partOfSpeech": "noun"
+  },
+  "kameraderie": {
+    "rank": 1581,
+    "translation": "camaraderie",
+    "partOfSpeech": "noun"
+  },
+  "toegeneentheid": {
+    "rank": 1582,
+    "translation": "affection",
+    "partOfSpeech": "noun"
+  },
+  "teerheid": {
+    "rank": 1583,
+    "translation": "tenderness",
+    "partOfSpeech": "noun"
+  },
+  "intimiteit": {
+    "rank": 1585,
+    "translation": "intimacy",
+    "partOfSpeech": "noun"
+  },
+  "verbondenheid": {
+    "rank": 1586,
+    "translation": "connection",
+    "partOfSpeech": "noun"
+  },
+  "geborgenheid": {
+    "rank": 1588,
+    "translation": "security/safety",
+    "partOfSpeech": "noun"
+  },
+  "stabiliteit": {
+    "rank": 1589,
+    "translation": "stability",
+    "partOfSpeech": "noun"
+  },
+  "versorging": {
+    "rank": 1590,
+    "translation": "care",
+    "partOfSpeech": "noun"
+  },
+  "kalmte": {
+    "rank": 1591,
+    "translation": "calmness",
+    "partOfSpeech": "noun"
+  },
+  "harmonie": {
+    "rank": 1593,
+    "translation": "harmony",
+    "partOfSpeech": "noun"
+  },
+  "welstand": {
+    "rank": 1594,
+    "translation": "wellbeing",
+    "partOfSpeech": "noun"
+  },
+  "plesier": {
+    "rank": 1595,
+    "translation": "pleasure",
+    "partOfSpeech": "noun"
+  },
+  "genot": {
+    "rank": 1596,
+    "translation": "enjoyment",
+    "partOfSpeech": "noun"
+  },
+  "vervulling": {
+    "rank": 1597,
+    "translation": "fulfillment",
+    "partOfSpeech": "noun"
+  },
+  "doel": {
+    "rank": 1598,
+    "translation": "purpose",
+    "partOfSpeech": "noun"
+  },
+  "universiteit": {
+    "rank": 1599,
+    "translation": "university",
+    "partOfSpeech": "noun"
+  },
+  "kollege": {
+    "rank": 1600,
+    "translation": "college",
+    "partOfSpeech": "noun"
+  },
+  "akademie": {
+    "rank": 1601,
+    "translation": "academy",
+    "partOfSpeech": "noun"
+  },
+  "biblioteek": {
+    "rank": 1602,
+    "translation": "library",
+    "partOfSpeech": "noun"
+  },
+  "laboratorium": {
+    "rank": 1603,
+    "translation": "laboratory",
+    "partOfSpeech": "noun"
+  },
+  "klaskamer": {
+    "rank": 1604,
+    "translation": "classroom",
+    "partOfSpeech": "noun"
+  },
+  "lesinglokaal": {
+    "rank": 1605,
+    "translation": "lecture hall",
+    "partOfSpeech": "noun"
+  },
+  "kurrikulum": {
+    "rank": 1606,
+    "translation": "curriculum",
+    "partOfSpeech": "noun"
+  },
+  "sillabus": {
+    "rank": 1607,
+    "translation": "syllabus",
+    "partOfSpeech": "noun"
+  },
+  "vak": {
+    "rank": 1608,
+    "translation": "subject",
+    "partOfSpeech": "noun"
+  },
+  "kursus": {
+    "rank": 1609,
+    "translation": "course",
+    "partOfSpeech": "noun"
+  },
+  "leerstof": {
+    "rank": 1610,
+    "translation": "curriculum/subject matter",
+    "partOfSpeech": "noun"
+  },
+  "handboek": {
+    "rank": 1611,
+    "translation": "textbook",
+    "partOfSpeech": "noun"
+  },
+  "woordeboek": {
+    "rank": 1612,
+    "translation": "dictionary",
+    "partOfSpeech": "noun"
+  },
+  "ensiklopedie": {
+    "rank": 1613,
+    "translation": "encyclopedia",
+    "partOfSpeech": "noun"
+  },
+  "atlas": {
+    "rank": 1614,
+    "translation": "atlas",
+    "partOfSpeech": "noun"
+  },
+  "kaart": {
+    "rank": 1615,
+    "translation": "map/card",
+    "partOfSpeech": "noun"
+  },
+  "diagram": {
+    "rank": 1616,
+    "translation": "diagram",
+    "partOfSpeech": "noun"
+  },
+  "grafiek": {
+    "rank": 1617,
+    "translation": "graph",
+    "partOfSpeech": "noun"
+  },
+  "tabel": {
+    "rank": 1618,
+    "translation": "table/chart",
+    "partOfSpeech": "noun"
+  },
+  "formule": {
+    "rank": 1619,
+    "translation": "formula",
+    "partOfSpeech": "noun"
+  },
+  "hipotese": {
+    "rank": 1622,
+    "translation": "hypothesis",
+    "partOfSpeech": "noun"
+  },
+  "eksperiment": {
+    "rank": 1623,
+    "translation": "experiment",
+    "partOfSpeech": "noun"
+  },
+  "gevolgtrekking": {
+    "rank": 1982,
+    "translation": "conclusion",
+    "partOfSpeech": "noun"
+  },
+  "data": {
+    "rank": 1895,
+    "translation": "data",
+    "partOfSpeech": "noun"
+  },
+  "inligting": {
+    "rank": 1628,
+    "translation": "information",
+    "partOfSpeech": "noun"
+  },
+  "statistiek": {
+    "rank": 1629,
+    "translation": "statistics",
+    "partOfSpeech": "noun"
+  },
+  "mediaan": {
+    "rank": 1631,
+    "translation": "median",
+    "partOfSpeech": "noun"
+  },
+  "modus": {
+    "rank": 1632,
+    "translation": "mode",
+    "partOfSpeech": "noun"
+  },
+  "afwyking": {
+    "rank": 1633,
+    "translation": "deviation",
+    "partOfSpeech": "noun"
+  },
+  "korrelasie": {
+    "rank": 1634,
+    "translation": "correlation",
+    "partOfSpeech": "noun"
+  },
+  "tendens": {
+    "rank": 1635,
+    "translation": "tendency/trend",
+    "partOfSpeech": "noun"
+  },
+  "groeikoers": {
+    "rank": 1636,
+    "translation": "growth rate",
+    "partOfSpeech": "noun"
+  },
+  "indeks": {
+    "rank": 2000,
+    "translation": "index",
+    "partOfSpeech": "noun"
+  },
+  "breuk": {
+    "rank": 1639,
+    "translation": "fraction",
+    "partOfSpeech": "noun"
+  },
+  "desimaal": {
+    "rank": 1640,
+    "translation": "decimal",
+    "partOfSpeech": "noun"
+  },
+  "kwadraat": {
+    "rank": 1641,
+    "translation": "square",
+    "partOfSpeech": "noun"
+  },
+  "wortel": {
+    "rank": 1642,
+    "translation": "root",
+    "partOfSpeech": "noun"
+  },
+  "mag": {
+    "rank": 1643,
+    "translation": "power",
+    "partOfSpeech": "noun"
+  },
+  "eksponent": {
+    "rank": 1644,
+    "translation": "exponent",
+    "partOfSpeech": "noun"
+  },
+  "logaritme": {
+    "rank": 1645,
+    "translation": "logarithm",
+    "partOfSpeech": "noun"
+  },
+  "driehoek": {
+    "rank": 1646,
+    "translation": "triangle",
+    "partOfSpeech": "noun"
+  },
+  "vierkant": {
+    "rank": 1647,
+    "translation": "square",
+    "partOfSpeech": "noun"
+  },
+  "reghoek": {
+    "rank": 1648,
+    "translation": "rectangle",
+    "partOfSpeech": "noun"
+  },
+  "sirkel": {
+    "rank": 1649,
+    "translation": "circle",
+    "partOfSpeech": "noun"
+  },
+  "sfeer": {
+    "rank": 1650,
+    "translation": "sphere",
+    "partOfSpeech": "noun"
+  },
+  "kubus": {
+    "rank": 1651,
+    "translation": "cube",
+    "partOfSpeech": "noun"
+  },
+  "silinder": {
+    "rank": 1652,
+    "translation": "cylinder",
+    "partOfSpeech": "noun"
+  },
+  "kegel": {
+    "rank": 1653,
+    "translation": "cone",
+    "partOfSpeech": "noun"
+  },
+  "piramide": {
+    "rank": 1654,
+    "translation": "pyramid",
+    "partOfSpeech": "noun"
+  },
+  "hoek": {
+    "rank": 1655,
+    "translation": "angle/corner",
+    "partOfSpeech": "noun"
+  },
+  "lyn": {
+    "rank": 1656,
+    "translation": "line",
+    "partOfSpeech": "noun"
+  },
+  "oppervlakte": {
+    "rank": 1658,
+    "translation": "surface/area",
+    "partOfSpeech": "noun"
+  },
+  "volume": {
+    "rank": 1659,
+    "translation": "volume",
+    "partOfSpeech": "noun"
+  },
+  "omtrek": {
+    "rank": 1660,
+    "translation": "circumference",
+    "partOfSpeech": "noun"
+  },
+  "deursnee": {
+    "rank": 1661,
+    "translation": "diameter",
+    "partOfSpeech": "noun"
+  },
+  "radius": {
+    "rank": 1662,
+    "translation": "radius",
+    "partOfSpeech": "noun"
+  },
+  "swaartekrag": {
+    "rank": 1663,
+    "translation": "gravity",
+    "partOfSpeech": "noun"
+  },
+  "massa": {
+    "rank": 1664,
+    "translation": "mass",
+    "partOfSpeech": "noun"
+  },
+  "gewig": {
+    "rank": 1665,
+    "translation": "weight",
+    "partOfSpeech": "noun"
+  },
+  "digtheid": {
+    "rank": 1666,
+    "translation": "density",
+    "partOfSpeech": "noun"
+  },
+  "snelheid": {
+    "rank": 1667,
+    "translation": "speed/velocity",
+    "partOfSpeech": "noun"
+  },
+  "versnelling": {
+    "rank": 1668,
+    "translation": "acceleration",
+    "partOfSpeech": "noun"
+  },
+  "wrywing": {
+    "rank": 1670,
+    "translation": "friction",
+    "partOfSpeech": "noun"
+  },
+  "hitte": {
+    "rank": 1673,
+    "translation": "heat",
+    "partOfSpeech": "noun"
+  },
+  "koue": {
+    "rank": 1674,
+    "translation": "cold",
+    "partOfSpeech": "noun",
+    "prefixes": {
+      "ver": {
+        "rank": 982,
+        "translation": "cold"
+      }
+    }
+  },
+  "smeltpunt": {
+    "rank": 1675,
+    "translation": "melting point",
+    "partOfSpeech": "noun"
+  },
+  "kookpunt": {
+    "rank": 1676,
+    "translation": "boiling point",
+    "partOfSpeech": "noun"
+  },
+  "vloeistof": {
+    "rank": 1678,
+    "translation": "liquid",
+    "partOfSpeech": "noun"
+  },
+  "vastestof": {
+    "rank": 1679,
+    "translation": "solid",
+    "partOfSpeech": "noun"
+  },
+  "atoom": {
+    "rank": 1680,
+    "translation": "atom",
+    "partOfSpeech": "noun"
+  },
+  "molekuul": {
+    "rank": 1681,
+    "translation": "molecule",
+    "partOfSpeech": "noun"
+  },
+  "element": {
+    "rank": 1682,
+    "translation": "element",
+    "partOfSpeech": "noun"
+  },
+  "suur": {
+    "rank": 1686,
+    "translation": "acid",
+    "partOfSpeech": "noun"
+  },
+  "basis": {
+    "rank": 1687,
+    "translation": "base",
+    "partOfSpeech": "noun"
+  },
+  "oksidasie": {
+    "rank": 1689,
+    "translation": "oxidation",
+    "partOfSpeech": "noun"
+  },
+  "reduksie": {
+    "rank": 1690,
+    "translation": "reduction",
+    "partOfSpeech": "noun"
+  },
+  "sel": {
+    "rank": 1691,
+    "translation": "cell",
+    "partOfSpeech": "noun"
+  },
+  "kern": {
+    "rank": 1692,
+    "translation": "nucleus",
+    "partOfSpeech": "noun"
+  },
+  "membraan": {
+    "rank": 1693,
+    "translation": "membrane",
+    "partOfSpeech": "noun"
+  },
+  "organisme": {
+    "rank": 1694,
+    "translation": "organism",
+    "partOfSpeech": "noun"
+  },
+  "spesie": {
+    "rank": 1695,
+    "translation": "species",
+    "partOfSpeech": "noun"
+  },
+  "genus": {
+    "rank": 1696,
+    "translation": "genus",
+    "partOfSpeech": "noun"
+  },
+  "orde": {
+    "rank": 1698,
+    "translation": "order",
+    "partOfSpeech": "noun"
+  },
+  "koninkryk": {
+    "rank": 1700,
+    "translation": "kingdom",
+    "partOfSpeech": "noun"
+  },
+  "ekosisteem": {
+    "rank": 1701,
+    "translation": "ecosystem",
+    "partOfSpeech": "noun"
+  },
+  "habitat": {
+    "rank": 1702,
+    "translation": "habitat",
+    "partOfSpeech": "noun"
+  },
+  "bioom": {
+    "rank": 1703,
+    "translation": "biome",
+    "partOfSpeech": "noun"
+  },
+  "voedselketting": {
+    "rank": 1704,
+    "translation": "food chain",
+    "partOfSpeech": "noun"
+  },
+  "fotosintese": {
+    "rank": 1705,
+    "translation": "photosynthesis",
+    "partOfSpeech": "noun"
+  },
+  "respirasie": {
+    "rank": 1706,
+    "translation": "respiration",
+    "partOfSpeech": "noun"
+  },
+  "metabolisme": {
+    "rank": 1707,
+    "translation": "metabolism",
+    "partOfSpeech": "noun"
+  },
+  "gene": {
+    "rank": 1708,
+    "translation": "gene",
+    "partOfSpeech": "noun"
+  },
+  "chromosoom": {
+    "rank": 1709,
+    "translation": "chromosome",
+    "partOfSpeech": "noun"
+  },
+  "dns": {
+    "rank": 1710,
+    "translation": "DNA",
+    "partOfSpeech": "noun"
+  },
+  "mutasie": {
+    "rank": 1711,
+    "translation": "mutation",
+    "partOfSpeech": "noun"
+  },
+  "natuurlike seleksie": {
+    "rank": 1713,
+    "translation": "natural selection",
+    "partOfSpeech": "noun"
+  },
+  "uitsterwing": {
+    "rank": 1715,
+    "translation": "extinction",
+    "partOfSpeech": "noun"
+  },
+  "biodiversiteit": {
+    "rank": 1716,
+    "translation": "biodiversity",
+    "partOfSpeech": "noun"
+  },
+  "klimaatsverandering": {
+    "rank": 1721,
+    "translation": "climate change",
+    "partOfSpeech": "noun"
+  },
+  "aardverwarming": {
+    "rank": 1722,
+    "translation": "global warming",
+    "partOfSpeech": "noun"
+  },
+  "kweekhuiseffek": {
+    "rank": 1723,
+    "translation": "greenhouse effect",
+    "partOfSpeech": "noun"
+  },
+  "osoonlaag": {
+    "rank": 1724,
+    "translation": "ozone layer",
+    "partOfSpeech": "noun"
+  },
+  "atmosfeer": {
+    "rank": 1725,
+    "translation": "atmosphere",
+    "partOfSpeech": "noun"
+  },
+  "hidrosfeer": {
+    "rank": 1726,
+    "translation": "hydrosphere",
+    "partOfSpeech": "noun"
+  },
+  "litosfeer": {
+    "rank": 1727,
+    "translation": "lithosphere",
+    "partOfSpeech": "noun"
+  },
+  "biosfeer": {
+    "rank": 1728,
+    "translation": "biosphere",
+    "partOfSpeech": "noun"
+  },
+  "kontinent": {
+    "rank": 1729,
+    "translation": "continent",
+    "partOfSpeech": "noun"
+  },
+  "oseaan": {
+    "rank": 1730,
+    "translation": "ocean",
+    "partOfSpeech": "noun"
+  },
+  "eiland": {
+    "rank": 1731,
+    "translation": "island",
+    "partOfSpeech": "noun"
+  },
+  "skiereiland": {
+    "rank": 1732,
+    "translation": "peninsula",
+    "partOfSpeech": "noun"
+  },
+  "vallei": {
+    "rank": 1733,
+    "translation": "valley",
+    "partOfSpeech": "noun"
+  },
+  "plato": {
+    "rank": 1734,
+    "translation": "plateau",
+    "partOfSpeech": "noun"
+  },
+  "woestyn": {
+    "rank": 1736,
+    "translation": "desert",
+    "partOfSpeech": "noun"
+  },
+  "woud": {
+    "rank": 1737,
+    "translation": "forest",
+    "partOfSpeech": "noun"
+  },
+  "reënwoud": {
+    "rank": 1738,
+    "translation": "rainforest",
+    "partOfSpeech": "noun"
+  },
+  "savanne": {
+    "rank": 1739,
+    "translation": "savanna",
+    "partOfSpeech": "noun"
+  },
+  "toendra": {
+    "rank": 1740,
+    "translation": "tundra",
+    "partOfSpeech": "noun"
+  },
+  "vulkaan": {
+    "rank": 1741,
+    "translation": "volcano",
+    "partOfSpeech": "noun"
+  },
+  "tsoenami": {
+    "rank": 1743,
+    "translation": "tsunami",
+    "partOfSpeech": "noun"
+  },
+  "orkaan": {
+    "rank": 1744,
+    "translation": "hurricane",
+    "partOfSpeech": "noun"
+  },
+  "tornado": {
+    "rank": 1745,
+    "translation": "tornado",
+    "partOfSpeech": "noun"
+  },
+  "aardskuiwing": {
+    "rank": 1748,
+    "translation": "landslide",
+    "partOfSpeech": "noun"
+  },
+  "sneeustorm": {
+    "rank": 1749,
+    "translation": "blizzard",
+    "partOfSpeech": "noun"
+  },
+  "hael": {
+    "rank": 1750,
+    "translation": "hail",
+    "partOfSpeech": "noun"
+  },
+  "dou": {
+    "rank": 1751,
+    "translation": "dew",
+    "partOfSpeech": "noun"
+  },
+  "mis": {
+    "rank": 1752,
+    "translation": "fog/mist",
+    "partOfSpeech": "noun"
+  },
+  "ryp": {
+    "rank": 1753,
+    "translation": "frost",
+    "partOfSpeech": "noun"
+  },
+  "reënboog": {
+    "rank": 1754,
+    "translation": "rainbow",
+    "partOfSpeech": "noun"
+  },
+  "sonsopkoms": {
+    "rank": 1755,
+    "translation": "sunrise",
+    "partOfSpeech": "noun"
+  },
+  "sonsondergang": {
+    "rank": 1756,
+    "translation": "sunset",
+    "partOfSpeech": "noun"
+  },
+  "skemer": {
+    "rank": 1757,
+    "translation": "twilight",
+    "partOfSpeech": "noun"
+  },
+  "dagbreek": {
+    "rank": 1758,
+    "translation": "dawn",
+    "partOfSpeech": "noun"
+  },
+  "middernag": {
+    "rank": 1759,
+    "translation": "midnight",
+    "partOfSpeech": "noun"
+  },
+  "seisoen": {
+    "rank": 1761,
+    "translation": "season",
+    "partOfSpeech": "noun"
+  },
+  "ewenaar": {
+    "rank": 1762,
+    "translation": "equator",
+    "partOfSpeech": "noun"
+  },
+  "trope": {
+    "rank": 1763,
+    "translation": "tropics",
+    "partOfSpeech": "noun"
+  },
+  "poolsirkel": {
+    "rank": 1764,
+    "translation": "polar circle",
+    "partOfSpeech": "noun"
+  },
+  "noordpool": {
+    "rank": 1765,
+    "translation": "North Pole",
+    "partOfSpeech": "noun"
+  },
+  "suidpool": {
+    "rank": 1766,
+    "translation": "South Pole",
+    "partOfSpeech": "noun"
+  },
+  "antarktika": {
+    "rank": 1767,
+    "translation": "Antarctica",
+    "partOfSpeech": "noun"
+  },
+  "arktika": {
+    "rank": 1768,
+    "translation": "Arctic",
+    "partOfSpeech": "noun"
+  },
+  "gletser": {
+    "rank": 1769,
+    "translation": "glacier",
+    "partOfSpeech": "noun"
+  },
+  "ysberg": {
+    "rank": 1770,
+    "translation": "iceberg",
+    "partOfSpeech": "noun"
+  },
+  "poolkap": {
+    "rank": 1771,
+    "translation": "ice cap",
+    "partOfSpeech": "noun"
+  },
+  "permafrost": {
+    "rank": 1772,
+    "translation": "permafrost",
+    "partOfSpeech": "noun"
+  },
+  "sonnestelsel": {
+    "rank": 1773,
+    "translation": "solar system",
+    "partOfSpeech": "noun"
+  },
+  "planeet": {
+    "rank": 1774,
+    "translation": "planet",
+    "partOfSpeech": "noun"
+  },
+  "sterrestelsel": {
+    "rank": 1778,
+    "translation": "galaxy",
+    "partOfSpeech": "noun"
+  },
+  "melkweg": {
+    "rank": 1779,
+    "translation": "Milky Way",
+    "partOfSpeech": "noun"
+  },
+  "swart gat": {
+    "rank": 1780,
+    "translation": "black hole",
+    "partOfSpeech": "noun"
+  },
+  "asteroïde": {
+    "rank": 1781,
+    "translation": "asteroid",
+    "partOfSpeech": "noun"
+  },
+  "komeet": {
+    "rank": 1782,
+    "translation": "comet",
+    "partOfSpeech": "noun"
+  },
+  "meteoor": {
+    "rank": 1783,
+    "translation": "meteor",
+    "partOfSpeech": "noun"
+  },
+  "ruimte": {
+    "rank": 1784,
+    "translation": "space",
+    "partOfSpeech": "noun"
+  },
+  "heelal": {
+    "rank": 1785,
+    "translation": "universe",
+    "partOfSpeech": "noun"
+  },
+  "kosmos": {
+    "rank": 1786,
+    "translation": "cosmos",
+    "partOfSpeech": "noun"
+  },
+  "ligspoed": {
+    "rank": 1787,
+    "translation": "speed of light",
+    "partOfSpeech": "noun"
+  },
+  "ligjaar": {
+    "rank": 1788,
+    "translation": "light year",
+    "partOfSpeech": "noun"
+  },
+  "wentelbaan": {
+    "rank": 1789,
+    "translation": "orbit",
+    "partOfSpeech": "noun"
+  },
+  "gravitasie": {
+    "rank": 1790,
+    "translation": "gravitation",
+    "partOfSpeech": "noun"
+  },
+  "astronout": {
+    "rank": 1791,
+    "translation": "astronaut",
+    "partOfSpeech": "noun"
+  },
+  "ruimteskip": {
+    "rank": 1792,
+    "translation": "spaceship",
+    "partOfSpeech": "noun"
+  },
+  "ruimtestasie": {
+    "rank": 1793,
+    "translation": "space station",
+    "partOfSpeech": "noun"
+  },
+  "satelliet": {
+    "rank": 1794,
+    "translation": "satellite",
+    "partOfSpeech": "noun"
+  },
+  "teleskoop": {
+    "rank": 1795,
+    "translation": "telescope",
+    "partOfSpeech": "noun"
+  },
+  "mikroskoop": {
+    "rank": 1796,
+    "translation": "microscope",
+    "partOfSpeech": "noun"
+  },
+  "lens": {
+    "rank": 1797,
+    "translation": "lens",
+    "partOfSpeech": "noun"
+  },
+  "fokus": {
+    "rank": 1798,
+    "translation": "focus",
+    "partOfSpeech": "noun"
+  },
+  "spektrum": {
+    "rank": 1799,
+    "translation": "spectrum",
+    "partOfSpeech": "noun"
+  },
+  "golflengte": {
+    "rank": 1800,
+    "translation": "wavelength",
+    "partOfSpeech": "noun"
+  },
+  "frekwensie": {
+    "rank": 1801,
+    "translation": "frequency",
+    "partOfSpeech": "noun"
+  },
+  "amplitude": {
+    "rank": 1802,
+    "translation": "amplitude",
+    "partOfSpeech": "noun"
+  },
+  "vibrasie": {
+    "rank": 1803,
+    "translation": "vibration",
+    "partOfSpeech": "noun"
+  },
+  "resonansie": {
+    "rank": 1804,
+    "translation": "resonance",
+    "partOfSpeech": "noun"
+  },
+  "klank": {
+    "rank": 1805,
+    "translation": "sound",
+    "partOfSpeech": "noun"
+  },
+  "eggo": {
+    "rank": 1806,
+    "translation": "echo",
+    "partOfSpeech": "noun"
+  },
+  "ultraklank": {
+    "rank": 1807,
+    "translation": "ultrasound",
+    "partOfSpeech": "noun"
+  },
+  "infrarooi": {
+    "rank": 1808,
+    "translation": "infrared",
+    "partOfSpeech": "noun"
+  },
+  "ultraviolet": {
+    "rank": 1809,
+    "translation": "ultraviolet",
+    "partOfSpeech": "noun"
+  },
+  "x-strale": {
+    "rank": 1810,
+    "translation": "X-rays",
+    "partOfSpeech": "noun"
+  },
+  "radioaktiwiteit": {
+    "rank": 1811,
+    "translation": "radioactivity",
+    "partOfSpeech": "noun"
+  },
+  "straling": {
+    "rank": 1812,
+    "translation": "radiation",
+    "partOfSpeech": "noun"
+  },
+  "elektron": {
+    "rank": 1813,
+    "translation": "electron",
+    "partOfSpeech": "noun"
+  },
+  "proton": {
+    "rank": 1814,
+    "translation": "proton",
+    "partOfSpeech": "noun"
+  },
+  "neutron": {
+    "rank": 1815,
+    "translation": "neutron",
+    "partOfSpeech": "noun"
+  },
+  "ioon": {
+    "rank": 1816,
+    "translation": "ion",
+    "partOfSpeech": "noun"
+  },
+  "stroom": {
+    "rank": 1817,
+    "translation": "current/stream",
+    "partOfSpeech": "noun"
+  },
+  "weerstand": {
+    "rank": 1835,
+    "translation": "resistor",
+    "partOfSpeech": "noun"
+  },
+  "stroombaan": {
+    "rank": 1820,
+    "translation": "circuit",
+    "partOfSpeech": "noun"
+  },
+  "geleier": {
+    "rank": 1821,
+    "translation": "conductor",
+    "partOfSpeech": "noun"
+  },
+  "isolator": {
+    "rank": 1822,
+    "translation": "insulator",
+    "partOfSpeech": "noun"
+  },
+  "battery": {
+    "rank": 1823,
+    "translation": "battery",
+    "partOfSpeech": "noun"
+  },
+  "generator": {
+    "rank": 1824,
+    "translation": "generator",
+    "partOfSpeech": "noun"
+  },
+  "magneet": {
+    "rank": 1826,
+    "translation": "magnet",
+    "partOfSpeech": "noun"
+  },
+  "magnetisme": {
+    "rank": 1827,
+    "translation": "magnetism",
+    "partOfSpeech": "noun"
+  },
+  "elektromagnetisme": {
+    "rank": 1828,
+    "translation": "electromagnetism",
+    "partOfSpeech": "noun"
+  },
+  "transduktor": {
+    "rank": 1829,
+    "translation": "transducer",
+    "partOfSpeech": "noun"
+  },
+  "sensor": {
+    "rank": 1830,
+    "translation": "sensor",
+    "partOfSpeech": "noun"
+  },
+  "skakelaar": {
+    "rank": 1831,
+    "translation": "switch",
+    "partOfSpeech": "noun"
+  },
+  "relais": {
+    "rank": 1832,
+    "translation": "relay",
+    "partOfSpeech": "noun"
+  },
+  "transformator": {
+    "rank": 1833,
+    "translation": "transformer",
+    "partOfSpeech": "noun"
+  },
+  "kapasitor": {
+    "rank": 1834,
+    "translation": "capacitor",
+    "partOfSpeech": "noun"
+  },
+  "diode": {
+    "rank": 1836,
+    "translation": "diode",
+    "partOfSpeech": "noun"
+  },
+  "transistor": {
+    "rank": 1837,
+    "translation": "transistor",
+    "partOfSpeech": "noun"
+  },
+  "mikroskyfie": {
+    "rank": 1838,
+    "translation": "microchip",
+    "partOfSpeech": "noun"
+  },
+  "verwerker": {
+    "rank": 1839,
+    "translation": "processor",
+    "partOfSpeech": "noun"
+  },
+  "hardeskyf": {
+    "rank": 1841,
+    "translation": "hard drive",
+    "partOfSpeech": "noun"
+  },
+  "sagteware": {
+    "rank": 1842,
+    "translation": "software",
+    "partOfSpeech": "noun"
+  },
+  "hardeware": {
+    "rank": 1843,
+    "translation": "hardware",
+    "partOfSpeech": "noun"
+  },
+  "bedryfstelsel": {
+    "rank": 1844,
+    "translation": "operating system",
+    "partOfSpeech": "noun"
+  },
+  "toepassing": {
+    "rank": 1846,
+    "translation": "application",
+    "partOfSpeech": "noun"
+  },
+  "lêer": {
+    "rank": 1847,
+    "translation": "file",
+    "partOfSpeech": "noun"
+  },
+  "databasis": {
+    "rank": 1849,
+    "translation": "database",
+    "partOfSpeech": "noun"
+  },
+  "internet": {
+    "rank": 1851,
+    "translation": "internet",
+    "partOfSpeech": "noun"
+  },
+  "webwerf": {
+    "rank": 1852,
+    "translation": "website",
+    "partOfSpeech": "noun"
+  },
+  "blaaier": {
+    "rank": 1853,
+    "translation": "browser",
+    "partOfSpeech": "noun"
+  },
+  "soekenjin": {
+    "rank": 1854,
+    "translation": "search engine",
+    "partOfSpeech": "noun"
+  },
+  "e-pos": {
+    "rank": 1855,
+    "translation": "email",
+    "partOfSpeech": "noun"
+  },
+  "wagwoord": {
+    "rank": 1856,
+    "translation": "password",
+    "partOfSpeech": "noun"
+  },
+  "gebruikersnaam": {
+    "rank": 1857,
+    "translation": "username",
+    "partOfSpeech": "noun"
+  },
+  "rekening": {
+    "rank": 1858,
+    "translation": "account",
+    "partOfSpeech": "noun"
+  },
+  "aanmelding": {
+    "rank": 1859,
+    "translation": "login",
+    "partOfSpeech": "noun"
+  },
+  "afmelding": {
+    "rank": 1860,
+    "translation": "logout",
+    "partOfSpeech": "noun"
+  },
+  "aflaai": {
+    "rank": 1861,
+    "translation": "download",
+    "partOfSpeech": "noun"
+  },
+  "oplaai": {
+    "rank": 1862,
+    "translation": "upload",
+    "partOfSpeech": "noun"
+  },
+  "url": {
+    "rank": 1864,
+    "translation": "URL",
+    "partOfSpeech": "noun"
+  },
+  "domein": {
+    "rank": 1865,
+    "translation": "domain",
+    "partOfSpeech": "noun"
+  },
+  "bediener": {
+    "rank": 1866,
+    "translation": "server",
+    "partOfSpeech": "noun"
+  },
+  "stoor": {
+    "rank": 1869,
+    "translation": "storage",
+    "partOfSpeech": "noun"
+  },
+  "rugsteun": {
+    "rank": 1870,
+    "translation": "backup",
+    "partOfSpeech": "noun"
+  },
+  "wanware": {
+    "rank": 1872,
+    "translation": "malware",
+    "partOfSpeech": "noun"
+  },
+  "firewall": {
+    "rank": 1873,
+    "translation": "firewall",
+    "partOfSpeech": "noun"
+  },
+  "enkripsie": {
+    "rank": 1874,
+    "translation": "encryption",
+    "partOfSpeech": "noun"
+  },
+  "selfoon": {
+    "rank": 1876,
+    "translation": "cellphone",
+    "partOfSpeech": "noun"
+  },
+  "slimfoon": {
+    "rank": 1877,
+    "translation": "smartphone",
+    "partOfSpeech": "noun"
+  },
+  "tablet": {
+    "rank": 1878,
+    "translation": "tablet",
+    "partOfSpeech": "noun"
+  },
+  "skootrekenaar": {
+    "rank": 1879,
+    "translation": "laptop",
+    "partOfSpeech": "noun"
+  },
+  "lessenaar": {
+    "rank": 1880,
+    "translation": "desktop",
+    "partOfSpeech": "noun"
+  },
+  "drukker": {
+    "rank": 1881,
+    "translation": "printer",
+    "partOfSpeech": "noun"
+  },
+  "skandeerder": {
+    "rank": 1882,
+    "translation": "scanner",
+    "partOfSpeech": "noun"
+  },
+  "skerm": {
+    "rank": 1883,
+    "translation": "screen",
+    "partOfSpeech": "noun"
+  },
+  "sleutelbord": {
+    "rank": 1884,
+    "translation": "keyboard",
+    "partOfSpeech": "noun"
+  },
+  "muis": {
+    "rank": 1885,
+    "translation": "mouse",
+    "partOfSpeech": "noun"
+  },
+  "kopfoon": {
+    "rank": 1886,
+    "translation": "headphones",
+    "partOfSpeech": "noun"
+  },
+  "luidspreker": {
+    "rank": 1887,
+    "translation": "speaker",
+    "partOfSpeech": "noun"
+  },
+  "mikrofoon": {
+    "rank": 1888,
+    "translation": "microphone",
+    "partOfSpeech": "noun"
+  },
+  "kamera": {
+    "rank": 1889,
+    "translation": "camera",
+    "partOfSpeech": "noun"
+  },
+  "webkamera": {
+    "rank": 1890,
+    "translation": "webcam",
+    "partOfSpeech": "noun"
+  },
+  "kabel": {
+    "rank": 1891,
+    "translation": "cable",
+    "partOfSpeech": "noun"
+  },
+  "draadloos": {
+    "rank": 1892,
+    "translation": "wireless",
+    "partOfSpeech": "adjective"
+  },
+  "bluetooth": {
+    "rank": 1893,
+    "translation": "Bluetooth",
+    "partOfSpeech": "noun"
+  },
+  "wifi": {
+    "rank": 1894,
+    "translation": "Wi-Fi",
+    "partOfSpeech": "noun"
+  },
+  "sein": {
+    "rank": 1896,
+    "translation": "signal",
+    "partOfSpeech": "noun"
+  },
+  "bandwydte": {
+    "rank": 1898,
+    "translation": "bandwidth",
+    "partOfSpeech": "noun"
+  },
+  "latensie": {
+    "rank": 1900,
+    "translation": "latency",
+    "partOfSpeech": "noun"
+  },
+  "oplos": {
+    "rank": 1901,
+    "translation": "resolve/solve",
+    "partOfSpeech": "verb",
+    "suffixes": {
+      "ing": {
+        "rank": 897,
+        "translation": "solution",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "ontleed": {
+    "rank": 1902,
+    "translation": "analyze",
+    "partOfSpeech": "verb"
+  },
+  "bereken": {
+    "rank": 1903,
+    "translation": "calculate",
+    "partOfSpeech": "verb"
+  },
+  "vergelyk": {
+    "rank": 1904,
+    "translation": "compare",
+    "partOfSpeech": "verb",
+    "suffixes": {
+      "ing": {
+        "rank": 1962,
+        "translation": "simile",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "definieer": {
+    "rank": 1905,
+    "translation": "define",
+    "partOfSpeech": "verb"
+  },
+  "verduidelik": {
+    "rank": 1907,
+    "translation": "explain",
+    "partOfSpeech": "verb",
+    "suffixes": {
+      "ing": {
+        "rank": 1078,
+        "translation": "explanation",
+        "partOfSpeech": "noun"
+      }
+    }
+  },
+  "identifiseer": {
+    "rank": 1908,
+    "translation": "identify",
+    "partOfSpeech": "verb"
+  },
+  "illustreer": {
+    "rank": 1909,
+    "translation": "illustrate",
+    "partOfSpeech": "verb"
+  },
+  "interpreteer": {
+    "rank": 1910,
+    "translation": "interpret",
+    "partOfSpeech": "verb"
+  },
+  "kategoriseer": {
+    "rank": 1911,
+    "translation": "categorize",
+    "partOfSpeech": "verb"
+  },
+  "klassifiseer": {
+    "rank": 1912,
+    "translation": "classify",
+    "partOfSpeech": "verb"
+  },
+  "kombineer": {
+    "rank": 1913,
+    "translation": "combine",
+    "partOfSpeech": "verb"
+  },
+  "kommunikeer": {
+    "rank": 1914,
+    "translation": "communicate",
+    "partOfSpeech": "verb"
+  },
+  "konsentreer": {
+    "rank": 1915,
+    "translation": "concentrate",
+    "partOfSpeech": "verb"
+  },
+  "konstrueer": {
+    "rank": 1916,
+    "translation": "construct",
+    "partOfSpeech": "verb"
+  },
+  "kontrasteer": {
+    "rank": 1917,
+    "translation": "contrast",
+    "partOfSpeech": "verb"
+  },
+  "kritiseer": {
+    "rank": 1918,
+    "translation": "criticize",
+    "partOfSpeech": "verb"
+  },
+  "demonstreer": {
+    "rank": 1919,
+    "translation": "demonstrate",
+    "partOfSpeech": "verb"
+  },
+  "onderskei": {
+    "rank": 1920,
+    "translation": "distinguish",
+    "partOfSpeech": "verb"
+  },
+  "evalueer": {
+    "rank": 1921,
+    "translation": "evaluate",
+    "partOfSpeech": "verb"
+  },
+  "formuleer": {
+    "rank": 1923,
+    "translation": "formulate",
+    "partOfSpeech": "verb"
+  },
+  "genereer": {
+    "rank": 1924,
+    "translation": "generate",
+    "partOfSpeech": "verb"
+  },
+  "implementeer": {
+    "rank": 1925,
+    "translation": "implement",
+    "partOfSpeech": "verb"
+  },
+  "inkorporeer": {
+    "rank": 1926,
+    "translation": "incorporate",
+    "partOfSpeech": "verb"
+  },
+  "integreer": {
+    "rank": 1927,
+    "translation": "integrate",
+    "partOfSpeech": "verb"
+  },
+  "justifiseer": {
+    "rank": 1928,
+    "translation": "justify",
+    "partOfSpeech": "verb"
+  },
+  "manipuleer": {
+    "rank": 1929,
+    "translation": "manipulate",
+    "partOfSpeech": "verb"
+  },
+  "modifiseer": {
+    "rank": 1930,
+    "translation": "modify",
+    "partOfSpeech": "verb"
+  },
+  "motiveer": {
+    "rank": 1931,
+    "translation": "motivate",
+    "partOfSpeech": "verb"
+  },
+  "organiseer": {
+    "rank": 1932,
+    "translation": "organize",
+    "partOfSpeech": "verb"
+  },
+  "prioritiseer": {
+    "rank": 1933,
+    "translation": "prioritize",
+    "partOfSpeech": "verb"
+  },
+  "produseer": {
+    "rank": 1934,
+    "translation": "produce",
+    "partOfSpeech": "verb"
+  },
+  "rangskik": {
+    "rank": 1935,
+    "translation": "arrange",
+    "partOfSpeech": "verb"
+  },
+  "reageer": {
+    "rank": 1936,
+    "translation": "react",
+    "partOfSpeech": "verb"
+  },
+  "redeneer": {
+    "rank": 1937,
+    "translation": "reason",
+    "partOfSpeech": "verb"
+  },
+  "reguleer": {
+    "rank": 1938,
+    "translation": "regulate",
+    "partOfSpeech": "verb"
+  },
+  "reproduseer": {
+    "rank": 1939,
+    "translation": "reproduce",
+    "partOfSpeech": "verb"
+  },
+  "selekteer": {
+    "rank": 1940,
+    "translation": "select",
+    "partOfSpeech": "verb"
+  },
+  "sintetiseer": {
+    "rank": 1941,
+    "translation": "synthesize",
+    "partOfSpeech": "verb"
+  },
+  "spesialiseer": {
+    "rank": 1942,
+    "translation": "specialize",
+    "partOfSpeech": "verb"
+  },
+  "spesifiseer": {
+    "rank": 1943,
+    "translation": "specify",
+    "partOfSpeech": "verb"
+  },
+  "stimuleer": {
+    "rank": 1944,
+    "translation": "stimulate",
+    "partOfSpeech": "verb"
+  },
+  "struktureer": {
+    "rank": 1945,
+    "translation": "structure",
+    "partOfSpeech": "verb"
+  },
+  "substitueer": {
+    "rank": 1946,
+    "translation": "substitute",
+    "partOfSpeech": "verb"
+  },
+  "suggereer": {
+    "rank": 1947,
+    "translation": "suggest",
+    "partOfSpeech": "verb"
+  },
+  "opsomming": {
+    "rank": 1983,
+    "translation": "summary",
+    "partOfSpeech": "noun"
+  },
+  "transformeer": {
+    "rank": 1949,
+    "translation": "transform",
+    "partOfSpeech": "verb"
+  },
+  "vertaal": {
+    "rank": 1950,
+    "translation": "translate",
+    "partOfSpeech": "verb"
+  },
+  "valideer": {
+    "rank": 1951,
+    "translation": "validate",
+    "partOfSpeech": "verb"
+  },
+  "verifieer": {
+    "rank": 1952,
+    "translation": "verify",
+    "partOfSpeech": "verb"
+  },
+  "visualiseer": {
+    "rank": 1953,
+    "translation": "visualize",
+    "partOfSpeech": "verb"
+  },
+  "hoofstuk": {
+    "rank": 1954,
+    "translation": "chapter",
+    "partOfSpeech": "noun"
+  },
+  "paragraaf": {
+    "rank": 1955,
+    "translation": "paragraph",
+    "partOfSpeech": "noun"
+  },
+  "frase": {
+    "rank": 1957,
+    "translation": "phrase",
+    "partOfSpeech": "noun"
+  },
+  "klousule": {
+    "rank": 1958,
+    "translation": "clause",
+    "partOfSpeech": "noun"
+  },
+  "uitdrukking": {
+    "rank": 1959,
+    "translation": "expression",
+    "partOfSpeech": "noun"
+  },
+  "idioom": {
+    "rank": 1960,
+    "translation": "idiom",
+    "partOfSpeech": "noun"
+  },
+  "metafoor": {
+    "rank": 1961,
+    "translation": "metaphor",
+    "partOfSpeech": "noun"
+  },
+  "hiperbool": {
+    "rank": 1963,
+    "translation": "hyperbole",
+    "partOfSpeech": "noun"
+  },
+  "personifikasie": {
+    "rank": 1964,
+    "translation": "personification",
+    "partOfSpeech": "noun"
+  },
+  "alliterasie": {
+    "rank": 1965,
+    "translation": "alliteration",
+    "partOfSpeech": "noun"
+  },
+  "rym": {
+    "rank": 1966,
+    "translation": "rhyme",
+    "partOfSpeech": "noun"
+  },
+  "toon": {
+    "rank": 1968,
+    "translation": "tone",
+    "partOfSpeech": "noun"
+  },
+  "genre": {
+    "rank": 1970,
+    "translation": "genre",
+    "partOfSpeech": "noun"
+  },
+  "fiksie": {
+    "rank": 1971,
+    "translation": "fiction",
+    "partOfSpeech": "noun"
+  },
+  "nie-fiksie": {
+    "rank": 1972,
+    "translation": "non-fiction",
+    "partOfSpeech": "noun"
+  },
+  "outobiografie": {
+    "rank": 1973,
+    "translation": "autobiography",
+    "partOfSpeech": "noun"
+  },
+  "biografie": {
+    "rank": 1974,
+    "translation": "biography",
+    "partOfSpeech": "noun"
+  },
+  "memoir": {
+    "rank": 1975,
+    "translation": "memoir",
+    "partOfSpeech": "noun"
+  },
+  "essay": {
+    "rank": 1976,
+    "translation": "essay",
+    "partOfSpeech": "noun"
+  },
+  "artikel": {
+    "rank": 1977,
+    "translation": "article",
+    "partOfSpeech": "noun"
+  },
+  "rubriek": {
+    "rank": 1978,
+    "translation": "column",
+    "partOfSpeech": "noun"
+  },
+  "opskrif": {
+    "rank": 1979,
+    "translation": "headline",
+    "partOfSpeech": "noun"
+  },
+  "subopskrif": {
+    "rank": 1980,
+    "translation": "subheading",
+    "partOfSpeech": "noun"
+  },
+  "inleiding": {
+    "rank": 1981,
+    "translation": "introduction",
+    "partOfSpeech": "noun"
+  },
+  "abstrak": {
+    "rank": 1984,
+    "translation": "abstract",
+    "partOfSpeech": "noun"
+  },
+  "bibliografie": {
+    "rank": 1985,
+    "translation": "bibliography",
+    "partOfSpeech": "noun"
+  },
+  "verwysing": {
+    "rank": 1986,
+    "translation": "reference",
+    "partOfSpeech": "noun"
+  },
+  "voetnota": {
+    "rank": 1987,
+    "translation": "footnote",
+    "partOfSpeech": "noun"
+  },
+  "aanhaling": {
+    "rank": 1988,
+    "translation": "quotation",
+    "partOfSpeech": "noun"
+  },
+  "bron": {
+    "rank": 1989,
+    "translation": "source",
+    "partOfSpeech": "noun"
+  },
+  "proefleser": {
+    "rank": 1993,
+    "translation": "proofreader",
+    "partOfSpeech": "noun"
+  },
+  "kopie": {
+    "rank": 1994,
+    "translation": "copy",
+    "partOfSpeech": "noun"
+  },
+  "manuskrip": {
+    "rank": 1995,
+    "translation": "manuscript",
+    "partOfSpeech": "noun"
+  },
+  "drukwerk": {
+    "rank": 1996,
+    "translation": "printing",
+    "partOfSpeech": "noun"
+  },
+  "publikasie": {
+    "rank": 1997,
+    "translation": "publication",
+    "partOfSpeech": "noun"
+  },
+  "kopiereg": {
+    "rank": 1998,
+    "translation": "copyright",
+    "partOfSpeech": "noun"
+  },
+  "isbn": {
+    "rank": 1999,
+    "translation": "ISBN",
+    "partOfSpeech": "noun"
+  },
+  "dis": {
+    "rank": 2001,
+    "translation": "it is/that's",
+    "partOfSpeech": "contraction"
+  },
+  "oom": {
+    "rank": 2002,
+    "translation": "uncle/sir",
+    "partOfSpeech": "noun"
+  },
+  "want": {
+    "rank": 2003,
+    "translation": "because/for",
+    "partOfSpeech": "conjunction"
+  },
+  "lyk": {
+    "rank": 2004,
+    "translation": "seem/look/corpse",
+    "partOfSpeech": "verb"
+  },
+  "alles": {
+    "rank": 2005,
+    "translation": "everything",
+    "partOfSpeech": "pronoun"
+  },
+  "tog": {
+    "rank": 2006,
+    "translation": "yet/still/after all",
+    "partOfSpeech": "adverb"
+  },
+  "julle": {
+    "rank": 2007,
+    "translation": "you (plural)",
+    "partOfSpeech": "pronoun"
+  },
+  "almal": {
+    "rank": 2008,
+    "translation": "everyone",
+    "partOfSpeech": "pronoun"
+  },
+  "keer": {
+    "rank": 2009,
+    "translation": "time/turn/prevent",
+    "partOfSpeech": "noun"
+  },
+  "lang": {
+    "rank": 2010,
+    "translation": "long/tall",
+    "partOfSpeech": "adjective"
+  },
+  "alleen": {
+    "rank": 2011,
+    "translation": "alone/only",
+    "partOfSpeech": "adverb"
+  },
+  "vas": {
+    "rank": 2012,
+    "translation": "firm/stuck/fast",
+    "partOfSpeech": "adjective"
+  },
+  "veld": {
+    "rank": 2013,
+    "translation": "field/bush/veld",
+    "partOfSpeech": "noun"
+  },
+  "ag": {
+    "rank": 2014,
+    "translation": "oh/eight",
+    "partOfSpeech": "interjection"
+  },
+  "ma": {
+    "rank": 2015,
+    "translation": "mother/mom",
+    "partOfSpeech": "noun"
+  },
+  "tant": {
+    "rank": 2016,
+    "translation": "aunt/ma'am",
+    "partOfSpeech": "noun"
+  },
+  "staar": {
+    "rank": 2017,
+    "translation": "stare",
+    "partOfSpeech": "verb"
+  },
+  "iemand": {
+    "rank": 2018,
+    "translation": "someone",
+    "partOfSpeech": "pronoun"
+  },
+  "taal": {
+    "rank": 2019,
+    "translation": "language",
+    "partOfSpeech": "noun"
+  },
+  "wel": {
+    "rank": 2020,
+    "translation": "well/indeed",
+    "partOfSpeech": "adverb"
+  },
+  "volk": {
+    "rank": 2021,
+    "translation": "nation/people",
+    "partOfSpeech": "noun"
+  },
+  "mekaar": {
+    "rank": 2022,
+    "translation": "each other",
+    "partOfSpeech": "pronoun"
+  },
+  "dié": {
+    "rank": 2023,
+    "translation": "this/these",
+    "partOfSpeech": "determiner"
+  },
+  "niemand": {
+    "rank": 2024,
+    "translation": "nobody/no one",
+    "partOfSpeech": "pronoun"
+  },
+  "raak": {
+    "rank": 2025,
+    "translation": "touch/become/get",
+    "partOfSpeech": "verb"
+  },
+  "pa": {
+    "rank": 2026,
+    "translation": "father/dad",
+    "partOfSpeech": "noun"
+  },
+  "verdwyn": {
+    "rank": 2027,
+    "translation": "disappear",
+    "partOfSpeech": "verb"
+  },
+  "jare": {
+    "rank": 2028,
+    "translation": "years",
+    "partOfSpeech": "noun"
+  },
+  "moes": {
+    "rank": 2029,
+    "translation": "had to/must (past)",
+    "partOfSpeech": "verb"
+  },
+  "asof": {
+    "rank": 2030,
+    "translation": "as if",
+    "partOfSpeech": "conjunction"
+  },
+  "steek": {
+    "rank": 2031,
+    "translation": "stab/sting/put",
+    "partOfSpeech": "verb"
+  },
+  "sterre": {
+    "rank": 2032,
+    "translation": "stars",
+    "partOfSpeech": "noun"
+  },
+  "daarvan": {
+    "rank": 2033,
+    "translation": "of it/thereof",
+    "partOfSpeech": "adverb"
+  },
+  "skyn": {
+    "rank": 2034,
+    "translation": "shine/seem",
+    "partOfSpeech": "verb"
+  },
+  "neer": {
+    "rank": 2035,
+    "translation": "down",
+    "partOfSpeech": "adverb"
+  },
+  "half": {
+    "rank": 2036,
+    "translation": "half",
+    "partOfSpeech": "adjective"
+  },
+  "luister": {
+    "rank": 2037,
+    "translation": "listen",
+    "partOfSpeech": "verb"
+  },
+  "veel": {
+    "rank": 2038,
+    "translation": "much/many",
+    "partOfSpeech": "adverb"
+  },
+  "blink": {
+    "rank": 2039,
+    "translation": "shine/bright",
+    "partOfSpeech": "verb"
+  },
+  "droom": {
+    "rank": 2040,
+    "translation": "dream",
+    "partOfSpeech": "noun"
+  },
+  "gebeur": {
+    "rank": 2041,
+    "translation": "happen",
+    "partOfSpeech": "verb"
+  },
+  "mee": {
+    "rank": 2042,
+    "translation": "with/along",
+    "partOfSpeech": "adverb"
+  },
+  "glimlag": {
+    "rank": 2043,
+    "translation": "smile",
+    "partOfSpeech": "noun"
+  },
+  "gang": {
+    "rank": 2044,
+    "translation": "corridor/pace",
+    "partOfSpeech": "noun"
+  },
+  "mos": {
+    "rank": 2045,
+    "translation": "after all/surely",
+    "partOfSpeech": "adverb"
+  },
+  "aarde": {
+    "rank": 2046,
+    "translation": "earth/ground",
+    "partOfSpeech": "noun"
+  },
+  "kleur": {
+    "rank": 2047,
+    "translation": "colour",
+    "partOfSpeech": "noun"
+  },
+  "ore": {
+    "rank": 2048,
+    "translation": "ears",
+    "partOfSpeech": "noun"
+  },
+  "slang": {
+    "rank": 2049,
+    "translation": "snake",
+    "partOfSpeech": "noun"
+  },
+  "verskyn": {
+    "rank": 2050,
+    "translation": "appear",
+    "partOfSpeech": "verb"
+  },
+  "middel": {
+    "rank": 2051,
+    "translation": "middle/waist",
+    "partOfSpeech": "noun"
+  },
+  "meisie": {
+    "rank": 2052,
+    "translation": "girl",
+    "partOfSpeech": "noun"
+  },
+  "geniet": {
+    "rank": 2053,
+    "translation": "enjoy",
+    "partOfSpeech": "verb"
+  },
+  "ontdek": {
+    "rank": 2054,
+    "translation": "discover",
+    "partOfSpeech": "verb"
+  },
+  "eis": {
+    "rank": 2055,
+    "translation": "demand/claim",
+    "partOfSpeech": "verb"
+  },
+  "ouma": {
+    "rank": 2056,
+    "translation": "grandmother",
+    "partOfSpeech": "noun"
+  },
+  "verdien": {
+    "rank": 2057,
+    "translation": "earn/deserve",
+    "partOfSpeech": "verb"
+  },
+  "oupa": {
+    "rank": 2058,
+    "translation": "grandfather",
+    "partOfSpeech": "noun"
+  },
+  "brug": {
+    "rank": 2059,
+    "translation": "bridge",
+    "partOfSpeech": "noun"
+  },
+  "baba": {
+    "rank": 2060,
+    "translation": "baby",
+    "partOfSpeech": "noun"
+  },
+  "blad": {
+    "rank": 2061,
+    "translation": "leaf/page",
+    "partOfSpeech": "noun"
+  },
+  "vlees": {
+    "rank": 2062,
+    "translation": "meat/flesh",
+    "partOfSpeech": "noun"
+  },
+  "berei": {
+    "rank": 2063,
+    "translation": "prepare",
+    "partOfSpeech": "verb"
+  },
+  "skaap": {
+    "rank": 2064,
+    "translation": "sheep",
+    "partOfSpeech": "noun"
+  },
+  "hoender": {
+    "rank": 2065,
+    "translation": "chicken",
+    "partOfSpeech": "noun"
+  },
+  "sowat": {
+    "rank": 2066,
+    "translation": "about/approximately",
+    "partOfSpeech": "adverb"
+  },
+  "bely": {
+    "rank": 2067,
+    "translation": "confess",
+    "partOfSpeech": "verb"
+  },
+  "koei": {
+    "rank": 2068,
+    "translation": "cow",
+    "partOfSpeech": "noun"
+  },
+  "later": {
+    "rank": 2069,
+    "translation": "later",
+    "partOfSpeech": "adverb"
+  },
+  "wens": {
+    "rank": 2070,
+    "translation": "wish",
+    "partOfSpeech": "verb"
+  },
+  "besoek": {
+    "rank": 2071,
+    "translation": "visit",
+    "partOfSpeech": "verb"
+  },
+  "beweeg": {
+    "rank": 2072,
+    "translation": "move",
+    "partOfSpeech": "verb"
+  },
+  "vermy": {
+    "rank": 2073,
+    "translation": "avoid",
+    "partOfSpeech": "verb"
+  },
+  "bedoel": {
+    "rank": 2074,
+    "translation": "mean/intend",
+    "partOfSpeech": "verb"
+  }
+}

--- a/src/lib/dictionary.ts
+++ b/src/lib/dictionary.ts
@@ -1,62 +1,153 @@
-import dictionaryData from './dictionary-data.json';
+import rootData from './dictionary-roots.json';
 
 export interface DictionaryEntry {
   word: string;
   rank: number;
   translation: string;
   partOfSpeech: string;
+  /** Present when the word was found via affix stripping */
+  lemmaInfo?: { stem: string; label: string };
 }
 
-// Create a Map for O(1) lookup by word
-const dictionaryMap = new Map<string, DictionaryEntry>();
+interface DerivedEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech?: string;
+}
 
-// Populate the map from the JSON data
-(dictionaryData as DictionaryEntry[]).forEach((entry) => {
-  dictionaryMap.set(entry.word.toLowerCase(), entry);
-});
+interface RootEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech: string;
+  prefixes?: Record<string, DerivedEntry>;
+  suffixes?: Record<string, DerivedEntry>;
+}
+
+const roots = rootData as Record<string, RootEntry>;
+
+// Ordered longest-first to avoid premature matches
+const PREFIXES = ['ont', 'ver', 'her', 'ge', 'be'];
+const SUFFIXES = ['heid', 'tjie', 'jie', 'ing', 'lik', 'te', 'de', 'e', 's'];
+const PREFIX_LABELS: Record<string, string> = {
+  ge: 'past participle of', ver: 'derived from', be: 'derived from',
+  her: 'repetition of', ont: 'derived from',
+};
+const SUFFIX_LABELS: Record<string, string> = {
+  heid: 'abstract noun from', tjie: 'diminutive of', jie: 'diminutive of',
+  ing: 'nominalization of', lik: 'adverbial form of', te: 'inflected form of',
+  de: 'inflected form of', e: 'inflected/plural of', s: 'plural of',
+};
+
+const VOWELS = new Set('aeiouyêëéèôöûüîïáà'.split(''));
+const MIN_STEM = 2;
+
+function undoubleConsonant(stem: string): string | null {
+  if (stem.length >= 3) {
+    const last = stem[stem.length - 1];
+    if (last === stem[stem.length - 2] && !VOWELS.has(last)) {
+      return stem.slice(0, -1);
+    }
+  }
+  return null;
+}
+
+function rootToEntry(word: string, root: RootEntry): DictionaryEntry {
+  return { word, rank: root.rank, translation: root.translation, partOfSpeech: root.partOfSpeech };
+}
+
+function derivedToEntry(word: string, root: RootEntry, derived: DerivedEntry, stem: string, label: string): DictionaryEntry {
+  return {
+    word,
+    rank: derived.rank,
+    translation: derived.translation,
+    partOfSpeech: derived.partOfSpeech || root.partOfSpeech,
+    lemmaInfo: { stem, label },
+  };
+}
 
 /**
- * Look up a word in the dictionary
- * @param word - The Afrikaans word to look up (case-insensitive)
- * @returns The dictionary entry or undefined if not found
+ * Look up a word in the dictionary.
+ * Checks: exact root → prefix derivation → suffix derivation → affix-strip fallback.
  */
 export function lookupWord(word: string): DictionaryEntry | undefined {
-  return dictionaryMap.get(word.toLowerCase());
+  const lower = word.toLowerCase();
+
+  // 1. Exact root match
+  const root = roots[lower];
+  if (root) return rootToEntry(lower, root);
+
+  // 2. Check if it's a known prefix derivation
+  for (const prefix of PREFIXES) {
+    if (!lower.startsWith(prefix)) continue;
+    const stem = lower.slice(prefix.length);
+    if (stem.length < MIN_STEM) continue;
+
+    const stemRoot = roots[stem];
+    if (stemRoot?.prefixes?.[prefix]) {
+      return derivedToEntry(lower, stemRoot, stemRoot.prefixes[prefix], stem, PREFIX_LABELS[prefix]);
+    }
+  }
+
+  // 3. Check if it's a known suffix derivation
+  for (const suffix of SUFFIXES) {
+    if (!lower.endsWith(suffix)) continue;
+    const stem = lower.slice(0, -suffix.length);
+    if (stem.length < MIN_STEM) continue;
+
+    const stemRoot = roots[stem];
+    if (stemRoot?.suffixes?.[suffix]) {
+      return derivedToEntry(lower, stemRoot, stemRoot.suffixes[suffix], stem, SUFFIX_LABELS[suffix]);
+    }
+
+    // Try consonant undoubling
+    const undoubled = undoubleConsonant(stem);
+    if (undoubled && undoubled.length >= MIN_STEM) {
+      const undoubledRoot = roots[undoubled];
+      if (undoubledRoot?.suffixes?.[suffix]) {
+        return derivedToEntry(lower, undoubledRoot, undoubledRoot.suffixes[suffix], undoubled, SUFFIX_LABELS[suffix]);
+      }
+    }
+  }
+
+  // 4. Affix-strip fallback: strip affix and use root entry with generic label
+  for (const prefix of PREFIXES) {
+    if (!lower.startsWith(prefix)) continue;
+    const stem = lower.slice(prefix.length);
+    if (stem.length >= MIN_STEM && roots[stem]) {
+      const r = roots[stem];
+      return { ...rootToEntry(lower, r), rank: 0, lemmaInfo: { stem, label: PREFIX_LABELS[prefix] } };
+    }
+  }
+
+  for (const suffix of SUFFIXES) {
+    if (!lower.endsWith(suffix)) continue;
+    const stem = lower.slice(0, -suffix.length);
+
+    if (stem.length >= MIN_STEM && roots[stem]) {
+      const r = roots[stem];
+      return { ...rootToEntry(lower, r), rank: 0, lemmaInfo: { stem, label: SUFFIX_LABELS[suffix] } };
+    }
+
+    const undoubled = undoubleConsonant(stem);
+    if (undoubled && undoubled.length >= MIN_STEM && roots[undoubled]) {
+      const r = roots[undoubled];
+      return { ...rootToEntry(lower, r), rank: 0, lemmaInfo: { stem: undoubled, label: SUFFIX_LABELS[suffix] } };
+    }
+  }
+
+  return undefined;
 }
 
 /**
- * Check if a word exists in the dictionary
- * @param word - The Afrikaans word to check (case-insensitive)
- * @returns true if the word is in the dictionary
+ * Check if a word exists in the dictionary (exact root match only)
  */
 export function hasWord(word: string): boolean {
-  return dictionaryMap.has(word.toLowerCase());
-}
-
-/**
- * Get all dictionary entries
- * @returns Array of all dictionary entries sorted by rank
- */
-export function getAllEntries(): DictionaryEntry[] {
-  return dictionaryData as DictionaryEntry[];
-}
-
-/**
- * Get the dictionary map for direct access
- * @returns The Map containing all dictionary entries
- */
-export function getDictionaryMap(): Map<string, DictionaryEntry> {
-  return dictionaryMap;
+  return word.toLowerCase() in roots;
 }
 
 /**
  * Get word frequency rank (lower = more common)
- * @param word - The Afrikaans word
- * @returns The rank (1-2000) or undefined if not in top 2000
  */
 export function getWordRank(word: string): number | undefined {
-  const entry = dictionaryMap.get(word.toLowerCase());
-  return entry?.rank;
+  return lookupWord(word)?.rank || undefined;
 }
-
-export default dictionaryMap;


### PR DESCRIPTION
## Summary

- Restructures the flat dictionary (2000 entries) into a root-based format with nested prefix/suffix derivations, freeing 131 slots
- Adds 74 new Afrikaans words sourced from the reading corpus (e.g. `dis`, `oom`, `julle`, `meisie`, `glimlag`, `bietjie`)
- Lookup flow: exact root → known derivation (with specific translation) → affix-strip fallback → consonant undoubling (AWS XII-5)
- Morphological context displayed in word panel (e.g. "listen (past participle of luister)")
- 25 false positives excluded via curated list (e.g. `been`≠`be-`+`en`, `geen`≠`ge-`+`en`)
- Build scripts (`scripts/build-root-dictionary.ts`, `scripts/expand-dictionary.ts`) for regenerating and expanding

Closes #56

## Test plan

- [x] 11 unit tests covering exact match, prefix/suffix derivation, fallback stripping, consonant undoubling, and no-match cases
- [x] E2e reader tests pass (69/72, 2 pre-existing failures, 1 skipped)
- [x] Build passes
- [x] Verified lookups: `verstaan` → "understand", `geluister` → "listen (past participle of luister)", `katte` → "cat (inflected/plural of kat)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)