### PR TITLE
fix: ignore modifier+number keys in practice MC mode

### DIFF
--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -322,6 +322,36 @@ test.describe.serial("Practice - Multiple Choice Mode", () => {
     // Wait for auto-advance
     await page.waitForTimeout(2000);
   });
+
+  test("should not capture number keys when Cmd/Ctrl is held", async ({ page }) => {
+    await waitForSetup(page);
+
+    await page.getByRole("button", { name: "10", exact: true }).click();
+    await page.getByRole("button", { name: "MC" }).click();
+    await page.getByRole("button", { name: "Start" }).click();
+
+    await expect(page.getByText("Choose the correct word")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // All 4 MC options should be visible and unselected
+    const mcGrid = page.locator(".grid.grid-cols-1");
+    const mcButtons = mcGrid.locator("button");
+    await expect(mcButtons.first()).toBeVisible();
+
+    // Press Cmd+1 (Meta+1) — should NOT trigger MC selection
+    await page.keyboard.down("Meta");
+    await page.keyboard.press("1");
+    await page.keyboard.up("Meta");
+    await page.waitForTimeout(500);
+
+    // No button should have been selected (no green/red border)
+    const selectedBtn = mcGrid.locator("button.border-green-500, button.border-red-500");
+    await expect(selectedBtn).toHaveCount(0);
+
+    // The instruction text should still be visible (not advanced)
+    await expect(page.getByText("Choose the correct word")).toBeVisible();
+  });
 });
 
 test.describe.serial("Practice - Review Flow", () => {

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -601,6 +601,7 @@ export default function PracticePage() {
     }
     if (state === 'practicing' && practiceMode === 'mc' && !mcLocked) {
       const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
         // Number keys 1-4 for MC selection
         if (e.key >= '1' && e.key <= '4') {
           const idx = parseInt(e.key) - 1;


### PR DESCRIPTION
## Summary
- Add `metaKey/ctrlKey/altKey` guard to the practice page MC mode keydown handler, matching the existing guard in the read page
- Cmd+1..4 (or Ctrl+1..4) now falls through to the browser for tab switching instead of being captured as MC option selection

Closes #60

## Test plan
- [x] E2e test added: verifies Cmd+1 does not trigger MC selection
- [x] All 24 practice e2e tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
