### PR TITLE
feat: collection groups for organizing library

### DIFF
--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+
+test.describe("Collection Groups", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    // Clean up test groups
+    const groupsRes = await page.request.get("/api/groups");
+    const groups = await groupsRes.json();
+    for (const g of groups) {
+      if (g.name.startsWith("Test") || g.name.startsWith("Toets")) {
+        await page.request.delete(`/api/groups/${g.id}`);
+      }
+    }
+
+    // Clean up test collections
+    const colRes = await page.request.get("/api/collections");
+    const collections = await colRes.json();
+    for (const c of collections) {
+      if (c.title.startsWith("Toets") || c.title.startsWith("Test")) {
+        await page.request.delete(`/api/collections/${c.id}`);
+      }
+    }
+  });
+
+  test("should create a group via the UI", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("new-group-btn").click();
+    await page.getByTestId("new-group-input").fill("Test Group");
+    await page.getByTestId("new-group-submit").click();
+
+    // Group heading should appear
+    await expect(page.locator("h3", { hasText: "Test Group" })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("0 items")).toBeVisible();
+  });
+
+  test("should assign a collection to a group via detail page", async ({ page }) => {
+    // Create a group via API
+    const groupRes = await page.request.post("/api/groups", {
+      data: { name: "Test Assign Group" },
+    });
+    const { id: groupId } = await groupRes.json();
+
+    // Import a test collection
+    const epubPath = path.join(__dirname, "fixtures/test-book.epub");
+    const fs = await import("fs");
+    const buffer = fs.readFileSync(epubPath);
+    const importRes = await page.request.post("/api/import/epub", {
+      multipart: {
+        file: {
+          name: "test-book.epub",
+          mimeType: "application/epub+zip",
+          buffer,
+        },
+      },
+    });
+    const { collectionId } = await importRes.json();
+
+    // Navigate to collection detail
+    await page.goto(`/collection/${collectionId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Select the group and wait for the API call to complete
+    const [updateResponse] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes("/api/collections/") && r.request().method() === "PUT"),
+      page.getByTestId("group-select").selectOption(groupId),
+    ]);
+    expect(updateResponse.ok()).toBeTruthy();
+
+    // Navigate back to library
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Collection should be under the group heading
+    const groupSection = page.getByTestId(`group-${groupId}`);
+    await expect(groupSection).toBeVisible();
+    await expect(groupSection.locator("h3", { hasText: "Test Assign Group" })).toBeVisible();
+    await expect(groupSection.getByText("Toets Boek").first()).toBeVisible();
+  });
+
+  test("should ungroup a collection", async ({ page }) => {
+    // Create group + collection assigned to it
+    const groupRes = await page.request.post("/api/groups", {
+      data: { name: "Test Ungroup" },
+    });
+    const { id: groupId } = await groupRes.json();
+
+    const colRes = await page.request.post("/api/collections", {
+      data: { title: "Test Ungrouped Book", author: "Test" },
+    });
+    const { id: collectionId } = await colRes.json();
+    await page.request.put(`/api/collections/${collectionId}`, {
+      data: { groupId },
+    });
+
+    // Go to detail page and set group to None
+    await page.goto(`/collection/${collectionId}`);
+    await page.waitForLoadState("networkidle");
+    await page.getByTestId("group-select").selectOption("");
+
+    // Verify on home page
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // The group section should show 0 items
+    const groupSection = page.getByTestId(`group-${groupId}`);
+    await expect(groupSection.getByText("0 items")).toBeVisible();
+  });
+
+  test("should rename a group", async ({ page }) => {
+    const groupRes = await page.request.post("/api/groups", {
+      data: { name: "Test Rename Me" },
+    });
+    await groupRes.json();
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("h3", { hasText: "Test Rename Me" })).toBeVisible();
+
+    // Set up dialog handler before triggering it
+    page.once("dialog", async (dialog) => {
+      await dialog.accept("Test Renamed");
+    });
+    await page.getByTestId("group-menu-btn").first().click();
+
+    const [renameResponse] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes("/api/groups/") && r.request().method() === "PUT"),
+      page.getByTestId("group-rename-btn").click(),
+    ]);
+    expect(renameResponse.ok()).toBeTruthy();
+
+    await expect(page.locator("h3", { hasText: "Test Renamed" })).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should delete a group and ungroup its collections", async ({ page }) => {
+    // Create group + collection
+    const groupRes = await page.request.post("/api/groups", {
+      data: { name: "Test Delete Group" },
+    });
+    const { id: groupId } = await groupRes.json();
+
+    const colRes = await page.request.post("/api/collections", {
+      data: { title: "Test Survives Delete", author: "Test" },
+    });
+    const { id: collectionId } = await colRes.json();
+    await page.request.put(`/api/collections/${collectionId}`, {
+      data: { groupId },
+    });
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Set up dialog handler before triggering it
+    page.once("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await page.getByTestId("group-menu-btn").first().click();
+
+    const [deleteResponse] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes("/api/groups/") && r.request().method() === "DELETE"),
+      page.getByTestId("group-delete-btn").click(),
+    ]);
+    expect(deleteResponse.ok()).toBeTruthy();
+
+    // Group heading should be gone
+    await expect(page.locator("h3", { hasText: "Test Delete Group" })).not.toBeVisible({ timeout: 5000 });
+
+    // Collection should still exist (now ungrouped) — check via API
+    const colRes2 = await page.request.get("/api/collections");
+    const remaining = await colRes2.json();
+    expect(remaining.some((c: { title: string }) => c.title === "Test Survives Delete")).toBeTruthy();
+  });
+
+  test("should create a new group from collection detail page", async ({ page }) => {
+    // Create a collection
+    const colRes = await page.request.post("/api/collections", {
+      data: { title: "Test Detail Group Book", author: "Test" },
+    });
+    const { id: collectionId } = await colRes.json();
+
+    await page.goto(`/collection/${collectionId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Set up dialog handler before selecting the option
+    page.once("dialog", async (dialog) => {
+      await dialog.accept("Test From Detail");
+    });
+    await page.getByTestId("group-select").selectOption("__new__");
+
+    // Wait for the select to update with the new group value
+    await expect(page.getByTestId("group-select")).not.toHaveValue("");
+    await expect(page.getByTestId("group-select")).not.toHaveValue("__new__");
+
+    // Verify on home page
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("h3", { hasText: "Test From Detail" })).toBeVisible();
+  });
+
+  test("groups API CRUD works correctly", async ({ page }) => {
+    // POST
+    const createRes = await page.request.post("/api/groups", {
+      data: { name: "Test API Group" },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const { id } = await createRes.json();
+    expect(id).toBeTruthy();
+
+    // GET
+    const listRes = await page.request.get("/api/groups");
+    const groups = await listRes.json();
+    const created = groups.find((g: { id: string }) => g.id === id);
+    expect(created).toBeTruthy();
+    expect(created.name).toBe("Test API Group");
+
+    // PUT
+    const updateRes = await page.request.put(`/api/groups/${id}`, {
+      data: { name: "Test API Group Renamed" },
+    });
+    expect(updateRes.ok()).toBeTruthy();
+
+    const listRes2 = await page.request.get("/api/groups");
+    const groups2 = await listRes2.json();
+    expect(groups2.find((g: { id: string }) => g.id === id).name).toBe("Test API Group Renamed");
+
+    // DELETE
+    const deleteRes = await page.request.delete(`/api/groups/${id}`);
+    expect(deleteRes.ok()).toBeTruthy();
+
+    const listRes3 = await page.request.get("/api/groups");
+    const groups3 = await listRes3.json();
+    expect(groups3.find((g: { id: string }) => g.id === id)).toBeUndefined();
+  });
+
+  test("should reject empty group name", async ({ page }) => {
+    const res = await page.request.post("/api/groups", {
+      data: { name: "" },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -169,10 +169,8 @@ test.describe("Collection Groups", () => {
     // Group heading should be gone
     await expect(page.locator("h3", { hasText: "Test Delete Group" })).not.toBeVisible({ timeout: 5000 });
 
-    // Collection should still exist (now ungrouped) — check via API
-    const colRes2 = await page.request.get("/api/collections");
-    const remaining = await colRes2.json();
-    expect(remaining.some((c: { title: string }) => c.title === "Test Survives Delete")).toBeTruthy();
+    // Collection should still be visible on the page (ungrouped, not orphaned)
+    await expect(page.getByText("Test Survives Delete").first()).toBeVisible();
   });
 
   test("should create a new group from collection detail page", async ({ page }) => {

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -37,6 +37,7 @@ export async function PUT(
   if (body.title !== undefined) { updates.push('title = ?'); values.push(body.title); }
   if (body.author !== undefined) { updates.push('author = ?'); values.push(body.author); }
   if (body.coverUrl !== undefined) { updates.push('coverUrl = ?'); values.push(body.coverUrl); }
+  if (body.groupId !== undefined) { updates.push('groupId = ?'); values.push(body.groupId); }
 
   updates.push('lastReadAt = ?');
   values.push(new Date().toISOString());

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -39,8 +39,12 @@ export async function PUT(
   if (body.coverUrl !== undefined) { updates.push('coverUrl = ?'); values.push(body.coverUrl); }
   if (body.groupId !== undefined) { updates.push('groupId = ?'); values.push(body.groupId); }
 
-  updates.push('lastReadAt = ?');
-  values.push(new Date().toISOString());
+  // Only bump lastReadAt for content changes, not metadata-only changes like groupId
+  const isContentChange = body.title !== undefined || body.author !== undefined || body.coverUrl !== undefined;
+  if (isContentChange) {
+    updates.push('lastReadAt = ?');
+    values.push(new Date().toISOString());
+  }
   values.push(id);
 
   db.prepare(`UPDATE collections SET ${updates.join(', ')} WHERE id = ?`).run(...values);

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -5,13 +5,14 @@ import { randomUUID } from 'crypto';
 // GET /api/collections - List all collections with lesson counts
 export async function GET() {
   const collections = db.prepare(`
-    SELECT c.*, COUNT(l.id) as lessonCount,
+    SELECT c.*, g.name as groupName, COUNT(l.id) as lessonCount,
       COALESCE(AVG(l.progress_percentComplete), 0) as avgProgress
     FROM collections c
+    LEFT JOIN collection_groups g ON g.id = c.groupId
     LEFT JOIN lessons l ON l.collectionId = c.id
     GROUP BY c.id
     ORDER BY c.lastReadAt DESC
-  `).all() as (CollectionRow & { lessonCount: number; avgProgress: number })[];
+  `).all() as (CollectionRow & { groupName: string | null; lessonCount: number; avgProgress: number })[];
 
   return NextResponse.json(collections);
 }

--- a/src/app/api/groups/[id]/route.ts
+++ b/src/app/api/groups/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+
+// PUT /api/groups/[id] - Update a group
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const body = await request.json();
+
+  const updates: string[] = [];
+  const values: unknown[] = [];
+
+  if (body.name !== undefined) { updates.push('name = ?'); values.push(body.name); }
+  if (body.sortOrder !== undefined) { updates.push('sortOrder = ?'); values.push(body.sortOrder); }
+
+  if (updates.length === 0) {
+    return NextResponse.json({ success: true });
+  }
+
+  values.push(id);
+  db.prepare(`UPDATE collection_groups SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+
+  return NextResponse.json({ success: true });
+}
+
+// DELETE /api/groups/[id] - Delete a group (collections become ungrouped)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  db.prepare('DELETE FROM collection_groups WHERE id = ?').run(id);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/groups/[id]/route.ts
+++ b/src/app/api/groups/[id]/route.ts
@@ -12,7 +12,12 @@ export async function PUT(
   const updates: string[] = [];
   const values: unknown[] = [];
 
-  if (body.name !== undefined) { updates.push('name = ?'); values.push(body.name); }
+  if (body.name !== undefined) {
+    if (!body.name.trim()) {
+      return NextResponse.json({ error: 'name cannot be empty' }, { status: 400 });
+    }
+    updates.push('name = ?'); values.push(body.name.trim());
+  }
   if (body.sortOrder !== undefined) { updates.push('sortOrder = ?'); values.push(body.sortOrder); }
 
   if (updates.length === 0) {
@@ -31,6 +36,8 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  // Manually ungroup collections since SQLite FK ON DELETE SET NULL requires PRAGMA foreign_keys = ON
+  db.prepare('UPDATE collections SET groupId = NULL WHERE groupId = ?').run(id);
   db.prepare('DELETE FROM collection_groups WHERE id = ?').run(id);
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/groups/route.ts
+++ b/src/app/api/groups/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, CollectionGroupRow } from '@/lib/server/database';
+import { randomUUID } from 'crypto';
+
+// GET /api/groups - List all groups
+export async function GET() {
+  const groups = db.prepare(
+    'SELECT * FROM collection_groups ORDER BY sortOrder ASC'
+  ).all() as CollectionGroupRow[];
+
+  return NextResponse.json(groups);
+}
+
+// POST /api/groups - Create a new group
+export async function POST(request: NextRequest) {
+  const { name } = await request.json();
+
+  if (!name?.trim()) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const maxOrder = db.prepare(
+    'SELECT COALESCE(MAX(sortOrder), -1) as maxOrder FROM collection_groups'
+  ).get() as { maxOrder: number };
+
+  db.prepare(
+    'INSERT INTO collection_groups (id, name, sortOrder, createdAt) VALUES (?, ?, ?, ?)'
+  ).run(id, name.trim(), maxOrder.maxOrder + 1, now);
+
+  return NextResponse.json({ id });
+}

--- a/src/app/collection/[id]/page.tsx
+++ b/src/app/collection/[id]/page.tsx
@@ -9,7 +9,11 @@ import {
   getLessonsForCollection,
   deleteCollection,
   deleteLesson,
+  updateCollection,
+  getAllGroups,
+  createGroup,
   type Collection,
+  type CollectionGroup,
   type LessonSummary,
 } from '@/lib/data-layer';
 
@@ -22,14 +26,16 @@ export default function CollectionPage({
   const router = useRouter();
   const [collection, setCollection] = useState<Collection | null>(null);
   const [lessons, setLessons] = useState<LessonSummary[]>([]);
+  const [groups, setGroups] = useState<CollectionGroup[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     async function load() {
       try {
-        const [col, les] = await Promise.all([
+        const [col, les, grps] = await Promise.all([
           getCollection(id),
           getLessonsForCollection(id),
+          getAllGroups(),
         ]);
         if (!col) {
           router.push('/');
@@ -37,6 +43,7 @@ export default function CollectionPage({
         }
         setCollection(col);
         setLessons(les);
+        setGroups(grps);
       } catch (err) {
         console.error('Error loading collection:', err);
       } finally {
@@ -56,6 +63,26 @@ export default function CollectionPage({
     if (!confirm(`Delete "${title}"?`)) return;
     await deleteLesson(lessonId);
     setLessons((prev) => prev.filter((l) => l.id !== lessonId));
+  }
+
+  async function handleGroupChange(value: string) {
+    if (value === '__new__') {
+      const name = prompt('New group name:');
+      if (!name?.trim()) return;
+      const newId = await createGroup(name.trim());
+      await updateCollection(id, { groupId: newId });
+      const [updatedCol, updatedGroups] = await Promise.all([
+        getCollection(id),
+        getAllGroups(),
+      ]);
+      if (updatedCol) setCollection(updatedCol);
+      setGroups(updatedGroups);
+    } else {
+      const groupId = value === '' ? null : value;
+      await updateCollection(id, { groupId });
+      const updatedCol = await getCollection(id);
+      if (updatedCol) setCollection(updatedCol);
+    }
   }
 
   function getContinueLesson(): LessonSummary | undefined {
@@ -104,8 +131,28 @@ export default function CollectionPage({
           </h1>
           <p className="mt-1 text-zinc-500 dark:text-zinc-400">
             {collection.author} &middot; {lessons.length} {lessons.length === 1 ? 'lesson' : 'lessons'}
-            {completedCount > 0 && ` &middot; ${completedCount} completed`}
+            {completedCount > 0 && ` \u00b7 ${completedCount} completed`}
           </p>
+
+          {/* Group selector */}
+          <div className="mt-3 flex items-center gap-2">
+            <label htmlFor="group-select" className="text-sm text-zinc-500 dark:text-zinc-400">
+              Group:
+            </label>
+            <select
+              id="group-select"
+              value={collection.groupId || ''}
+              onChange={(e) => handleGroupChange(e.target.value)}
+              className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-700 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+              data-testid="group-select"
+            >
+              <option value="">None</option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id}>{g.name}</option>
+              ))}
+              <option value="__new__">+ New group...</option>
+            </select>
+          </div>
 
           <div className="mt-4 flex items-center gap-3">
             {continueLesson && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,21 +9,29 @@ import WebImportModal from '@/components/WebImportModal';
 import PasteImportModal from '@/components/PasteImportModal';
 import {
   getAllCollections,
+  getAllGroups,
+  createGroup,
+  updateGroup,
+  deleteGroup,
   createStandaloneLesson,
   importEpub,
   getVocabStats,
   getRecentStats,
   type Collection,
+  type CollectionGroup,
 } from '@/lib/data-layer';
 
 export default function Home() {
   const [collections, setCollections] = useState<Collection[]>([]);
+  const [groups, setGroups] = useState<CollectionGroup[]>([]);
   const [knownWordsCount, setKnownWordsCount] = useState(0);
   const [currentStreak, setCurrentStreak] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isImporting, setIsImporting] = useState(false);
   const [isWebImportOpen, setIsWebImportOpen] = useState(false);
   const [isPasteImportOpen, setIsPasteImportOpen] = useState(false);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [isCreatingGroup, setIsCreatingGroup] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -32,13 +40,15 @@ export default function Home() {
 
   async function loadData() {
     try {
-      const [collectionsData, vocabStats, recentStats] = await Promise.all([
+      const [collectionsData, groupsData, vocabStats, recentStats] = await Promise.all([
         getAllCollections(),
+        getAllGroups(),
         getVocabStats(),
         getRecentStats(30),
       ]);
 
       setCollections(collectionsData);
+      setGroups(groupsData);
 
       const knownCount =
         vocabStats.byState.level3 +
@@ -139,6 +149,50 @@ export default function Home() {
     setCollections(updated);
   }
 
+  async function handleCreateGroup() {
+    if (!newGroupName.trim()) return;
+    await createGroup(newGroupName.trim());
+    setNewGroupName('');
+    setIsCreatingGroup(false);
+    const updated = await getAllGroups();
+    setGroups(updated);
+  }
+
+  async function handleRenameGroup(id: string, currentName: string) {
+    const name = prompt('Rename group:', currentName);
+    if (name === null || !name.trim() || name.trim() === currentName) return;
+    await updateGroup(id, { name: name.trim() });
+    const updated = await getAllGroups();
+    setGroups(updated);
+  }
+
+  async function handleDeleteGroup(id: string, name: string) {
+    if (!confirm(`Delete group "${name}"? Collections in this group will become ungrouped.`)) return;
+    await deleteGroup(id);
+    const [updatedGroups, updatedCollections] = await Promise.all([
+      getAllGroups(),
+      getAllCollections(),
+    ]);
+    setGroups(updatedGroups);
+    setCollections(updatedCollections);
+  }
+
+  // Group collections by groupId
+  const groupedCollections = new Map<string, Collection[]>();
+  const ungrouped: Collection[] = [];
+
+  for (const c of collections) {
+    if (c.groupId) {
+      const list = groupedCollections.get(c.groupId) || [];
+      list.push(c);
+      groupedCollections.set(c.groupId, list);
+    } else {
+      ungrouped.push(c);
+    }
+  }
+
+  const hasGroups = groups.length > 0;
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 sm:ml-56">
@@ -198,8 +252,52 @@ export default function Home() {
 
         {/* Library Section */}
         <section>
-          <div className="mb-6 flex items-center justify-between">
+          <div className="mb-6 flex items-center gap-3">
             <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Your Library</h2>
+            <div className="flex-1" />
+
+            {isCreatingGroup ? (
+              <form
+                onSubmit={(e) => { e.preventDefault(); handleCreateGroup(); }}
+                className="flex items-center gap-2"
+              >
+                <input
+                  type="text"
+                  value={newGroupName}
+                  onChange={(e) => setNewGroupName(e.target.value)}
+                  placeholder="Group name"
+                  autoFocus
+                  data-testid="new-group-input"
+                  className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                />
+                <button
+                  type="submit"
+                  data-testid="new-group-submit"
+                  className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setIsCreatingGroup(false); setNewGroupName(''); }}
+                  className="rounded-lg px-3 py-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                >
+                  Cancel
+                </button>
+              </form>
+            ) : (
+              <button
+                onClick={() => setIsCreatingGroup(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                data-testid="new-group-btn"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+                New Group
+              </button>
+            )}
+
             <ImportDropdown
               onFileImport={handleImportClick}
               onUrlImport={() => setIsWebImportOpen(true)}
@@ -226,17 +324,110 @@ export default function Home() {
             onSave={handlePasteImportSave}
           />
 
-          {collections.length > 0 ? (
-            <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-              {collections.map((collection) => (
-                <CollectionCard key={collection.id} collection={collection} />
-              ))}
+          {collections.length > 0 || hasGroups ? (
+            <div className="space-y-10">
+              {/* Grouped sections */}
+              {groups.map((group) => {
+                const items = groupedCollections.get(group.id) || [];
+                return (
+                  <div key={group.id} data-testid={`group-${group.id}`}>
+                    <div className="mb-4 flex items-center gap-3">
+                      <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200">
+                        {group.name}
+                      </h3>
+                      <span className="text-sm text-zinc-400 dark:text-zinc-500">
+                        {items.length} {items.length === 1 ? 'item' : 'items'}
+                      </span>
+                      <div className="flex-1" />
+                      <GroupMenu
+                        onRename={() => handleRenameGroup(group.id, group.name)}
+                        onDelete={() => handleDeleteGroup(group.id, group.name)}
+                      />
+                    </div>
+                    {items.length > 0 ? (
+                      <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                        {items.map((collection) => (
+                          <CollectionCard key={collection.id} collection={collection} />
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="rounded-xl border border-dashed border-zinc-200 py-8 text-center text-sm text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
+                        No collections in this group yet. Assign collections from their detail page.
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+
+              {/* Ungrouped */}
+              {ungrouped.length > 0 && (
+                <div data-testid="ungrouped-section">
+                  {hasGroups && (
+                    <h3 className="mb-4 text-lg font-semibold text-zinc-800 dark:text-zinc-200">
+                      Ungrouped
+                    </h3>
+                  )}
+                  <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                    {ungrouped.map((collection) => (
+                      <CollectionCard key={collection.id} collection={collection} />
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           ) : (
             <EmptyState onImport={handleImportClick} />
           )}
         </section>
       </main>
+    </div>
+  );
+}
+
+function GroupMenu({ onRename, onDelete }: { onRename: () => void; onDelete: () => void }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+        data-testid="group-menu-btn"
+      >
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 z-50 mt-1 w-36 rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+          <button
+            onClick={() => { setIsOpen(false); onRename(); }}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-700"
+            data-testid="group-rename-btn"
+          >
+            Rename
+          </button>
+          <button
+            onClick={() => { setIsOpen(false); onDelete(); }}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+            data-testid="group-delete-btn"
+          >
+            Delete
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -13,6 +13,7 @@ export type {
   ClozeSource,
   ClozeCollection,
   Collection,
+  CollectionGroup,
   Lesson,
   LessonSummary,
   VocabEntry,
@@ -25,6 +26,7 @@ export type {
 import type {
   WordState,
   Collection,
+  CollectionGroup,
   Lesson,
   LessonSummary,
   VocabEntry,
@@ -62,6 +64,45 @@ export async function createCollection(data: { title: string; author?: string })
 
 export async function deleteCollection(id: string): Promise<void> {
   await fetch(`/api/collections/${id}`, { method: 'DELETE' });
+}
+
+export async function updateCollection(id: string, data: { title?: string; author?: string; groupId?: string | null }): Promise<void> {
+  await fetch(`/api/collections/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+// ============================================================================
+// Helper Functions - Groups
+// ============================================================================
+
+export async function getAllGroups(): Promise<CollectionGroup[]> {
+  const res = await fetch('/api/groups');
+  return res.json();
+}
+
+export async function createGroup(name: string): Promise<string> {
+  const res = await fetch('/api/groups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  const { id } = await res.json();
+  return id;
+}
+
+export async function updateGroup(id: string, data: { name?: string; sortOrder?: number }): Promise<void> {
+  await fetch(`/api/groups/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteGroup(id: string): Promise<void> {
+  await fetch(`/api/groups/${id}`, { method: 'DELETE' });
 }
 
 // ============================================================================

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -15,10 +15,19 @@ export interface Collection {
   title: string;
   author: string;
   coverUrl?: string;
+  groupId?: string | null;
+  groupName?: string | null;
   lessonCount: number;
   avgProgress: number;
   createdAt: string;
   lastReadAt: string;
+}
+
+export interface CollectionGroup {
+  id: string;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
 }
 
 export interface Lesson {

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -139,6 +139,13 @@ function getDb(): DatabaseType {
     CREATE INDEX IF NOT EXISTS idx_journal_entryDate ON journal_entries(entryDate);
     CREATE INDEX IF NOT EXISTS idx_journal_status ON journal_entries(status);
 
+    CREATE TABLE IF NOT EXISTS collection_groups (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      createdAt TEXT NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS chat_messages (
       id TEXT PRIMARY KEY,
       role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
@@ -169,6 +176,11 @@ function getDb(): DatabaseType {
   const clozeCols = _db.prepare("PRAGMA table_info(clozeSentences)").all() as { name: string }[];
   if (!clozeCols.some(c => c.name === 'blacklisted')) {
     _db.exec('ALTER TABLE clozeSentences ADD COLUMN blacklisted INTEGER DEFAULT 0');
+  }
+
+  const collectionCols = _db.prepare("PRAGMA table_info(collections)").all() as { name: string }[];
+  if (!collectionCols.some(c => c.name === 'groupId')) {
+    _db.exec('ALTER TABLE collections ADD COLUMN groupId TEXT REFERENCES collection_groups(id) ON DELETE SET NULL');
   }
 
   // Remove FK constraint on vocab.bookId that references old books table
@@ -366,8 +378,16 @@ export interface CollectionRow {
   title: string;
   author: string;
   coverUrl: string | null;
+  groupId: string | null;
   createdAt: string;
   lastReadAt: string;
+}
+
+export interface CollectionGroupRow {
+  id: string;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
 }
 
 export interface LessonRow {


### PR DESCRIPTION
## Summary

- Add named collection groups (e.g. "Bybel", "Musiek") to organize the library
- New `collection_groups` table with full CRUD API (`/api/groups`)
- Home page renders collections in group sections with headings, item counts, and a three-dot menu (rename/delete)
- Collection detail page has a group dropdown selector with "None", existing groups, and "+ New group..."
- Ungrouped collections shown in a separate section when groups exist; flat grid preserved when no groups exist

## Test plan

- [x] Create group via UI — inline form on home page
- [x] Assign collection to group from detail page dropdown
- [x] Ungroup a collection (set to "None")
- [x] Rename group via three-dot menu
- [x] Delete group — collections become ungrouped
- [x] Create new group from detail page ("+ New group..." option)
- [x] API CRUD (GET/POST/PUT/DELETE) validation
- [x] Empty group name rejected (400)
- [x] 92 e2e tests pass locally (0 failures)

### Proof

| Step | Screenshot |
|------|-----------|
| Library with "New Group" button | ![before](https://docs.lukeboyle.com/proof/2026-05-03/groups-01-library-before-9eb67dee.png) |
| Inline group creation form | ![creating](https://docs.lukeboyle.com/proof/2026-05-03/groups-02-creating-group-a7ca782f.png) |
| Empty "Bybel" group + Ungrouped section | ![created](https://docs.lukeboyle.com/proof/2026-05-03/groups-03-group-created-a49a8cd7.png) |
| Group selector on detail page | ![detail](https://docs.lukeboyle.com/proof/2026-05-03/groups-04-detail-group-select-e57ffd07.png) |
| Collection assigned to "Bybel" | ![assigned](https://docs.lukeboyle.com/proof/2026-05-03/groups-05-assigned-to-bybel-60a1238d.png) |
| Library with grouped collection | ![grouped](https://docs.lukeboyle.com/proof/2026-05-03/groups-06-collection-in-group-89e4f0ac.png) |
| Group three-dot menu (Rename/Delete) | ![menu](https://docs.lukeboyle.com/proof/2026-05-03/groups-07-group-menu-160fa6e3.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
