### PR TITLE
fix: stop leaking Anthropic credentials, add auth mode toggle

### DIFF
--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -25,10 +25,25 @@ export function getProvider(): LLMProvider {
   let cacheKey: string;
   switch (name) {
     case 'anthropic': {
-      const apiKey = getSetting('anthropicApiKey') || undefined;
-      const oauthToken = getSetting('claudeOauthToken') || undefined;
+      const storedApiKey = getSetting('anthropicApiKey') || undefined;
+      const storedOauthToken = getSetting('claudeOauthToken') || undefined;
+      const authMode = getSetting('anthropicAuthMode') as string | null;
       const model = process.env.ANTHROPIC_MODEL || undefined;
-      cacheKey = `anthropic:${apiKey ? 'key' : oauthToken ? 'oauth' : 'env'}:${model || 'default'}`;
+
+      // Respect explicit auth mode; fall back to whichever credential is set
+      let apiKey: string | undefined;
+      let oauthToken: string | undefined;
+      if (authMode === 'oauth') {
+        oauthToken = storedOauthToken;
+      } else if (authMode === 'api_key') {
+        apiKey = storedApiKey;
+      } else {
+        apiKey = storedApiKey;
+        oauthToken = storedApiKey ? undefined : storedOauthToken;
+      }
+
+      const effectiveMode = apiKey ? 'key' : oauthToken ? 'oauth' : 'env';
+      cacheKey = `anthropic:${effectiveMode}:${model || 'default'}`;
       if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
       cachedProvider = new AnthropicProvider({ apiKey, oauthToken, model });
       break;

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono';
 import { db, SettingRow } from '../db';
 
+const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken']);
+
 const app = new Hono();
 
 // GET /api/settings
@@ -8,6 +10,10 @@ app.get('/', (c) => {
   const settings = db.prepare('SELECT * FROM settings').all() as SettingRow[];
   const result: Record<string, unknown> = {};
   for (const s of settings) {
+    if (SENSITIVE_KEYS.has(s.key)) {
+      result[s.key] = true;
+      continue;
+    }
     try {
       result[s.key] = JSON.parse(s.value);
     } catch {
@@ -37,6 +43,10 @@ app.get('/:key', (c) => {
   const setting = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as SettingRow | undefined;
 
   if (!setting) return c.json(null);
+
+  if (SENSITIVE_KEYS.has(key)) {
+    return c.json(true);
+  }
 
   try {
     return c.json(JSON.parse(setting.value));

--- a/e2e/settings-credentials.spec.ts
+++ b/e2e/settings-credentials.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Anthropic Credential Management", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    // Clean up any existing credentials
+    await page.request.delete("/api/settings/anthropicApiKey");
+    await page.request.delete("/api/settings/claudeOauthToken");
+    await page.request.delete("/api/settings/anthropicAuthMode");
+    // Set provider to anthropic so the credential UI shows
+    await page.request.put("/api/settings/llmProvider", {
+      data: { value: "anthropic" },
+    });
+  });
+
+  test("should not leak credentials in GET /api/settings", async ({
+    page,
+  }) => {
+    // Set a credential via PUT
+    await page.request.put("/api/settings/anthropicApiKey", {
+      data: { value: "sk-ant-api-test-secret-key" },
+    });
+
+    // GET all settings should return true, not the actual key
+    const res = await page.request.get("/api/settings");
+    const settings = await res.json();
+    expect(settings.anthropicApiKey).toBe(true);
+
+    // GET individual setting should also return true
+    const res2 = await page.request.get("/api/settings/anthropicApiKey");
+    const value = await res2.json();
+    expect(value).toBe(true);
+  });
+
+  test("should show input when no API key is configured", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Should show the API key input (not "Configured")
+    await expect(
+      page.getByPlaceholder("sk-ant-api...")
+    ).toBeVisible();
+    await expect(page.getByText("Configured").first()).not.toBeVisible();
+  });
+
+  test("should show Configured badge after saving API key", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Type a key and save
+    await page.getByPlaceholder("sk-ant-api...").fill("sk-ant-api-test-key");
+    await page.getByRole("button", { name: "Save" }).first().click();
+
+    // Should now show Configured badge
+    await expect(page.getByText("Configured").first()).toBeVisible();
+
+    // Should show Replace and Clear buttons
+    await expect(
+      page.getByRole("button", { name: "Replace" }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Clear" }).first()
+    ).toBeVisible();
+
+    // Input should be gone
+    await expect(page.getByPlaceholder("sk-ant-api...")).not.toBeVisible();
+  });
+
+  test("should clear a configured API key", async ({ page }) => {
+    // Pre-set a key
+    await page.request.put("/api/settings/anthropicApiKey", {
+      data: { value: "sk-ant-api-to-clear" },
+    });
+
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Should show Configured
+    await expect(page.getByText("Configured").first()).toBeVisible();
+
+    // Click Clear
+    await page.getByRole("button", { name: "Clear" }).first().click();
+
+    // Should show input again
+    await expect(page.getByPlaceholder("sk-ant-api...")).toBeVisible();
+    await expect(page.getByText("Configured").first()).not.toBeVisible();
+  });
+
+  test("should show Replace flow for configured API key", async ({
+    page,
+  }) => {
+    // Pre-set a key
+    await page.request.put("/api/settings/anthropicApiKey", {
+      data: { value: "sk-ant-api-original" },
+    });
+
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Click Replace
+    await page.getByRole("button", { name: "Replace" }).first().click();
+
+    // Should show input with Save and Cancel
+    await expect(page.getByPlaceholder("sk-ant-api...")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Cancel" }).first()
+    ).toBeVisible();
+
+    // Cancel should go back to Configured
+    await page.getByRole("button", { name: "Cancel" }).first().click();
+    await expect(page.getByText("Configured").first()).toBeVisible();
+  });
+
+  test("should NOT show auth mode toggle when only one credential is set", async ({
+    page,
+  }) => {
+    // Set only API key
+    await page.request.put("/api/settings/anthropicApiKey", {
+      data: { value: "sk-ant-api-only" },
+    });
+
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Auth mode toggle should not be visible
+    await expect(
+      page.getByText("Authentication Method")
+    ).not.toBeVisible();
+  });
+
+  test("should show auth mode toggle when both credentials are set", async ({
+    page,
+  }) => {
+    // Set both credentials
+    await page.request.put("/api/settings/anthropicApiKey", {
+      data: { value: "sk-ant-api-both" },
+    });
+    await page.request.put("/api/settings/claudeOauthToken", {
+      data: { value: "sk-ant-oat01-both" },
+    });
+
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Auth mode toggle should be visible
+    await expect(
+      page.getByText("Authentication Method")
+    ).toBeVisible();
+
+    // Both toggle buttons should be visible
+    const apiKeyBtn = page
+      .locator("button")
+      .filter({ hasText: /^API Key$/ });
+    const oauthBtn = page
+      .locator("button")
+      .filter({ hasText: /^OAuth Token$/ });
+    await expect(apiKeyBtn).toBeVisible();
+    await expect(oauthBtn).toBeVisible();
+
+    // Both credentials should show Configured
+    const configured = page.getByText("Configured");
+    await expect(configured).toHaveCount(2);
+  });
+
+  test("should test connection when toggling auth mode", async ({
+    page,
+  }) => {
+    // Set both credentials
+    await page.request.put("/api/settings/anthropicApiKey", {
+      data: { value: "sk-ant-api-toggle" },
+    });
+    await page.request.put("/api/settings/claudeOauthToken", {
+      data: { value: "sk-ant-oat01-toggle" },
+    });
+
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // Listen for the test connection request
+    const testPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/llm-status/test") &&
+        req.method() === "POST"
+    );
+
+    // Click OAuth toggle
+    const oauthBtn = page
+      .locator("button")
+      .filter({ hasText: /^OAuth Token$/ });
+    await oauthBtn.click();
+
+    // Should have fired a test connection request
+    const testReq = await testPromise;
+    expect(testReq.method()).toBe("POST");
+
+    // The auth mode setting should be saved
+    const res = await page.request.get("/api/settings/anthropicAuthMode");
+    const mode = await res.json();
+    expect(mode).toBe("oauth");
+  });
+});

--- a/e2e/settings-credentials.spec.ts
+++ b/e2e/settings-credentials.spec.ts
@@ -161,8 +161,8 @@ test.describe("Anthropic Credential Management", () => {
     await expect(apiKeyBtn).toBeVisible();
     await expect(oauthBtn).toBeVisible();
 
-    // Both credentials should show Configured
-    const configured = page.getByText("Configured");
+    // Both credentials should show Configured badges
+    const configured = page.getByText("Configured", { exact: true });
     await expect(configured).toHaveCount(2);
   });
 

--- a/src/app/api/settings/[key]/route.ts
+++ b/src/app/api/settings/[key]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, SettingRow } from '@/lib/server/database';
 
+const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken']);
+
 // GET /api/settings/[key]
 export async function GET(
   request: NextRequest,
@@ -11,6 +13,10 @@ export async function GET(
 
   if (!setting) {
     return NextResponse.json(null);
+  }
+
+  if (SENSITIVE_KEYS.has(key)) {
+    return NextResponse.json(true);
   }
 
   try {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, SettingRow } from '@/lib/server/database';
 
+const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken']);
+
 // GET /api/settings - Get all settings
 export async function GET() {
   const settings = db.prepare('SELECT * FROM settings').all() as SettingRow[];
   const result: Record<string, unknown> = {};
   for (const s of settings) {
+    if (SENSITIVE_KEYS.has(s.key)) {
+      result[s.key] = true;
+      continue;
+    }
     try {
       result[s.key] = JSON.parse(s.value);
     } catch {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   bulkUpdateWordStates,
   getSetting,
   setSetting,
+  deleteSetting,
   importFromDexie,
   getAllVocab,
   getAllKnownWords,
@@ -102,10 +103,13 @@ export default function SettingsPage() {
   const [ollamaModel, setOllamaModel] = useState("llama3.1:8b");
   const [apfelUrl, setApfelUrl] = useState("http://localhost:11434");
   const [apfelModel, setApfelModel] = useState("default");
-  const [anthropicApiKey, setAnthropicApiKey] = useState("");
-  const [claudeOauthToken, setClaudeOauthToken] = useState("");
-  const [showApiKey, setShowApiKey] = useState(false);
-  const [showOauthToken, setShowOauthToken] = useState(false);
+  const [hasApiKey, setHasApiKey] = useState(false);
+  const [hasOauthToken, setHasOauthToken] = useState(false);
+  const [newApiKey, setNewApiKey] = useState("");
+  const [newOauthToken, setNewOauthToken] = useState("");
+  const [editingApiKey, setEditingApiKey] = useState(false);
+  const [editingOauthToken, setEditingOauthToken] = useState(false);
+  const [anthropicAuthMode, setAnthropicAuthMode] = useState<"api_key" | "oauth">("api_key");
   const [llmStatus, setLlmStatus] = useState<LLMStatus | null>(null);
   const [llmTesting, setLlmTesting] = useState(false);
 
@@ -166,11 +170,14 @@ export default function SettingsPage() {
     getSetting<string>('apfelModel').then((m) => {
       if (m) setApfelModel(m);
     });
-    getSetting<string>('anthropicApiKey').then((k) => {
-      if (k) setAnthropicApiKey(k);
+    getSetting<boolean>('anthropicApiKey').then((v) => {
+      setHasApiKey(v === true);
     });
-    getSetting<string>('claudeOauthToken').then((t) => {
-      if (t) setClaudeOauthToken(t);
+    getSetting<boolean>('claudeOauthToken').then((v) => {
+      setHasOauthToken(v === true);
+    });
+    getSetting<string>('anthropicAuthMode').then((m) => {
+      if (m === 'api_key' || m === 'oauth') setAnthropicAuthMode(m);
     });
 
     // Check LLM status
@@ -290,17 +297,51 @@ export default function SettingsPage() {
   };
 
   const saveAnthropicApiKey = async (key: string) => {
-    setAnthropicApiKey(key);
     await setSetting('anthropicApiKey', key);
+    setHasApiKey(true);
+    setNewApiKey("");
+    setEditingApiKey(false);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const clearAnthropicApiKey = async () => {
+    await deleteSetting('anthropicApiKey');
+    setHasApiKey(false);
     await fetch('/api/llm-status/reset', { method: 'POST' });
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
   };
 
   const saveClaudeOauthToken = async (token: string) => {
-    setClaudeOauthToken(token);
     await setSetting('claudeOauthToken', token);
+    setHasOauthToken(true);
+    setNewOauthToken("");
+    setEditingOauthToken(false);
     await fetch('/api/llm-status/reset', { method: 'POST' });
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const clearClaudeOauthToken = async () => {
+    await deleteSetting('claudeOauthToken');
+    setHasOauthToken(false);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveAnthropicAuthMode = async (mode: "api_key" | "oauth") => {
+    setAnthropicAuthMode(mode);
+    await setSetting('anthropicAuthMode', mode);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    setLlmTesting(true);
+    try {
+      const res = await fetch('/api/llm-status/test', { method: 'POST' });
+      const data = await res.json();
+      setLlmStatus(prev => prev ? { ...prev, ok: data.ok, error: data.error } : { provider: llmProvider, model: ollamaModel, ok: data.ok, error: data.error });
+    } catch {
+      setLlmStatus(prev => prev ? { ...prev, ok: false, error: 'Failed to reach server' } : null);
+    } finally {
+      setLlmTesting(false);
+    }
   };
 
   const testLLMConnection = async () => {
@@ -711,6 +752,43 @@ export default function SettingsPage() {
             {/* Anthropic settings */}
             {llmProvider === "anthropic" && (
               <div className="mb-4 space-y-4">
+                {/* Auth mode toggle — only when both credentials are configured */}
+                {hasApiKey && hasOauthToken && (
+                  <div>
+                    <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                      Authentication Method
+                    </label>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => saveAnthropicAuthMode("api_key")}
+                        disabled={llmTesting}
+                        className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
+                          anthropicAuthMode === "api_key"
+                            ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400"
+                            : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                        }`}
+                      >
+                        API Key
+                      </button>
+                      <button
+                        onClick={() => saveAnthropicAuthMode("oauth")}
+                        disabled={llmTesting}
+                        className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
+                          anthropicAuthMode === "oauth"
+                            ? "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400"
+                            : "border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                        }`}
+                      >
+                        OAuth Token
+                      </button>
+                    </div>
+                    <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+                      Both credentials are configured. Choose which to use — connection will be tested automatically.
+                    </p>
+                  </div>
+                )}
+
+                {/* API Key */}
                 <div>
                   <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
                     API Key
@@ -726,27 +804,60 @@ export default function SettingsPage() {
                       console.anthropic.com
                     </a>
                   </p>
-                  <div className="flex gap-2">
-                    <input
-                      type={showApiKey ? "text" : "password"}
-                      value={anthropicApiKey}
-                      onChange={(e) => saveAnthropicApiKey(e.target.value)}
-                      placeholder="sk-ant-..."
-                      className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-                    />
-                    <button
-                      onClick={() => setShowApiKey(!showApiKey)}
-                      className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
-                    >
-                      {showApiKey ? "Hide" : "Show"}
-                    </button>
-                  </div>
+                  {hasApiKey && !editingApiKey ? (
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-2 text-sm font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
+                        <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                        Configured
+                      </span>
+                      <button
+                        onClick={() => setEditingApiKey(true)}
+                        className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                      >
+                        Replace
+                      </button>
+                      <button
+                        onClick={clearAnthropicApiKey}
+                        className="rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex gap-2">
+                      <input
+                        type="password"
+                        value={newApiKey}
+                        onChange={(e) => setNewApiKey(e.target.value)}
+                        placeholder="sk-ant-api..."
+                        className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                      />
+                      <button
+                        onClick={() => saveAnthropicApiKey(newApiKey)}
+                        disabled={!newApiKey.trim()}
+                        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Save
+                      </button>
+                      {editingApiKey && (
+                        <button
+                          onClick={() => { setEditingApiKey(false); setNewApiKey(""); }}
+                          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                        >
+                          Cancel
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
+
                 <div className="relative flex items-center py-2">
                   <div className="flex-grow border-t border-zinc-200 dark:border-zinc-700" />
                   <span className="mx-3 flex-shrink text-xs text-zinc-400 dark:text-zinc-500">or</span>
                   <div className="flex-grow border-t border-zinc-200 dark:border-zinc-700" />
                 </div>
+
+                {/* OAuth Token */}
                 <div>
                   <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
                     OAuth Token <span className="font-normal text-zinc-400">(Pro/Team plan)</span>
@@ -754,21 +865,51 @@ export default function SettingsPage() {
                   <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
                     Uses your Claude Pro or Team subscription credits. Run <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">claude setup-token</code> to obtain a token. Note: slower initial startup than API keys.
                   </p>
-                  <div className="flex gap-2">
-                    <input
-                      type={showOauthToken ? "text" : "password"}
-                      value={claudeOauthToken}
-                      onChange={(e) => saveClaudeOauthToken(e.target.value)}
-                      placeholder="sk-ant-oat01-..."
-                      className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-                    />
-                    <button
-                      onClick={() => setShowOauthToken(!showOauthToken)}
-                      className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
-                    >
-                      {showOauthToken ? "Hide" : "Show"}
-                    </button>
-                  </div>
+                  {hasOauthToken && !editingOauthToken ? (
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-2 text-sm font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
+                        <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                        Configured
+                      </span>
+                      <button
+                        onClick={() => setEditingOauthToken(true)}
+                        className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                      >
+                        Replace
+                      </button>
+                      <button
+                        onClick={clearClaudeOauthToken}
+                        className="rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex gap-2">
+                      <input
+                        type="password"
+                        value={newOauthToken}
+                        onChange={(e) => setNewOauthToken(e.target.value)}
+                        placeholder="sk-ant-oat01-..."
+                        className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                      />
+                      <button
+                        onClick={() => saveClaudeOauthToken(newOauthToken)}
+                        disabled={!newOauthToken.trim()}
+                        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Save
+                      </button>
+                      {editingOauthToken && (
+                        <button
+                          onClick={() => { setEditingOauthToken(false); setNewOauthToken(""); }}
+                          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                        >
+                          Cancel
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary

- **Stop leaking credentials:** Settings API GET endpoints now return `true` for `anthropicApiKey` and `claudeOauthToken` instead of the actual values. Credentials are write-only from the frontend.
- **Reworked settings UI:** Credential fields show "Configured" status with Replace/Clear actions instead of displaying raw values in password inputs.
- **Auth mode toggle:** When both API key and OAuth token are configured, a toggle lets users explicitly choose which to use. Toggling automatically tests the connection.
- **Fixed silent precedence bug:** The LLM provider now respects an explicit `anthropicAuthMode` setting instead of silently preferring API key over OAuth token.

## Test plan

- [x] Verify `GET /api/settings` and `GET /api/settings/anthropicApiKey` return `true`, not the actual key — [proof](https://github.com/heuwels/lector/pull/79#issuecomment-4370396473)
- [x] Set both credentials -> auth toggle appears, both show "Configured" — [proof](https://github.com/heuwels/lector/pull/79#issuecomment-4370396615)
- [x] Clear a credential -> input reappears, toggle disappears if only one remains — [proof](https://github.com/heuwels/lector/pull/79#issuecomment-4370396758)
- [ ] E2E: `npx playwright test e2e/settings-credentials.spec.ts`
- [ ] Full suite: `npx playwright test`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
