### PR TITLE
fix: activity heatmap and streak read from dictionaryLookups (closes #77)

### DIFF
--- a/e2e/activity-heatmap.spec.ts
+++ b/e2e/activity-heatmap.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Activity Heatmap", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+  });
+
+  test("renders on stats page with lookup-based total", async ({ page }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const heatmap = page.locator('[data-testid="activity-heatmap"]');
+    await expect(heatmap).toBeVisible({ timeout: 10000 });
+
+    const total = page.locator('[data-testid="activity-heatmap-total"]');
+    await expect(total).toBeVisible();
+    await expect(total).toHaveText(/^\d[\d,]*\s+lookups in the last year$/);
+  });
+
+  test("reflects new dictionary lookups after a reload", async ({ page }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const total = page.locator('[data-testid="activity-heatmap-total"]');
+    const initialText = (await total.textContent()) ?? "";
+    const initialCount = parseInt(initialText.replace(/[^\d]/g, ""), 10) || 0;
+
+    const bump = 3;
+    for (let i = 0; i < bump; i++) {
+      const res = await page.request.put("/api/stats/today", {
+        data: { field: "dictionaryLookups", amount: 1 },
+      });
+      expect(res.ok()).toBeTruthy();
+    }
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const updatedText = (await total.textContent()) ?? "";
+    const updatedCount = parseInt(updatedText.replace(/[^\d]/g, ""), 10) || 0;
+    expect(updatedCount).toBe(initialCount + bump);
+  });
+});

--- a/e2e/streak.spec.ts
+++ b/e2e/streak.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Reading Streak", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+  });
+
+  test("home page streak counts a day with dictionary lookups", async ({ page }) => {
+    // Make sure today registers as a reading day
+    const res = await page.request.put("/api/stats/today", {
+      data: { field: "dictionaryLookups", amount: 1 },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const card = page.locator('[data-testid="current-streak"]');
+    await expect(card).toBeVisible({ timeout: 10000 });
+
+    // Streak text reads "N day(s)" with N >= 1
+    const text = (await card.textContent()) ?? "";
+    const match = text.match(/(\d+)\s+days?/);
+    expect(match).not.toBeNull();
+    const streakDays = parseInt(match![1], 10);
+    expect(streakDays).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ export default function Home() {
     }
   }
 
-  function calculateStreak(stats: { date: string; wordsRead: number }[]): number {
+  function calculateStreak(stats: { date: string; dictionaryLookups: number }[]): number {
     if (stats.length === 0) return 0;
 
     const sorted = [...stats].sort((a, b) => b.date.localeCompare(a.date));
@@ -73,9 +73,9 @@ export default function Home() {
     const today = new Date().toISOString().split('T')[0];
     const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
 
-    const hasActivityToday = sorted.some((s) => s.date === today && s.wordsRead > 0);
+    const hasActivityToday = sorted.some((s) => s.date === today && s.dictionaryLookups > 0);
     const hasActivityYesterday = sorted.some(
-      (s) => s.date === yesterday && s.wordsRead > 0
+      (s) => s.date === yesterday && s.dictionaryLookups > 0
     );
 
     if (!hasActivityToday && !hasActivityYesterday) return 0;
@@ -84,7 +84,7 @@ export default function Home() {
     let checkDate = hasActivityToday ? today : yesterday;
 
     for (const stat of sorted) {
-      if (stat.date === checkDate && stat.wordsRead > 0) {
+      if (stat.date === checkDate && stat.dictionaryLookups > 0) {
         streak++;
         const prevDate = new Date(checkDate);
         prevDate.setDate(prevDate.getDate() - 1);
@@ -229,6 +229,7 @@ export default function Home() {
             }
           />
           <StatsCard
+            testId="current-streak"
             label="Current Streak"
             value={`${currentStreak} ${currentStreak === 1 ? 'day' : 'days'}`}
             icon={

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -447,10 +447,10 @@ export default function StatsPage() {
         // Calculate streaks
         const { current: currentStreak, longest: longestStreak } = calculateStreak(dailyStats);
 
-        // Build activity heatmap data (words read per day)
+        // Build activity heatmap data (dictionary lookups per day)
         const activityData = dailyStats.map((d) => ({
           date: d.date,
-          count: d.wordsRead,
+          count: d.dictionaryLookups,
         }));
 
         // Build vocab growth data (cumulative over time)

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -344,7 +344,7 @@ function calculateStreak(dailyStats: DailyStats[]): { current: number; longest: 
 
   // Calculate current streak
   for (const stat of sorted) {
-    const hasActivity = stat.wordsRead > 0 || stat.clozePracticed > 0;
+    const hasActivity = stat.dictionaryLookups > 0 || stat.clozePracticed > 0;
     if (!hasActivity) continue;
 
     if (currentStreak === 0) {
@@ -370,7 +370,7 @@ function calculateStreak(dailyStats: DailyStats[]): { current: number; longest: 
   // Calculate longest streak
   lastDate = null;
   for (const stat of sorted) {
-    const hasActivity = stat.wordsRead > 0 || stat.clozePracticed > 0;
+    const hasActivity = stat.dictionaryLookups > 0 || stat.clozePracticed > 0;
     if (!hasActivity) {
       longestStreak = Math.max(longestStreak, tempStreak);
       tempStreak = 0;

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -138,11 +138,11 @@ export default function ActivityHeatmap({
   }, [data]);
 
   return (
-    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6">
+    <div data-testid="activity-heatmap" className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Activity</h3>
-        <div className="text-sm text-zinc-500 dark:text-slate-400">
-          {totalActivity.toLocaleString()} words in the last year
+        <div data-testid="activity-heatmap-total" className="text-sm text-zinc-500 dark:text-slate-400">
+          {totalActivity.toLocaleString()} lookups in the last year
         </div>
       </div>
 
@@ -187,7 +187,7 @@ export default function ActivityHeatmap({
                   key={day.date}
                   className="w-[12px] h-[12px] rounded-sm transition-colors hover:ring-1 hover:ring-black/20 dark:hover:ring-white/30"
                   style={{ backgroundColor: getColor(day.count, maxCount, colorScheme) }}
-                  title={`${day.date}: ${day.count} words read`}
+                  title={`${day.date}: ${day.count} lookups`}
                 />
               ))}
               {/* Fill empty days for incomplete weeks */}

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -3,11 +3,13 @@ interface StatsCardProps {
   value: string | number;
   icon?: React.ReactNode;
   highlight?: boolean;
+  testId?: string;
 }
 
-export default function StatsCard({ label, value, icon, highlight = false }: StatsCardProps) {
+export default function StatsCard({ label, value, icon, highlight = false, testId }: StatsCardProps) {
   return (
     <div
+      data-testid={testId}
       className={`flex items-center gap-4 rounded-xl border p-4 ${
         highlight
           ? 'border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 dark:border-amber-900/50 dark:from-amber-950/30 dark:to-orange-950/30'


### PR DESCRIPTION
## Summary

Fixes #77 and the related streak bug, both caused by the same dead `wordsRead` field — declared in the schema, allowed by the API, and read by display code, but never written by any code path.

- **Activity heatmap** (`/stats`) now reads `dictionaryLookups` instead of `wordsRead`. Heatmap copy and tooltip updated to "lookups".
- **Streak** on both the home page and `/stats` now treats a day as active if it has any dictionary lookups (or cloze practice, on `/stats`). Previously reading-only days didn't extend the streak — only cloze did.

The `dictionaryLookups` counter increments on every word/phrase tap in the reader, so this captures real reading engagement, including re-reads and phrase study.

## Not addressed here

- "Time Reading" stat card on `/stats` — still stuck at 0 because `minutesRead` has the same dead-field problem. That one needs actual time-on-page instrumentation rather than a metric swap, so it's a separate fix.
- The `wordsRead` column itself is still in the schema; removing it would require a DB migration and isn't necessary for this fix.

## Test plan

- [x] `e2e/activity-heatmap.spec.ts` — heatmap renders with new copy; bumping `dictionaryLookups` via the existing PUT API increases the displayed total after reload
- [x] `e2e/streak.spec.ts` — home page streak counts a day with lookups
- [x] Full e2e suite: 95 passed, 1 skipped, 0 failed
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
