### PR TITLE
feat: add/edit lessons within a collection (#76)

### DIFF
--- a/e2e/collections.spec.ts
+++ b/e2e/collections.spec.ts
@@ -189,6 +189,132 @@ test.describe("Collections & Lessons", () => {
     await expect(card.first()).toBeVisible({ timeout: 10000 });
   });
 
+  test("should add a lesson to an existing collection", async ({ page }) => {
+    // Seed a collection via API
+    const epubPath = path.join(__dirname, "fixtures/test-book.epub");
+    const fs = await import("fs");
+    const buffer = fs.readFileSync(epubPath);
+
+    const importRes = await page.request.post("/api/import/epub", {
+      multipart: {
+        file: {
+          name: "test-book.epub",
+          mimeType: "application/epub+zip",
+          buffer,
+        },
+      },
+    });
+    const { collectionId } = await importRes.json();
+
+    await page.goto(`/collection/${collectionId}`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText("3 lessons")).toBeVisible();
+
+    // Click "Add lesson" — opens the modal
+    await page.getByTestId("add-lesson").click();
+
+    await page.locator("#lesson-title").fill("Toets Hoofstuk 4");
+    await page.locator("#lesson-content").fill(
+      "Hierdie is die vierde hoofstuk wat handmatig bygevoeg is."
+    );
+
+    await page.getByRole("button", { name: "Create lesson" }).click();
+
+    // New lesson should appear in the list and the count should update
+    await expect(page.getByText("Toets Hoofstuk 4")).toBeVisible();
+    await expect(page.getByText("4 lessons")).toBeVisible();
+  });
+
+  test("should rename a lesson via the edit modal", async ({ page }) => {
+    const epubPath = path.join(__dirname, "fixtures/test-book.epub");
+    const fs = await import("fs");
+    const buffer = fs.readFileSync(epubPath);
+
+    const importRes = await page.request.post("/api/import/epub", {
+      multipart: {
+        file: {
+          name: "test-book.epub",
+          mimeType: "application/epub+zip",
+          buffer,
+        },
+      },
+    });
+    const { collectionId } = await importRes.json();
+    const lessonsRes = await page.request.get(
+      `/api/collections/${collectionId}/lessons`
+    );
+    const lessons = await lessonsRes.json();
+    const firstLessonId = lessons[0].id;
+
+    await page.goto(`/collection/${collectionId}`);
+    await page.waitForLoadState("networkidle");
+
+    // The edit affordance is hidden until row hover, but click works regardless
+    await page.getByTestId(`edit-lesson-${firstLessonId}`).click();
+
+    await expect(page.locator("#lesson-title")).toHaveValue(
+      "Hoofstuk 1: Die Begin"
+    );
+
+    await page.locator("#lesson-title").fill("Hoofstuk 1: Die Hernoemde Begin");
+    await page.getByRole("button", { name: "Save changes" }).click();
+
+    await expect(
+      page.getByText("Hoofstuk 1: Die Hernoemde Begin")
+    ).toBeVisible();
+    await expect(page.getByText("Hoofstuk 1: Die Begin")).not.toBeVisible();
+  });
+
+  test("should edit lesson content and refresh the word count", async ({
+    page,
+  }) => {
+    const epubPath = path.join(__dirname, "fixtures/test-book.epub");
+    const fs = await import("fs");
+    const buffer = fs.readFileSync(epubPath);
+
+    const importRes = await page.request.post("/api/import/epub", {
+      multipart: {
+        file: {
+          name: "test-book.epub",
+          mimeType: "application/epub+zip",
+          buffer,
+        },
+      },
+    });
+    const { collectionId } = await importRes.json();
+    const lessonsRes = await page.request.get(
+      `/api/collections/${collectionId}/lessons`
+    );
+    const lessons = await lessonsRes.json();
+    const firstLessonId = lessons[0].id;
+    const originalWordCount = lessons[0].wordCount;
+
+    await page.goto(`/collection/${collectionId}`);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId(`edit-lesson-${firstLessonId}`).click();
+
+    // Replace content with something of a known, very different word count
+    const newContent = Array.from({ length: 5 }, (_, i) => `woord${i + 1}`).join(
+      " "
+    );
+    await page.locator("#lesson-content").fill(newContent);
+    await page.getByRole("button", { name: "Save changes" }).click();
+
+    // Wait for the modal to close and the row to re-render
+    await expect(page.locator("#lesson-content")).not.toBeVisible();
+
+    // Word count should now be 5, not the original
+    expect(originalWordCount).not.toBe(5);
+    await expect(
+      page
+        .getByText("Hoofstuk 1: Die Begin")
+        .locator("..")
+        .locator("..")
+        .getByText("5 words")
+    ).toBeVisible();
+  });
+
   test("should delete a collection", async ({ page }) => {
     // Create via API
     const epubPath = path.join(__dirname, "fixtures/test-book.epub");

--- a/src/app/api/lessons/[id]/route.ts
+++ b/src/app/api/lessons/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, LessonRow } from '@/lib/server/database';
+import { countWords } from '@/lib/html-to-markdown';
 
 // GET /api/lessons/[id]
 export async function GET(
@@ -28,7 +29,10 @@ export async function PUT(
   const values: unknown[] = [];
 
   if (body.title !== undefined) { updates.push('title = ?'); values.push(body.title); }
-  if (body.textContent !== undefined) { updates.push('textContent = ?'); values.push(body.textContent); }
+  if (body.textContent !== undefined) {
+    updates.push('textContent = ?'); values.push(body.textContent);
+    updates.push('wordCount = ?'); values.push(countWords(body.textContent));
+  }
   if (body.sortOrder !== undefined) { updates.push('sortOrder = ?'); values.push(body.sortOrder); }
   if (body.collectionId !== undefined) { updates.push('collectionId = ?'); values.push(body.collectionId); }
 

--- a/src/app/collection/[id]/page.tsx
+++ b/src/app/collection/[id]/page.tsx
@@ -4,9 +4,13 @@ import { useEffect, useState, use } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import NavHeader from '@/components/NavHeader';
+import LessonFormModal from '@/components/LessonFormModal';
 import {
   getCollection,
   getLessonsForCollection,
+  getLesson,
+  addLessonToCollection,
+  updateLesson,
   deleteCollection,
   deleteLesson,
   updateCollection,
@@ -28,6 +32,9 @@ export default function CollectionPage({
   const [lessons, setLessons] = useState<LessonSummary[]>([]);
   const [groups, setGroups] = useState<CollectionGroup[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [editingLessonId, setEditingLessonId] = useState<string | null>(null);
+  const [editingInitial, setEditingInitial] = useState<{ title: string; textContent: string } | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -63,6 +70,29 @@ export default function CollectionPage({
     if (!confirm(`Delete "${title}"?`)) return;
     await deleteLesson(lessonId);
     setLessons((prev) => prev.filter((l) => l.id !== lessonId));
+  }
+
+  async function refreshLessons() {
+    const updated = await getLessonsForCollection(id);
+    setLessons(updated);
+  }
+
+  async function handleAddLesson(data: { title: string; textContent: string }) {
+    await addLessonToCollection(id, data);
+    await refreshLessons();
+  }
+
+  async function openEditLesson(lessonId: string) {
+    const lesson = await getLesson(lessonId);
+    if (!lesson) return;
+    setEditingInitial({ title: lesson.title, textContent: lesson.textContent ?? '' });
+    setEditingLessonId(lessonId);
+  }
+
+  async function handleEditLesson(data: { title: string; textContent: string }) {
+    if (!editingLessonId) return;
+    await updateLesson(editingLessonId, data);
+    await refreshLessons();
   }
 
   async function handleGroupChange(value: string) {
@@ -228,6 +258,18 @@ export default function CollectionPage({
                   </svg>
                 </Link>
 
+                {/* Edit button */}
+                <button
+                  onClick={() => openEditLesson(lesson.id)}
+                  className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all hover:bg-zinc-100 hover:text-zinc-700 group-hover:opacity-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                  title="Edit lesson"
+                  data-testid={`edit-lesson-${lesson.id}`}
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                </button>
+
                 {/* Delete button */}
                 <button
                   onClick={() => handleDeleteLesson(lesson.id, lesson.title)}
@@ -241,7 +283,36 @@ export default function CollectionPage({
               </div>
             );
           })}
+
+          {/* Add lesson button */}
+          <button
+            onClick={() => setIsAddOpen(true)}
+            data-testid="add-lesson"
+            className="group flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-300 bg-transparent px-5 py-4 text-sm font-medium text-zinc-500 transition-all hover:border-zinc-400 hover:bg-white hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-900 dark:hover:text-zinc-200"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Add lesson
+          </button>
         </div>
+
+        <LessonFormModal
+          isOpen={isAddOpen}
+          mode="create"
+          onClose={() => setIsAddOpen(false)}
+          onSave={handleAddLesson}
+        />
+        <LessonFormModal
+          isOpen={editingLessonId !== null}
+          mode="edit"
+          initial={editingInitial}
+          onClose={() => {
+            setEditingLessonId(null);
+            setEditingInitial(null);
+          }}
+          onSave={handleEditLesson}
+        />
       </main>
     </div>
   );

--- a/src/components/LessonFormModal.tsx
+++ b/src/components/LessonFormModal.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+
+interface LessonFormModalProps {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  initial?: { title: string; textContent: string } | null;
+  onClose: () => void;
+  onSave: (data: { title: string; textContent: string }) => Promise<void>;
+}
+
+export default function LessonFormModal({
+  isOpen,
+  mode,
+  initial,
+  onClose,
+  onSave,
+}: LessonFormModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const [title, setTitle] = useState('');
+  const [textContent, setTextContent] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional reset on open/close */
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(initial?.title ?? '');
+      setTextContent(initial?.textContent ?? '');
+      setIsSaving(false);
+      requestAnimationFrame(() => setIsVisible(true));
+      setTimeout(() => titleRef.current?.focus(), 100);
+    } else {
+      setIsVisible(false);
+    }
+  }, [isOpen, initial]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const timeoutId = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 100);
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const wordCount = textContent.trim() ? textContent.trim().split(/\s+/).length : 0;
+
+  const handleSave = useCallback(async () => {
+    if (!title.trim() || !textContent.trim()) return;
+    setIsSaving(true);
+    try {
+      await onSave({ title: title.trim(), textContent: textContent.trim() });
+      onClose();
+    } catch {
+      setIsSaving(false);
+    }
+  }, [title, textContent, onSave, onClose]);
+
+  if (!isOpen || typeof window === 'undefined') return null;
+
+  const heading = mode === 'create' ? 'Add lesson' : 'Edit lesson';
+  const submitLabel = mode === 'create' ? 'Create lesson' : 'Save changes';
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+      <div
+        ref={modalRef}
+        className={`
+          w-full max-w-2xl max-h-[85vh]
+          bg-white dark:bg-zinc-900
+          rounded-2xl shadow-2xl
+          border border-zinc-200 dark:border-zinc-700
+          overflow-hidden flex flex-col
+          transition-all duration-200 ease-out
+          ${isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}
+        `}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-700">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{heading}</h2>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          <div>
+            <label htmlFor="lesson-title" className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+              Title
+            </label>
+            <input
+              ref={titleRef}
+              id="lesson-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={isSaving}
+              placeholder="Lesson title"
+              className="w-full px-4 py-2.5 rounded-lg border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 disabled:opacity-50"
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label htmlFor="lesson-content" className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Text
+              </label>
+              {wordCount > 0 && (
+                <span className="text-xs text-zinc-400 dark:text-zinc-500">{wordCount.toLocaleString()} words</span>
+              )}
+            </div>
+            <textarea
+              id="lesson-content"
+              value={textContent}
+              onChange={(e) => setTextContent(e.target.value)}
+              disabled={isSaving}
+              placeholder="Lesson text. Markdown is supported."
+              rows={12}
+              className="w-full px-4 py-3 rounded-lg border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:focus:ring-zinc-100 disabled:opacity-50 resize-none text-sm leading-relaxed"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
+          <button
+            onClick={onClose}
+            disabled={isSaving}
+            className="px-4 py-2 rounded-lg text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 font-medium transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !title.trim() || !textContent.trim()}
+            className="px-5 py-2 rounded-lg bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 font-medium hover:bg-zinc-800 dark:hover:bg-zinc-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {isSaving ? (
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 border-2 border-white/30 border-t-white dark:border-zinc-900/30 dark:border-t-zinc-900 rounded-full animate-spin" />
+                Saving...
+              </div>
+            ) : (
+              submitLabel
+            )}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -145,6 +145,17 @@ export async function addLessonToCollection(
   return id;
 }
 
+export async function updateLesson(
+  id: string,
+  data: { title?: string; textContent?: string }
+): Promise<void> {
+  await fetch(`/api/lessons/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
 export async function deleteLesson(id: string): Promise<void> {
   await fetch(`/api/lessons/${id}`, { method: 'DELETE' });
 }


### PR DESCRIPTION
Closes #76.

## Summary
- New `LessonFormModal` (shared create + edit) wired into the collection page: "Add lesson" trigger button at the bottom of the lesson list, plus a per-row edit affordance
- `updateLesson` helper in the data layer; PUT `/api/lessons/[id]` now recomputes `wordCount` when `textContent` changes (matches POST behaviour; previously stale)
- Three new e2e tests covering add, rename, and content-edit (with word-count refresh)

## Test plan
- [x] Add lesson via the "+ Add lesson" button on a collection page — [proof](https://github.com/heuwels/lector/pull/87#issuecomment-4407123261)
- [x] Rename a lesson via the edit affordance — [proof](https://github.com/heuwels/lector/pull/87#issuecomment-4407124013)
- [x] Edit a lesson's text content and confirm the word count updates on the row — [proof](https://github.com/heuwels/lector/pull/87#issuecomment-4407124690)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
