### PR TITLE
feat: add LM Studio as an LLM provider

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -145,6 +145,7 @@ function getDb(): Database {
       role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
       content TEXT NOT NULL,
       provider TEXT,
+      responseId TEXT,
       createdAt TEXT NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_chat_messages_createdAt ON chat_messages(createdAt);
@@ -159,6 +160,11 @@ function getDb(): Database {
   const clozeCols = _db.prepare("PRAGMA table_info(clozeSentences)").all() as { name: string }[];
   if (!clozeCols.some(c => c.name === 'blacklisted')) {
     _db.exec('ALTER TABLE clozeSentences ADD COLUMN blacklisted INTEGER DEFAULT 0');
+  }
+
+  const chatCols = _db.prepare("PRAGMA table_info(chat_messages)").all() as { name: string }[];
+  if (!chatCols.some(c => c.name === 'responseId')) {
+    _db.exec('ALTER TABLE chat_messages ADD COLUMN responseId TEXT');
   }
 
   migrateVocabForeignKey(_db);
@@ -487,5 +493,6 @@ export interface ChatMessageRow {
   role: 'user' | 'assistant';
   content: string;
   provider: string | null;
+  responseId: string | null;
   createdAt: string;
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -24,6 +24,7 @@ import llmStatus from './routes/llm-status';
 import tokens from './routes/tokens';
 import translateCompare from './routes/translate-compare';
 import chat from './routes/chat';
+import llmLmstudio from './routes/llm-lmstudio';
 import { authMiddleware } from './lib/auth';
 
 const app = new Hono();
@@ -53,6 +54,7 @@ app.route('/api/llm-status', llmStatus);
 app.route('/api/tokens', tokens);
 app.route('/api/translate-compare', translateCompare);
 app.route('/api/chat', chat);
+app.route('/api/llm/lmstudio', llmLmstudio);
 
 // Capture unhandled errors to Sentry/GlitchTip
 app.onError((err, c) => {

--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -2,6 +2,7 @@ import type { LLMProvider } from './types';
 import { OllamaProvider } from './ollama';
 import { AnthropicProvider } from './anthropic';
 import { ApfelProvider } from './apfel';
+import { LMStudioProvider } from './lmstudio';
 import { db } from '../../db';
 
 export type { LLMProvider, ChatMessage, CompletionOptions } from './types';
@@ -63,6 +64,15 @@ export function getProvider(): LLMProvider {
       cachedProvider = new OllamaProvider(undefined, model);
       break;
     }
+    case 'lmstudio': {
+      const baseUrl = getSetting('lmstudioUrl') || process.env.LMSTUDIO_URL || undefined;
+      const model = getSetting('lmstudioModel') || process.env.LMSTUDIO_MODEL || undefined;
+      const apiKey = getSetting('lmstudioApiKey') || process.env.LMSTUDIO_API_KEY || undefined;
+      cacheKey = `lmstudio:${baseUrl || 'default'}:${model || 'default'}:${apiKey ? 'keyed' : 'open'}`;
+      if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
+      cachedProvider = new LMStudioProvider({ baseUrl, model, apiKey });
+      break;
+    }
     default: {
       cacheKey = `${name}:default`;
       if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
@@ -86,10 +96,15 @@ export function getAllProviders(): Record<string, LLMProvider> {
 
   const ollamaModel = getSetting('ollamaModel') || process.env.OLLAMA_MODEL || undefined;
 
+  const lmstudioUrl = getSetting('lmstudioUrl') || process.env.LMSTUDIO_URL || undefined;
+  const lmstudioModel = getSetting('lmstudioModel') || process.env.LMSTUDIO_MODEL || undefined;
+  const lmstudioApiKey = getSetting('lmstudioApiKey') || process.env.LMSTUDIO_API_KEY || undefined;
+
   return {
     claude: new AnthropicProvider({ apiKey, oauthToken, model: anthropicModel }),
     apfel: new ApfelProvider(apfelUrl, apfelModel),
     ollama: new OllamaProvider(undefined, ollamaModel),
+    lmstudio: new LMStudioProvider({ baseUrl: lmstudioUrl, model: lmstudioModel, apiKey: lmstudioApiKey }),
   };
 }
 

--- a/api/src/lib/llm/lmstudio.test.ts
+++ b/api/src/lib/llm/lmstudio.test.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect, afterEach, mock } from 'bun:test';
+import { LMStudioProvider, LMStudioInvalidResponseIdError } from './lmstudio';
+
+describe('LMStudioProvider', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('constructor', () => {
+    test('uses defaults when no options provided', () => {
+      const provider = new LMStudioProvider();
+      expect(provider.name).toBe('lmstudio');
+    });
+
+    test('strips trailing slash from baseUrl', async () => {
+      const provider = new LMStudioProvider({ baseUrl: 'http://custom:1234/' });
+      globalThis.fetch = mock(async (url: string) => {
+        expect(url).toBe('http://custom:1234/v1/models');
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }) as typeof fetch;
+      await provider.healthCheck();
+    });
+
+    test('omits Authorization header when no apiKey', async () => {
+      const provider = new LMStudioProvider({ baseUrl: 'http://x:1234' });
+      globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBeUndefined();
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }) as typeof fetch;
+      await provider.healthCheck();
+    });
+
+    test('sets Authorization header when apiKey provided', async () => {
+      const provider = new LMStudioProvider({ baseUrl: 'http://x:1234', apiKey: 'sk-abc' });
+      globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer sk-abc');
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }) as typeof fetch;
+      await provider.healthCheck();
+    });
+  });
+
+  describe('complete', () => {
+    test('sends OpenAI-shaped request to /v1/chat/completions', async () => {
+      globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+        expect(url).toBe('http://localhost:1234/v1/chat/completions');
+        const body = JSON.parse(init?.body as string);
+        expect(body.model).toBe('my-model');
+        expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
+        expect(body.max_tokens).toBe(50);
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: 'hello back' } }] }),
+          { status: 200 },
+        );
+      }) as typeof fetch;
+
+      const provider = new LMStudioProvider({ model: 'my-model' });
+      const result = await provider.complete({
+        messages: [{ role: 'user', content: 'Hi' }],
+        maxTokens: 50,
+      });
+      expect(result).toBe('hello back');
+    });
+
+    test('returns empty string when response has no choices', async () => {
+      globalThis.fetch = mock(async () => new Response(JSON.stringify({ choices: [] }), { status: 200 })) as typeof fetch;
+      const provider = new LMStudioProvider();
+      const result = await provider.complete({ messages: [{ role: 'user', content: 'Hi' }], maxTokens: 10 });
+      expect(result).toBe('');
+    });
+
+    test('throws on non-OK response', async () => {
+      globalThis.fetch = mock(async () => new Response('Bad request', { status: 400 })) as typeof fetch;
+      const provider = new LMStudioProvider();
+      await expect(
+        provider.complete({ messages: [{ role: 'user', content: 'Hi' }], maxTokens: 10 }),
+      ).rejects.toThrow('LM Studio error: Bad request');
+    });
+  });
+
+  describe('chatStateful', () => {
+    test('sends input + system_prompt without previous_response_id on first call', async () => {
+      globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+        expect(url).toBe('http://localhost:1234/api/v1/chat');
+        const body = JSON.parse(init?.body as string);
+        expect(body.model).toBe('m');
+        expect(body.input).toBe('hello');
+        expect(body.system_prompt).toBe('You are a tutor');
+        expect(body.previous_response_id).toBeUndefined();
+        return new Response(
+          JSON.stringify({
+            response_id: 'resp_123',
+            output: [{ type: 'message', content: 'hi there' }],
+          }),
+          { status: 200 },
+        );
+      }) as typeof fetch;
+
+      const provider = new LMStudioProvider({ model: 'm' });
+      const result = await provider.chatStateful({ input: 'hello', systemPrompt: 'You are a tutor' });
+      expect(result).toEqual({ content: 'hi there', responseId: 'resp_123' });
+    });
+
+    test('threads previous_response_id when provided', async () => {
+      globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+        const body = JSON.parse(init?.body as string);
+        expect(body.previous_response_id).toBe('resp_prev');
+        return new Response(
+          JSON.stringify({
+            response_id: 'resp_next',
+            output: [{ type: 'message', content: 'continued' }],
+          }),
+          { status: 200 },
+        );
+      }) as typeof fetch;
+
+      const provider = new LMStudioProvider({ model: 'm' });
+      const result = await provider.chatStateful({ input: 'next', previousResponseId: 'resp_prev' });
+      expect(result.responseId).toBe('resp_next');
+      expect(result.content).toBe('continued');
+    });
+
+    test('throws LMStudioInvalidResponseIdError when previous_response_id is rejected', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('previous_response_id not found', { status: 404 }),
+      ) as typeof fetch;
+      const provider = new LMStudioProvider({ model: 'm' });
+      await expect(
+        provider.chatStateful({ input: 'x', previousResponseId: 'resp_dead' }),
+      ).rejects.toBeInstanceOf(LMStudioInvalidResponseIdError);
+    });
+
+    test('does not throw invalid-response-id error when no previousResponseId was sent', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response('previous_response_id missing', { status: 400 }),
+      ) as typeof fetch;
+      const provider = new LMStudioProvider({ model: 'm' });
+      // No previousResponseId → not the "invalid id" path; surfaces as a generic error
+      const err = await provider
+        .chatStateful({ input: 'x' })
+        .catch((e) => e);
+      expect(err).not.toBeInstanceOf(LMStudioInvalidResponseIdError);
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    test('returns empty content when output has no message-typed entries', async () => {
+      globalThis.fetch = mock(async () =>
+        new Response(JSON.stringify({ response_id: 'r', output: [{ type: 'tool_call', name: 'x' }] }), {
+          status: 200,
+        }),
+      ) as typeof fetch;
+      const provider = new LMStudioProvider({ model: 'm' });
+      const result = await provider.chatStateful({ input: 'x' });
+      expect(result.content).toBe('');
+      expect(result.responseId).toBe('r');
+    });
+  });
+
+  describe('healthCheck', () => {
+    test('returns ok on 200', async () => {
+      globalThis.fetch = mock(async () => new Response(JSON.stringify({ data: [{ id: 'm' }] }), { status: 200 })) as typeof fetch;
+      const provider = new LMStudioProvider();
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: true });
+    });
+
+    test('returns error on non-OK', async () => {
+      globalThis.fetch = mock(async () => new Response('Unauthorized', { status: 401 })) as typeof fetch;
+      const provider = new LMStudioProvider();
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: false, error: 'LM Studio returned 401' });
+    });
+
+    test('returns error on unreachable host', async () => {
+      globalThis.fetch = mock(async () => { throw new Error('ECONNREFUSED'); }) as typeof fetch;
+      const provider = new LMStudioProvider({ baseUrl: 'http://offline:9999' });
+      const result = await provider.healthCheck();
+      expect(result).toEqual({ ok: false, error: 'Cannot reach LM Studio at http://offline:9999' });
+    });
+  });
+
+  describe('listModels', () => {
+    test('returns ids from /v1/models data array', async () => {
+      globalThis.fetch = mock(async (url: string) => {
+        expect(url).toBe('http://localhost:1234/v1/models');
+        return new Response(
+          JSON.stringify({ data: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] }),
+          { status: 200 },
+        );
+      }) as typeof fetch;
+      const provider = new LMStudioProvider();
+      const ids = await provider.listModels();
+      expect(ids).toEqual(['a', 'b', 'c']);
+    });
+
+    test('throws on non-OK response', async () => {
+      globalThis.fetch = mock(async () => new Response('boom', { status: 500 })) as typeof fetch;
+      const provider = new LMStudioProvider();
+      await expect(provider.listModels()).rejects.toThrow('LM Studio /v1/models error');
+    });
+  });
+
+  describe('loadModel', () => {
+    test('posts model id to /api/v1/models/load and parses sync response', async () => {
+      globalThis.fetch = mock(async (url: string, init?: RequestInit) => {
+        expect(url).toBe('http://localhost:1234/api/v1/models/load');
+        const body = JSON.parse(init?.body as string);
+        expect(body).toEqual({ model: 'org/llm-7b' });
+        return new Response(
+          JSON.stringify({
+            type: 'llm',
+            instance_id: 'inst_99',
+            load_time_seconds: 4.2,
+            status: 'loaded',
+          }),
+          { status: 200 },
+        );
+      }) as typeof fetch;
+
+      const provider = new LMStudioProvider();
+      const result = await provider.loadModel('org/llm-7b');
+      expect(result).toEqual({ ok: true, instanceId: 'inst_99', loadTimeSeconds: 4.2 });
+    });
+
+    test('returns error on non-OK response without throwing', async () => {
+      globalThis.fetch = mock(async () => new Response('Model not found', { status: 404 })) as typeof fetch;
+      const provider = new LMStudioProvider();
+      const result = await provider.loadModel('nonexistent');
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('Model not found');
+    });
+
+    test('returns error when network throws', async () => {
+      globalThis.fetch = mock(async () => { throw new Error('ECONNREFUSED'); }) as typeof fetch;
+      const provider = new LMStudioProvider();
+      const result = await provider.loadModel('anything');
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('ECONNREFUSED');
+    });
+  });
+
+  describe('timeout', () => {
+    test('aborts when request exceeds timeoutMs', async () => {
+      globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+        // Simulate a hanging request that respects the abort signal
+        return await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            (err as Error & { name: string }).name = 'AbortError';
+            reject(err);
+          });
+        });
+      }) as typeof fetch;
+
+      const provider = new LMStudioProvider({ timeoutMs: 30 });
+      await expect(
+        provider.complete({ messages: [{ role: 'user', content: 'hi' }], maxTokens: 1 }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/api/src/lib/llm/lmstudio.ts
+++ b/api/src/lib/llm/lmstudio.ts
@@ -1,0 +1,206 @@
+import type { LLMProvider, CompletionOptions } from './types';
+
+const DEFAULT_URL = 'http://localhost:1234';
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface LMStudioStatefulInput {
+  input: string;
+  systemPrompt?: string;
+  previousResponseId?: string;
+}
+
+export interface LMStudioStatefulResult {
+  content: string;
+  responseId?: string;
+}
+
+export interface LMStudioLoadResult {
+  ok: boolean;
+  error?: string;
+  instanceId?: string;
+  loadTimeSeconds?: number;
+}
+
+/** Thrown when LM Studio rejects a previous_response_id (expired, unknown, server restart). */
+export class LMStudioInvalidResponseIdError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LMStudioInvalidResponseIdError';
+  }
+}
+
+export class LMStudioProvider implements LLMProvider {
+  name = 'lmstudio';
+  private baseUrl: string;
+  private model: string;
+  private apiKey?: string;
+  private timeoutMs: number;
+
+  constructor(options?: {
+    baseUrl?: string;
+    model?: string;
+    apiKey?: string;
+    timeoutMs?: number;
+  }) {
+    this.baseUrl = (options?.baseUrl || process.env.LMSTUDIO_URL || DEFAULT_URL).replace(/\/$/, '');
+    this.model = options?.model || process.env.LMSTUDIO_MODEL || '';
+    this.apiKey = options?.apiKey || process.env.LMSTUDIO_API_KEY || undefined;
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) h.Authorization = `Bearer ${this.apiKey}`;
+    return h;
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Stateless chat completion via OpenAI-compat /v1/chat/completions. Used for definitions, translation, and as a fallback for the chat widget. */
+  async complete(options: CompletionOptions): Promise<string> {
+    const body = {
+      model: this.model,
+      messages: options.messages,
+      max_tokens: options.maxTokens,
+    };
+
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`LM Studio error: ${error}`);
+    }
+
+    const data = await response.json();
+    return data.choices?.[0]?.message?.content || '';
+  }
+
+  /**
+   * Stateful chat via LM Studio's native /api/v1/chat. Used by the chat widget so
+   * LM Studio manages context server-side (we just thread previous_response_id).
+   * Throws LMStudioInvalidResponseIdError when previous_response_id is rejected,
+   * so callers can fall back to stateless complete() with full history.
+   */
+  async chatStateful(input: LMStudioStatefulInput): Promise<LMStudioStatefulResult> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      input: input.input,
+    };
+    if (input.systemPrompt) body.system_prompt = input.systemPrompt;
+    if (input.previousResponseId) body.previous_response_id = input.previousResponseId;
+
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/api/v1/chat`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      if (input.previousResponseId && isInvalidResponseIdError(response.status, errorText)) {
+        throw new LMStudioInvalidResponseIdError(errorText);
+      }
+      throw new Error(`LM Studio error: ${errorText}`);
+    }
+
+    const data = await response.json();
+    const content = extractMessageContent(data);
+    const responseId: string | undefined = typeof data.response_id === 'string' ? data.response_id : undefined;
+    return { content, responseId };
+  }
+
+  async healthCheck(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      const response = await this.fetchWithTimeout(`${this.baseUrl}/v1/models`, {
+        method: 'GET',
+        headers: this.headers(),
+      });
+      if (!response.ok) {
+        return { ok: false, error: `LM Studio returned ${response.status}` };
+      }
+      return { ok: true };
+    } catch {
+      return { ok: false, error: `Cannot reach LM Studio at ${this.baseUrl}` };
+    }
+  }
+
+  /** Returns the list of model identifiers known to LM Studio (loaded or available). */
+  async listModels(): Promise<string[]> {
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/v1/models`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`LM Studio /v1/models error: ${error}`);
+    }
+    const data = await response.json();
+    const items: unknown[] = Array.isArray(data?.data) ? data.data : [];
+    return items
+      .map((item) => (typeof item === 'object' && item && 'id' in item ? String((item as { id: unknown }).id) : ''))
+      .filter((id) => id.length > 0);
+  }
+
+  /** Synchronously loads a model into LM Studio. Resolves once the model is loaded (or fails). */
+  async loadModel(modelId: string): Promise<LMStudioLoadResult> {
+    try {
+      const response = await this.fetchWithTimeout(`${this.baseUrl}/api/v1/models/load`, {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify({ model: modelId }),
+      });
+      if (!response.ok) {
+        const error = await response.text();
+        return { ok: false, error: error || `Status ${response.status}` };
+      }
+      const data = await response.json();
+      return {
+        ok: data?.status === 'loaded',
+        instanceId: typeof data?.instance_id === 'string' ? data.instance_id : undefined,
+        loadTimeSeconds: typeof data?.load_time_seconds === 'number' ? data.load_time_seconds : undefined,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return { ok: false, error: message };
+    }
+  }
+}
+
+function extractMessageContent(data: unknown): string {
+  if (!data || typeof data !== 'object') return '';
+  const output = (data as { output?: unknown }).output;
+  if (!Array.isArray(output)) return '';
+  for (const item of output) {
+    if (
+      item &&
+      typeof item === 'object' &&
+      (item as { type?: unknown }).type === 'message' &&
+      typeof (item as { content?: unknown }).content === 'string'
+    ) {
+      return (item as { content: string }).content;
+    }
+  }
+  return '';
+}
+
+function isInvalidResponseIdError(status: number, body: string): boolean {
+  if (status !== 400 && status !== 404) return false;
+  const lower = body.toLowerCase();
+  return (
+    lower.includes('previous_response_id') ||
+    lower.includes('response id') ||
+    lower.includes('response_id')
+  );
+}

--- a/api/src/routes/chat.ts
+++ b/api/src/routes/chat.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { db, ChatMessageRow } from '../db';
 import { getProvider } from '../lib/llm';
+import { LMStudioProvider, LMStudioInvalidResponseIdError } from '../lib/llm/lmstudio';
 import { resolveLanguage } from '../lib/active-language';
 import { getLanguageConfig } from '../lib/languages';
 import { randomUUID } from 'crypto';
@@ -63,50 +64,88 @@ app.post('/', async (c) => {
       role: 'user',
       content: message.trim(),
       provider: null,
+      responseId: null,
       createdAt: now,
     };
 
-    // Build conversation history for LLM (include the new message)
-    const recentMessages = db
-      .prepare(
-        'SELECT * FROM chat_messages ORDER BY createdAt DESC LIMIT ?'
-      )
-      .all(MAX_CONTEXT_MESSAGES - 1) as ChatMessageRow[];
-
-    const history = [...recentMessages.reverse(), userMsg];
-
-    // Prepend the system prompt to the first user message so it works
-    // across all providers (Anthropic API doesn't accept role: 'system')
-    const chatHistory = history.map((m, i) => {
-      if (i === 0 && m.role === 'user') {
-        return {
-          role: 'user' as const,
-          content: `${SYSTEM_PROMPT}\n\nStudent's question: ${m.content}`,
-        };
-      }
-      return { role: m.role as 'user' | 'assistant', content: m.content };
-    });
-
     const provider = getProvider();
-    const response = await provider.complete({
-      messages: chatHistory,
-      maxTokens: 1024,
-    });
+    let responseText: string;
+    let newResponseId: string | null = null;
+
+    if (provider instanceof LMStudioProvider) {
+      // Stateful path: LM Studio holds the conversation; we just thread the latest response_id.
+      const latestAssistant = db
+        .prepare(
+          "SELECT * FROM chat_messages WHERE role = 'assistant' AND responseId IS NOT NULL ORDER BY createdAt DESC LIMIT 1"
+        )
+        .get() as ChatMessageRow | undefined;
+      const previousResponseId = latestAssistant?.responseId || undefined;
+
+      try {
+        const result = await provider.chatStateful({
+          input: userMsg.content,
+          systemPrompt: SYSTEM_PROMPT,
+          previousResponseId,
+        });
+        responseText = result.content;
+        newResponseId = result.responseId || null;
+      } catch (err) {
+        if (err instanceof LMStudioInvalidResponseIdError) {
+          // Fall back: replay the whole conversation through stateless complete().
+          // Happens when the LM Studio server restarted or the response_id expired.
+          const fallback = await runStatelessFallback(provider, userMsg, SYSTEM_PROMPT);
+          responseText = fallback;
+        } else {
+          throw err;
+        }
+      }
+    } else {
+      // Existing path for all other providers: send the full message history.
+      const recentMessages = db
+        .prepare('SELECT * FROM chat_messages ORDER BY createdAt DESC LIMIT ?')
+        .all(MAX_CONTEXT_MESSAGES - 1) as ChatMessageRow[];
+
+      const history = [...recentMessages.reverse(), userMsg];
+
+      // Prepend the system prompt to the first user message so it works
+      // across all providers (Anthropic API doesn't accept role: 'system')
+      const chatHistory = history.map((m, i) => {
+        if (i === 0 && m.role === 'user') {
+          return {
+            role: 'user' as const,
+            content: `${SYSTEM_PROMPT}\n\nStudent's question: ${m.content}`,
+          };
+        }
+        return { role: m.role as 'user' | 'assistant', content: m.content };
+      });
+
+      responseText = await provider.complete({
+        messages: chatHistory,
+        maxTokens: 1024,
+      });
+    }
 
     const assistantMsg: ChatMessageRow = {
       id: randomUUID(),
       role: 'assistant',
-      content: response,
+      content: responseText,
       provider: provider.name,
+      responseId: newResponseId,
       createdAt: new Date().toISOString(),
     };
 
     // Save both messages only after LLM succeeds
     const insertMsg = db.prepare(
-      'INSERT INTO chat_messages (id, role, content, provider, createdAt) VALUES (?, ?, ?, ?, ?)'
+      'INSERT INTO chat_messages (id, role, content, provider, responseId, createdAt) VALUES (?, ?, ?, ?, ?, ?)'
     );
-    insertMsg.run(userMsg.id, userMsg.role, userMsg.content, userMsg.provider, userMsg.createdAt);
-    insertMsg.run(assistantMsg.id, assistantMsg.role, assistantMsg.content, assistantMsg.provider, assistantMsg.createdAt);
+    insertMsg.run(
+      userMsg.id, userMsg.role, userMsg.content, userMsg.provider,
+      userMsg.responseId, userMsg.createdAt,
+    );
+    insertMsg.run(
+      assistantMsg.id, assistantMsg.role, assistantMsg.content, assistantMsg.provider,
+      assistantMsg.responseId, assistantMsg.createdAt,
+    );
 
     return c.json({ userMessage: userMsg, assistantMessage: assistantMsg });
   } catch (error) {
@@ -120,5 +159,28 @@ app.delete('/', (c) => {
   db.prepare('DELETE FROM chat_messages').run();
   return c.json({ ok: true });
 });
+
+async function runStatelessFallback(
+  provider: LMStudioProvider,
+  userMsg: ChatMessageRow,
+  systemPrompt: string,
+): Promise<string> {
+  const recentMessages = db
+    .prepare('SELECT * FROM chat_messages ORDER BY createdAt DESC LIMIT ?')
+    .all(MAX_CONTEXT_MESSAGES - 1) as ChatMessageRow[];
+
+  const history = [...recentMessages.reverse(), userMsg];
+  const chatHistory = history.map((m, i) => {
+    if (i === 0 && m.role === 'user') {
+      return {
+        role: 'user' as const,
+        content: `${systemPrompt}\n\nStudent's question: ${m.content}`,
+      };
+    }
+    return { role: m.role as 'user' | 'assistant', content: m.content };
+  });
+
+  return provider.complete({ messages: chatHistory, maxTokens: 1024 });
+}
 
 export default app;

--- a/api/src/routes/chat.ts
+++ b/api/src/routes/chat.ts
@@ -82,9 +82,12 @@ app.post('/', async (c) => {
       const previousResponseId = latestAssistant?.responseId || undefined;
 
       try {
+        // Send system_prompt only on the first turn. LM Studio retains it on
+        // the thread, and re-sending on every continuation muddies context
+        // (we observed the model occasionally hallucinating when it was repeated).
         const result = await provider.chatStateful({
           input: userMsg.content,
-          systemPrompt: SYSTEM_PROMPT,
+          systemPrompt: previousResponseId ? undefined : SYSTEM_PROMPT,
           previousResponseId,
         });
         responseText = result.content;

--- a/api/src/routes/llm-lmstudio.ts
+++ b/api/src/routes/llm-lmstudio.ts
@@ -1,11 +1,32 @@
 import { Hono } from 'hono';
 import { LMStudioProvider } from '../lib/llm/lmstudio';
+import { db } from '../db';
 
 const app = new Hono();
 
 interface BaseBody {
   endpoint?: string;
   apiKey?: string;
+}
+
+/**
+ * Read the saved LM Studio API key from settings. The browser never sends
+ * the saved key over the wire (the settings GET masks it as `true`), so the
+ * server resolves it itself when the request body doesn't carry one.
+ */
+function resolveApiKey(bodyKey: string | undefined): string | undefined {
+  const trimmed = bodyKey?.trim();
+  if (trimmed) return trimmed;
+  const row = db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get('lmstudioApiKey') as { value: string } | undefined;
+  if (!row) return undefined;
+  try {
+    const parsed = JSON.parse(row.value);
+    return typeof parsed === 'string' && parsed ? parsed : undefined;
+  } catch {
+    return row.value || undefined;
+  }
 }
 
 // POST /api/llm/lmstudio/models — list models known to LM Studio at the given endpoint.
@@ -26,7 +47,7 @@ app.post('/models', async (c) => {
 
   const provider = new LMStudioProvider({
     baseUrl,
-    apiKey: body.apiKey?.trim() || undefined,
+    apiKey: resolveApiKey(body.apiKey),
   });
 
   try {
@@ -59,7 +80,7 @@ app.post('/load', async (c) => {
 
   const provider = new LMStudioProvider({
     baseUrl,
-    apiKey: body.apiKey?.trim() || undefined,
+    apiKey: resolveApiKey(body.apiKey),
   });
 
   const result = await provider.loadModel(model);

--- a/api/src/routes/llm-lmstudio.ts
+++ b/api/src/routes/llm-lmstudio.ts
@@ -1,0 +1,75 @@
+import { Hono } from 'hono';
+import { LMStudioProvider } from '../lib/llm/lmstudio';
+
+const app = new Hono();
+
+interface BaseBody {
+  endpoint?: string;
+  apiKey?: string;
+}
+
+// POST /api/llm/lmstudio/models — list models known to LM Studio at the given endpoint.
+// Server-side proxy so the browser doesn't hit LM Studio cross-origin and so the API key
+// (if any) stays out of the browser network tab beyond the lector form submit.
+app.post('/models', async (c) => {
+  let body: BaseBody;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid JSON body' }, 400);
+  }
+
+  const baseUrl = (body.endpoint || '').trim();
+  if (!baseUrl) {
+    return c.json({ error: 'endpoint is required' }, 400);
+  }
+
+  const provider = new LMStudioProvider({
+    baseUrl,
+    apiKey: body.apiKey?.trim() || undefined,
+  });
+
+  try {
+    const models = await provider.listModels();
+    return c.json({ models });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return c.json({ error: message }, 502);
+  }
+});
+
+interface LoadBody extends BaseBody {
+  model?: string;
+}
+
+// POST /api/llm/lmstudio/load — explicitly load a model on LM Studio. Synchronous
+// per LM Studio's API: this resolves once the model finishes loading (or errors).
+app.post('/load', async (c) => {
+  let body: LoadBody;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid JSON body' }, 400);
+  }
+
+  const baseUrl = (body.endpoint || '').trim();
+  const model = (body.model || '').trim();
+  if (!baseUrl) return c.json({ error: 'endpoint is required' }, 400);
+  if (!model) return c.json({ error: 'model is required' }, 400);
+
+  const provider = new LMStudioProvider({
+    baseUrl,
+    apiKey: body.apiKey?.trim() || undefined,
+  });
+
+  const result = await provider.loadModel(model);
+  if (!result.ok) {
+    return c.json(
+      { ok: false, error: result.error || 'load failed' },
+      502,
+    );
+  }
+  return c.json(result);
+});
+
+export default app;

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { db, SettingRow } from '../db';
 
-const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken']);
+const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken', 'lmstudioApiKey']);
 
 const app = new Hono();
 

--- a/e2e/lmstudio-chat.spec.ts
+++ b/e2e/lmstudio-chat.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test";
+import * as http from "http";
+import { AddressInfo } from "net";
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: any;
+}
+
+/**
+ * Spin up an in-process stub that pretends to be LM Studio. Captures incoming
+ * requests so the test can assert on what lector sent (previous_response_id,
+ * input string, fallback messages array).
+ */
+function startStub(handler: (req: CapturedRequest) => { status: number; body: unknown }): Promise<{
+  url: string;
+  captured: CapturedRequest[];
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolve) => {
+    const captured: CapturedRequest[] = [];
+    const server = http.createServer((req, res) => {
+      let raw = "";
+      req.on("data", (chunk) => { raw += chunk.toString(); });
+      req.on("end", () => {
+        let body: unknown = null;
+        try { body = raw ? JSON.parse(raw) : null; } catch { body = raw; }
+        const captureEntry: CapturedRequest = {
+          method: req.method || "GET",
+          url: req.url || "",
+          body,
+        };
+        captured.push(captureEntry);
+        const out = handler(captureEntry);
+        res.writeHead(out.status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(out.body));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        captured,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+test.describe("Chat with LM Studio provider", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.request.delete("/api/chat");
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Reset provider so other tests don't get LM Studio routing
+    await page.request.put("/api/settings/llmProvider", { data: { value: "ollama" } });
+    await page.request.delete("/api/settings/lmstudioUrl");
+    await page.request.delete("/api/settings/lmstudioModel");
+    await page.request.post("/api/llm-status/reset");
+    await page.request.delete("/api/chat");
+  });
+
+  test("threads previous_response_id between messages", async ({ page }) => {
+    let nextResponseId = 1;
+    const stub = await startStub((req) => {
+      if (req.url === "/api/v1/chat") {
+        const responseId = `resp_${nextResponseId++}`;
+        return {
+          status: 200,
+          body: {
+            response_id: responseId,
+            output: [{ type: "message", content: `reply ${responseId}` }],
+          },
+        };
+      }
+      return { status: 404, body: { error: "not handled" } };
+    });
+
+    try {
+      await page.request.put("/api/settings/llmProvider", { data: { value: "lmstudio" } });
+      await page.request.put("/api/settings/lmstudioUrl", { data: { value: stub.url } });
+      await page.request.put("/api/settings/lmstudioModel", { data: { value: "test/model" } });
+      await page.request.post("/api/llm-status/reset");
+
+      // First message — no previous_response_id should be sent
+      const r1 = await page.request.post("/api/chat", {
+        data: { message: "first message", language: "af" },
+      });
+      expect(r1.ok()).toBeTruthy();
+      const data1 = await r1.json();
+      expect(data1.assistantMessage.content).toBe("reply resp_1");
+
+      // Second message — previous_response_id from message #1 should be threaded in
+      const r2 = await page.request.post("/api/chat", {
+        data: { message: "second message", language: "af" },
+      });
+      expect(r2.ok()).toBeTruthy();
+      const data2 = await r2.json();
+      expect(data2.assistantMessage.content).toBe("reply resp_2");
+
+      // Inspect what the stub received
+      const chatCalls = stub.captured.filter((c) => c.url === "/api/v1/chat");
+      expect(chatCalls).toHaveLength(2);
+      expect(chatCalls[0].body.input).toBe("first message");
+      expect(chatCalls[0].body.previous_response_id).toBeUndefined();
+      expect(chatCalls[1].body.input).toBe("second message");
+      expect(chatCalls[1].body.previous_response_id).toBe("resp_1");
+      // System prompt should always be sent
+      expect(typeof chatCalls[0].body.system_prompt).toBe("string");
+      expect(chatCalls[0].body.system_prompt).toContain("Afrikaans");
+    } finally {
+      await stub.close();
+    }
+  });
+
+  test("falls back to stateless complete() when previous_response_id is rejected", async ({ page }) => {
+    let firstChatCallReceived = false;
+    const stub = await startStub((req) => {
+      if (req.url === "/api/v1/chat") {
+        if (!firstChatCallReceived) {
+          firstChatCallReceived = true;
+          return {
+            status: 200,
+            body: {
+              response_id: "resp_seed",
+              output: [{ type: "message", content: "seed reply" }],
+            },
+          };
+        }
+        // Second call: reject the previous_response_id
+        return { status: 404, body: { error: "previous_response_id not found" } };
+      }
+      // Fallback path uses /v1/chat/completions
+      if (req.url === "/v1/chat/completions") {
+        return {
+          status: 200,
+          body: {
+            choices: [{ message: { content: "fallback reply with full history" } }],
+          },
+        };
+      }
+      return { status: 404, body: { error: "not handled" } };
+    });
+
+    try {
+      await page.request.put("/api/settings/llmProvider", { data: { value: "lmstudio" } });
+      await page.request.put("/api/settings/lmstudioUrl", { data: { value: stub.url } });
+      await page.request.put("/api/settings/lmstudioModel", { data: { value: "test/model" } });
+      await page.request.post("/api/llm-status/reset");
+
+      const r1 = await page.request.post("/api/chat", {
+        data: { message: "hi", language: "af" },
+      });
+      expect(r1.ok()).toBeTruthy();
+      expect((await r1.json()).assistantMessage.content).toBe("seed reply");
+
+      const r2 = await page.request.post("/api/chat", {
+        data: { message: "again", language: "af" },
+      });
+      expect(r2.ok()).toBeTruthy();
+      const data2 = await r2.json();
+      expect(data2.assistantMessage.content).toBe("fallback reply with full history");
+
+      // Verify the stub saw the fallback /v1/chat/completions call with the full history
+      const fallbackCalls = stub.captured.filter((c) => c.url === "/v1/chat/completions");
+      expect(fallbackCalls).toHaveLength(1);
+      expect(Array.isArray(fallbackCalls[0].body.messages)).toBe(true);
+      const messages = fallbackCalls[0].body.messages as Array<{ role: string; content: string }>;
+      expect(messages.length).toBeGreaterThanOrEqual(3);
+      expect(messages[messages.length - 1].content).toContain("again");
+    } finally {
+      await stub.close();
+    }
+  });
+});

--- a/e2e/lmstudio-settings.spec.ts
+++ b/e2e/lmstudio-settings.spec.ts
@@ -146,7 +146,7 @@ test.describe("LM Studio settings", () => {
     expect(value === "" || value === null).toBeTruthy();
   });
 
-  test("changing the API key clears the selected model", async ({ page }) => {
+  test("saving a new API key clears the selected model", async ({ page }) => {
     await page.route("**/api/llm/lmstudio/models", async (route) => {
       await route.fulfill({
         status: 200,
@@ -159,9 +159,10 @@ test.describe("LM Studio settings", () => {
     await page.getByTestId("lmstudio-fetch-models").click();
     await page.getByTestId("lmstudio-model").selectOption("a");
 
-    // Type something in the API key field — the save chain is async, so wait
-    // for the dropdown to reset before checking the persisted setting.
+    // Save a new API key via the explicit Save button (the input no longer
+    // saves on every keystroke — credentials use Configured/Replace/Clear).
     await page.getByTestId("lmstudio-api-key").fill("sk-secret");
+    await page.getByTestId("lmstudio-api-key-save").click();
     await expect(page.getByTestId("lmstudio-model")).toHaveValue("");
 
     await expect.poll(async () => {
@@ -169,9 +170,41 @@ test.describe("LM Studio settings", () => {
       const value = await saved.json();
       return value === "" || value === null;
     }).toBeTruthy();
+
+    // Status should now show Configured (not the plaintext key)
+    await expect(page.getByTestId("lmstudio-api-key-status")).toContainText("Configured");
   });
 
-  test("fetch-models proxy is sent the typed endpoint and apiKey", async ({ page }) => {
+  test("API key load returns true (masked) — never the plaintext", async ({ page }) => {
+    await page.request.put("/api/settings/lmstudioApiKey", { data: { value: "sk-very-secret" } });
+
+    // Both the bulk and single-key endpoints should mask
+    const bulk = await (await page.request.get("/api/settings")).json();
+    expect(bulk.lmstudioApiKey).toBe(true);
+
+    const single = await (await page.request.get("/api/settings/lmstudioApiKey")).json();
+    expect(single).toBe(true);
+
+    // Cleanup
+    await page.request.delete("/api/settings/lmstudioApiKey");
+  });
+
+  test("Clear removes the configured API key", async ({ page }) => {
+    await page.request.put("/api/settings/lmstudioApiKey", { data: { value: "sk-prior" } });
+    await selectLmStudioProvider(page);
+
+    await expect(page.getByTestId("lmstudio-api-key-status")).toContainText("Configured");
+    await page.getByTestId("lmstudio-api-key-clear").click();
+
+    // Should switch back to the password input
+    await expect(page.getByTestId("lmstudio-api-key")).toBeVisible();
+    await expect(page.getByTestId("lmstudio-api-key-status")).toHaveCount(0);
+
+    const cleared = await (await page.request.get("/api/settings/lmstudioApiKey")).json();
+    expect(cleared).toBeNull();
+  });
+
+  test("fetch-models proxy is sent the typed endpoint but not the API key", async ({ page }) => {
     type ModelsBody = { endpoint?: string; apiKey?: string };
     const captured: ModelsBody[] = [];
     await page.route("**/api/llm/lmstudio/models", async (route, request) => {
@@ -185,10 +218,10 @@ test.describe("LM Studio settings", () => {
 
     await selectLmStudioProvider(page);
     await page.getByTestId("lmstudio-endpoint").fill("http://my-host:1234");
-    await page.getByTestId("lmstudio-api-key").fill("sk-x");
     await page.getByTestId("lmstudio-fetch-models").click();
 
     await expect.poll(() => captured[0]?.endpoint).toBe("http://my-host:1234");
-    expect(captured[0]?.apiKey).toBe("sk-x");
+    // The browser must NOT send the API key — server resolves it from settings.
+    expect(captured[0]?.apiKey).toBeUndefined();
   });
 });

--- a/e2e/lmstudio-settings.spec.ts
+++ b/e2e/lmstudio-settings.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function selectLmStudioProvider(page: Page) {
+  await page.goto("/settings");
+  await page.waitForLoadState("networkidle");
+  await page.locator('select').first().selectOption("lmstudio");
+  await expect(page.getByTestId("lmstudio-settings")).toBeVisible();
+}
+
+test.describe("LM Studio settings", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    // Reset to a known state
+    await page.request.delete("/api/settings/lmstudioUrl");
+    await page.request.delete("/api/settings/lmstudioApiKey");
+    await page.request.delete("/api/settings/lmstudioModel");
+    await page.request.put("/api/settings/llmProvider", {
+      data: { value: "ollama" },
+    });
+  });
+
+  test("selecting LM Studio provider reveals the config block", async ({ page }) => {
+    await selectLmStudioProvider(page);
+    await expect(page.getByTestId("lmstudio-endpoint")).toBeVisible();
+    await expect(page.getByTestId("lmstudio-api-key")).toBeVisible();
+    await expect(page.getByTestId("lmstudio-model")).toBeVisible();
+    await expect(page.getByTestId("lmstudio-fetch-models")).toBeVisible();
+    await expect(page.getByTestId("lmstudio-load")).toBeVisible();
+    // Status pill should start as Idle
+    await expect(page.getByTestId("lmstudio-load-status")).toHaveAttribute("data-status", "idle");
+  });
+
+  test("API key input is type=password (does not leak via the DOM)", async ({ page }) => {
+    await selectLmStudioProvider(page);
+    await expect(page.getByTestId("lmstudio-api-key")).toHaveAttribute("type", "password");
+  });
+
+  test("fetch-models populates the dropdown", async ({ page }) => {
+    await page.route("**/api/llm/lmstudio/models", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ models: ["meta-llama/llama-3-8b", "openai/gpt-oss-20b"] }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-fetch-models").click();
+
+    const modelSelect = page.getByTestId("lmstudio-model");
+    await expect(modelSelect.locator('option[value="meta-llama/llama-3-8b"]')).toHaveCount(1);
+    await expect(modelSelect.locator('option[value="openai/gpt-oss-20b"]')).toHaveCount(1);
+  });
+
+  test("fetch-models surfaces an error when the endpoint is unreachable", async ({ page }) => {
+    await page.route("**/api/llm/lmstudio/models", async (route) => {
+      await route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Cannot reach LM Studio at http://localhost:1234" }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-fetch-models").click();
+    await expect(page.getByTestId("lmstudio-fetch-error")).toContainText("Cannot reach LM Studio");
+  });
+
+  test("Load button moves the status pill from Idle → Loaded", async ({ page }) => {
+    await page.route("**/api/llm/lmstudio/models", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ models: ["my-model"] }),
+      });
+    });
+    await page.route("**/api/llm/lmstudio/load", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, instanceId: "inst_1", loadTimeSeconds: 1.2 }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-fetch-models").click();
+    await page.getByTestId("lmstudio-model").selectOption("my-model");
+
+    await page.getByTestId("lmstudio-load").click();
+    await expect(page.getByTestId("lmstudio-load-status")).toHaveAttribute("data-status", "loaded");
+  });
+
+  test("Load failure shows error pill and message", async ({ page }) => {
+    await page.route("**/api/llm/lmstudio/models", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ models: ["my-model"] }),
+      });
+    });
+    await page.route("**/api/llm/lmstudio/load", async (route) => {
+      await route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: "Model not found" }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-fetch-models").click();
+    await page.getByTestId("lmstudio-model").selectOption("my-model");
+    await page.getByTestId("lmstudio-load").click();
+
+    await expect(page.getByTestId("lmstudio-load-status")).toHaveAttribute("data-status", "errored");
+    await expect(page.getByTestId("lmstudio-load-error")).toContainText("Model not found");
+  });
+
+  test("changing the endpoint clears the selected model and load status", async ({ page }) => {
+    await page.route("**/api/llm/lmstudio/models", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ models: ["alpha", "beta"] }),
+      });
+    });
+    await page.route("**/api/llm/lmstudio/load", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-fetch-models").click();
+    await page.getByTestId("lmstudio-model").selectOption("alpha");
+    await page.getByTestId("lmstudio-load").click();
+    await expect(page.getByTestId("lmstudio-load-status")).toHaveAttribute("data-status", "loaded");
+
+    // Change the endpoint — model selection AND the load status should clear
+    await page.getByTestId("lmstudio-endpoint").fill("http://localhost:9999");
+    await expect(page.getByTestId("lmstudio-load-status")).toHaveAttribute("data-status", "idle");
+    // Persisted model should also be cleared on the server
+    const saved = await page.request.get("/api/settings/lmstudioModel");
+    const value = await saved.json();
+    expect(value === "" || value === null).toBeTruthy();
+  });
+
+  test("changing the API key clears the selected model", async ({ page }) => {
+    await page.route("**/api/llm/lmstudio/models", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ models: ["a"] }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-fetch-models").click();
+    await page.getByTestId("lmstudio-model").selectOption("a");
+
+    // Type something in the API key field — the save chain is async, so wait
+    // for the dropdown to reset before checking the persisted setting.
+    await page.getByTestId("lmstudio-api-key").fill("sk-secret");
+    await expect(page.getByTestId("lmstudio-model")).toHaveValue("");
+
+    await expect.poll(async () => {
+      const saved = await page.request.get("/api/settings/lmstudioModel");
+      const value = await saved.json();
+      return value === "" || value === null;
+    }).toBeTruthy();
+  });
+
+  test("fetch-models proxy is sent the typed endpoint and apiKey", async ({ page }) => {
+    type ModelsBody = { endpoint?: string; apiKey?: string };
+    const captured: ModelsBody[] = [];
+    await page.route("**/api/llm/lmstudio/models", async (route, request) => {
+      captured.push(JSON.parse(request.postData() || "{}") as ModelsBody);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ models: [] }),
+      });
+    });
+
+    await selectLmStudioProvider(page);
+    await page.getByTestId("lmstudio-endpoint").fill("http://my-host:1234");
+    await page.getByTestId("lmstudio-api-key").fill("sk-x");
+    await page.getByTestId("lmstudio-fetch-models").click();
+
+    await expect.poll(() => captured[0]?.endpoint).toBe("http://my-host:1234");
+    expect(captured[0]?.apiKey).toBe("sk-x");
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,9 +28,20 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "npm run dev",
-    url: "http://localhost:3456",
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: [
+    {
+      command: "npm run dev",
+      url: "http://localhost:3456",
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      // Hono API on :3457 — Next.js proxies /api/chat (and a few others) to it.
+      // Started without --watch so it shuts down cleanly when Playwright exits.
+      command: "bun run src/index.ts",
+      cwd: "./api",
+      url: "http://localhost:3457/health",
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
 });

--- a/src/app/api/llm/lmstudio/load/route.ts
+++ b/src/app/api/llm/lmstudio/load/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const API_URL = process.env.INTERNAL_API_URL || 'http://localhost:3457';
+
+// POST /api/llm/lmstudio/load — proxies to the Hono API which calls LM Studio's /api/v1/models/load.
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.text();
+    const response = await fetch(`${API_URL}/api/llm/lmstudio/load`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('LM Studio load proxy error:', error);
+    return NextResponse.json({ error: 'Failed to load model' }, { status: 500 });
+  }
+}

--- a/src/app/api/llm/lmstudio/models/route.ts
+++ b/src/app/api/llm/lmstudio/models/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const API_URL = process.env.INTERNAL_API_URL || 'http://localhost:3457';
+
+// POST /api/llm/lmstudio/models — proxies to the Hono API which calls LM Studio's /v1/models.
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.text();
+    const response = await fetch(`${API_URL}/api/llm/lmstudio/models`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error('LM Studio models proxy error:', error);
+    return NextResponse.json({ error: 'Failed to fetch models' }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/[key]/route.ts
+++ b/src/app/api/settings/[key]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, SettingRow } from '@/lib/server/database';
 
-const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken']);
+const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken', 'lmstudioApiKey']);
 
 // GET /api/settings/[key]
 export async function GET(

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, SettingRow } from '@/lib/server/database';
 
-const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken']);
+const SENSITIVE_KEYS = new Set(['anthropicApiKey', 'claudeOauthToken', 'lmstudioApiKey']);
 
 // GET /api/settings - Get all settings
 export async function GET() {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -40,7 +40,8 @@ const SETTINGS_KEYS = {
 
 type CardType = "basic" | "cloze";
 type Theme = "light" | "dark" | "system";
-type LLMProvider = "ollama" | "anthropic" | "apfel";
+type LLMProvider = "ollama" | "anthropic" | "apfel" | "lmstudio";
+type LMStudioLoadStatus = "idle" | "loading" | "loaded" | "errored";
 
 const OLLAMA_MODELS = [
   { value: "llama3.2:3b", label: "Llama 3.2 3B (fastest, lower quality)" },
@@ -103,6 +104,14 @@ export default function SettingsPage() {
   const [ollamaModel, setOllamaModel] = useState("llama3.1:8b");
   const [apfelUrl, setApfelUrl] = useState("http://localhost:11434");
   const [apfelModel, setApfelModel] = useState("default");
+  const [lmstudioUrl, setLmstudioUrl] = useState("http://localhost:1234");
+  const [lmstudioApiKey, setLmstudioApiKey] = useState("");
+  const [lmstudioModel, setLmstudioModel] = useState("");
+  const [lmstudioModels, setLmstudioModels] = useState<string[]>([]);
+  const [lmstudioFetchingModels, setLmstudioFetchingModels] = useState(false);
+  const [lmstudioFetchError, setLmstudioFetchError] = useState<string | null>(null);
+  const [lmstudioLoadStatus, setLmstudioLoadStatus] = useState<LMStudioLoadStatus>("idle");
+  const [lmstudioLoadError, setLmstudioLoadError] = useState<string | null>(null);
   const [hasApiKey, setHasApiKey] = useState(false);
   const [hasOauthToken, setHasOauthToken] = useState(false);
   const [newApiKey, setNewApiKey] = useState("");
@@ -159,7 +168,7 @@ export default function SettingsPage() {
 
     // Load LLM provider settings from server
     getSetting<string>('llmProvider').then((p) => {
-      if (p === 'ollama' || p === 'anthropic' || p === 'apfel') setLlmProvider(p);
+      if (p === 'ollama' || p === 'anthropic' || p === 'apfel' || p === 'lmstudio') setLlmProvider(p);
     });
     getSetting<string>('ollamaModel').then((m) => {
       if (m) setOllamaModel(m);
@@ -169,6 +178,15 @@ export default function SettingsPage() {
     });
     getSetting<string>('apfelModel').then((m) => {
       if (m) setApfelModel(m);
+    });
+    getSetting<string>('lmstudioUrl').then((u) => {
+      if (u) setLmstudioUrl(u);
+    });
+    getSetting<string>('lmstudioApiKey').then((k) => {
+      if (k) setLmstudioApiKey(k);
+    });
+    getSetting<string>('lmstudioModel').then((m) => {
+      if (m) setLmstudioModel(m);
     });
     getSetting<boolean>('anthropicApiKey').then((v) => {
       setHasApiKey(v === true);
@@ -294,6 +312,98 @@ export default function SettingsPage() {
     await setSetting('apfelModel', model);
     await fetch('/api/llm-status/reset', { method: 'POST' });
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  // Whenever endpoint or apiKey changes, the previously-selected model may not exist
+  // on the new endpoint and any prior load status is stale. Clear them so the user
+  // re-fetches and re-loads. We don't auto-fetch models — the user owns that action.
+  const resetLmstudioModelSelection = async () => {
+    setLmstudioModel("");
+    setLmstudioModels([]);
+    setLmstudioFetchError(null);
+    setLmstudioLoadStatus("idle");
+    setLmstudioLoadError(null);
+    await setSetting('lmstudioModel', "");
+  };
+
+  const saveLmstudioUrl = async (url: string) => {
+    setLmstudioUrl(url);
+    await setSetting('lmstudioUrl', url);
+    await resetLmstudioModelSelection();
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveLmstudioApiKey = async (key: string) => {
+    setLmstudioApiKey(key);
+    await setSetting('lmstudioApiKey', key);
+    await resetLmstudioModelSelection();
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const saveLmstudioModel = async (model: string) => {
+    setLmstudioModel(model);
+    await setSetting('lmstudioModel', model);
+    setLmstudioLoadStatus("idle");
+    setLmstudioLoadError(null);
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const fetchLmstudioModels = async () => {
+    setLmstudioFetchingModels(true);
+    setLmstudioFetchError(null);
+    try {
+      const res = await fetch('/api/llm/lmstudio/models', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint: lmstudioUrl, apiKey: lmstudioApiKey || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setLmstudioFetchError(data?.error || `Status ${res.status}`);
+        setLmstudioModels([]);
+      } else {
+        const list: string[] = Array.isArray(data?.models) ? data.models : [];
+        setLmstudioModels(list);
+        if (list.length === 0) {
+          setLmstudioFetchError("No models reported by this endpoint");
+        }
+      }
+    } catch (err) {
+      setLmstudioFetchError(err instanceof Error ? err.message : 'Failed to fetch models');
+      setLmstudioModels([]);
+    } finally {
+      setLmstudioFetchingModels(false);
+    }
+  };
+
+  const loadLmstudioModel = async () => {
+    if (!lmstudioModel) return;
+    setLmstudioLoadStatus("loading");
+    setLmstudioLoadError(null);
+    try {
+      const res = await fetch('/api/llm/lmstudio/load', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          endpoint: lmstudioUrl,
+          apiKey: lmstudioApiKey || undefined,
+          model: lmstudioModel,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        setLmstudioLoadStatus("errored");
+        setLmstudioLoadError(data?.error || `Status ${res.status}`);
+      } else {
+        setLmstudioLoadStatus("loaded");
+      }
+    } catch (err) {
+      setLmstudioLoadStatus("errored");
+      setLmstudioLoadError(err instanceof Error ? err.message : 'Load failed');
+    }
   };
 
   const saveAnthropicApiKey = async (key: string) => {
@@ -723,6 +833,7 @@ export default function SettingsPage() {
                 <option value="ollama">Ollama (local)</option>
                 <option value="anthropic">Anthropic (cloud)</option>
                 <option value="apfel">Apfel (self-hosted)</option>
+                <option value="lmstudio">LM Studio (local)</option>
               </select>
             </div>
 
@@ -910,6 +1021,137 @@ export default function SettingsPage() {
                       )}
                     </div>
                   )}
+                </div>
+              </div>
+            )}
+
+            {/* LM Studio settings */}
+            {llmProvider === "lmstudio" && (
+              <div className="mb-4 space-y-4" data-testid="lmstudio-settings">
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Endpoint
+                  </label>
+                  <input
+                    type="text"
+                    value={lmstudioUrl}
+                    onChange={(e) => saveLmstudioUrl(e.target.value)}
+                    placeholder="http://localhost:1234"
+                    data-testid="lmstudio-endpoint"
+                    className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  />
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+                    The URL of your LM Studio server (default port 1234). The app talks to it server-side, so localhost works even when lector is hosted elsewhere — set this to a reachable address.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    API Key (optional)
+                  </label>
+                  <input
+                    type="password"
+                    value={lmstudioApiKey}
+                    onChange={(e) => saveLmstudioApiKey(e.target.value)}
+                    placeholder="leave empty unless your LM Studio is behind auth"
+                    data-testid="lmstudio-api-key"
+                    className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  />
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+                    Sent as a Bearer token. Only needed for reverse-proxied or LM Studio Cloud setups.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Model
+                  </label>
+                  <div className="flex gap-2">
+                    <select
+                      value={lmstudioModel}
+                      onChange={(e) => saveLmstudioModel(e.target.value)}
+                      data-testid="lmstudio-model"
+                      className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                    >
+                      {lmstudioModel && !lmstudioModels.includes(lmstudioModel) && (
+                        <option value={lmstudioModel}>{lmstudioModel} (saved)</option>
+                      )}
+                      {lmstudioModels.length === 0 && !lmstudioModel && (
+                        <option value="">— click &ldquo;Fetch models&rdquo; to populate —</option>
+                      )}
+                      {lmstudioModels.map((m) => (
+                        <option key={m} value={m}>
+                          {m}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={fetchLmstudioModels}
+                      disabled={lmstudioFetchingModels || !lmstudioUrl}
+                      data-testid="lmstudio-fetch-models"
+                      className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    >
+                      {lmstudioFetchingModels ? "Fetching..." : "Fetch models"}
+                    </button>
+                  </div>
+                  {lmstudioFetchError && (
+                    <p
+                      className="mt-1 text-xs text-red-600 dark:text-red-400"
+                      data-testid="lmstudio-fetch-error"
+                    >
+                      {lmstudioFetchError}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Load model
+                  </label>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={loadLmstudioModel}
+                      disabled={!lmstudioModel || lmstudioLoadStatus === "loading"}
+                      data-testid="lmstudio-load"
+                      className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    >
+                      {lmstudioLoadStatus === "loading" ? "Loading..." : "Load"}
+                    </button>
+                    <span
+                      data-testid="lmstudio-load-status"
+                      data-status={lmstudioLoadStatus}
+                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                        lmstudioLoadStatus === "loaded"
+                          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                          : lmstudioLoadStatus === "loading"
+                          ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400"
+                          : lmstudioLoadStatus === "errored"
+                          ? "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400"
+                          : "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400"
+                      }`}
+                    >
+                      {lmstudioLoadStatus === "idle"
+                        ? "Idle"
+                        : lmstudioLoadStatus === "loading"
+                        ? "Loading…"
+                        : lmstudioLoadStatus === "loaded"
+                        ? "Loaded"
+                        : "Errored"}
+                    </span>
+                  </div>
+                  {lmstudioLoadError && (
+                    <p
+                      className="mt-1 text-xs text-red-600 dark:text-red-400"
+                      data-testid="lmstudio-load-error"
+                    >
+                      {lmstudioLoadError}
+                    </p>
+                  )}
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+                    Loads the selected model on the LM Studio server. Make sure LM Studio&apos;s &ldquo;auto-load&rdquo; is enabled if you want JIT loading on chat too.
+                  </p>
                 </div>
               </div>
             )}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -114,6 +114,7 @@ export default function SettingsPage() {
   const [lmstudioFetchError, setLmstudioFetchError] = useState<string | null>(null);
   const [lmstudioLoadStatus, setLmstudioLoadStatus] = useState<LMStudioLoadStatus>("idle");
   const [lmstudioLoadError, setLmstudioLoadError] = useState<string | null>(null);
+  const lmstudioAutoFetchedForUrl = useRef<string | null>(null);
   const [hasApiKey, setHasApiKey] = useState(false);
   const [hasOauthToken, setHasOauthToken] = useState(false);
   const [newApiKey, setNewApiKey] = useState("");
@@ -229,6 +230,21 @@ export default function SettingsPage() {
   useEffect(() => {
     checkAnkiConnection();
   }, [checkAnkiConnection]);
+
+  // Auto-fetch LM Studio models when the user lands on Settings with LM Studio
+  // configured but the in-memory list is empty (e.g. on a page refresh — we
+  // don't persist the fetched list, only the selected model id). Tracks the
+  // last URL we fetched for to avoid refetching after a fetch returns empty.
+  useEffect(() => {
+    if (llmProvider !== "lmstudio") return;
+    if (!lmstudioUrl) return;
+    if (lmstudioFetchingModels) return;
+    if (lmstudioModels.length > 0) return;
+    if (lmstudioAutoFetchedForUrl.current === lmstudioUrl) return;
+    lmstudioAutoFetchedForUrl.current = lmstudioUrl;
+    fetchLmstudioModels();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchLmstudioModels is stable for our purposes; including it would cause re-runs on every render
+  }, [llmProvider, lmstudioUrl, lmstudioFetchingModels, lmstudioModels.length]);
 
   // Apply theme to document
   const applyTheme = (theme: Theme) => {
@@ -1138,11 +1154,18 @@ export default function SettingsPage() {
                       data-testid="lmstudio-model"
                       className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
                     >
+                      {/* Always include an empty placeholder so a freshly-fetched
+                          dropdown doesn't visually show a "selected" model that
+                          state doesn't actually know about (would leave Load disabled). */}
+                      <option value="" disabled>
+                        {lmstudioModels.length === 0
+                          ? lmstudioFetchingModels
+                            ? "Fetching models…"
+                            : "— click “Fetch models” to populate —"
+                          : "Select a model…"}
+                      </option>
                       {lmstudioModel && !lmstudioModels.includes(lmstudioModel) && (
                         <option value={lmstudioModel}>{lmstudioModel} (saved)</option>
-                      )}
-                      {lmstudioModels.length === 0 && !lmstudioModel && (
-                        <option value="">— click &ldquo;Fetch models&rdquo; to populate —</option>
                       )}
                       {lmstudioModels.map((m) => (
                         <option key={m} value={m}>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -105,7 +105,9 @@ export default function SettingsPage() {
   const [apfelUrl, setApfelUrl] = useState("http://localhost:11434");
   const [apfelModel, setApfelModel] = useState("default");
   const [lmstudioUrl, setLmstudioUrl] = useState("http://localhost:1234");
-  const [lmstudioApiKey, setLmstudioApiKey] = useState("");
+  const [hasLmstudioApiKey, setHasLmstudioApiKey] = useState(false);
+  const [newLmstudioApiKey, setNewLmstudioApiKey] = useState("");
+  const [editingLmstudioApiKey, setEditingLmstudioApiKey] = useState(false);
   const [lmstudioModel, setLmstudioModel] = useState("");
   const [lmstudioModels, setLmstudioModels] = useState<string[]>([]);
   const [lmstudioFetchingModels, setLmstudioFetchingModels] = useState(false);
@@ -182,8 +184,8 @@ export default function SettingsPage() {
     getSetting<string>('lmstudioUrl').then((u) => {
       if (u) setLmstudioUrl(u);
     });
-    getSetting<string>('lmstudioApiKey').then((k) => {
-      if (k) setLmstudioApiKey(k);
+    getSetting<boolean>('lmstudioApiKey').then((v) => {
+      setHasLmstudioApiKey(v === true);
     });
     getSetting<string>('lmstudioModel').then((m) => {
       if (m) setLmstudioModel(m);
@@ -335,8 +337,21 @@ export default function SettingsPage() {
   };
 
   const saveLmstudioApiKey = async (key: string) => {
-    setLmstudioApiKey(key);
+    if (!key.trim()) return;
     await setSetting('lmstudioApiKey', key);
+    setHasLmstudioApiKey(true);
+    setNewLmstudioApiKey("");
+    setEditingLmstudioApiKey(false);
+    await resetLmstudioModelSelection();
+    await fetch('/api/llm-status/reset', { method: 'POST' });
+    fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
+  };
+
+  const clearLmstudioApiKey = async () => {
+    await deleteSetting('lmstudioApiKey');
+    setHasLmstudioApiKey(false);
+    setNewLmstudioApiKey("");
+    setEditingLmstudioApiKey(false);
     await resetLmstudioModelSelection();
     await fetch('/api/llm-status/reset', { method: 'POST' });
     fetch('/api/llm-status').then(r => r.json()).then(setLlmStatus).catch(() => {});
@@ -355,10 +370,11 @@ export default function SettingsPage() {
     setLmstudioFetchingModels(true);
     setLmstudioFetchError(null);
     try {
+      // The server reads the saved API key from settings — never sent from the browser.
       const res = await fetch('/api/llm/lmstudio/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ endpoint: lmstudioUrl, apiKey: lmstudioApiKey || undefined }),
+        body: JSON.stringify({ endpoint: lmstudioUrl }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -389,7 +405,6 @@ export default function SettingsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           endpoint: lmstudioUrl,
-          apiKey: lmstudioApiKey || undefined,
           model: lmstudioModel,
         }),
       });
@@ -1049,16 +1064,66 @@ export default function SettingsPage() {
                   <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
                     API Key (optional)
                   </label>
-                  <input
-                    type="password"
-                    value={lmstudioApiKey}
-                    onChange={(e) => saveLmstudioApiKey(e.target.value)}
-                    placeholder="leave empty unless your LM Studio is behind auth"
-                    data-testid="lmstudio-api-key"
-                    className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-                  />
+                  {hasLmstudioApiKey && !editingLmstudioApiKey ? (
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-flex items-center rounded-md bg-green-100 px-2 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                        data-testid="lmstudio-api-key-status"
+                      >
+                        Configured
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setEditingLmstudioApiKey(true)}
+                        className="rounded-md border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                        data-testid="lmstudio-api-key-replace"
+                      >
+                        Replace
+                      </button>
+                      <button
+                        type="button"
+                        onClick={clearLmstudioApiKey}
+                        className="rounded-md border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:border-red-700 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                        data-testid="lmstudio-api-key-clear"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex gap-2">
+                      <input
+                        type="password"
+                        value={newLmstudioApiKey}
+                        onChange={(e) => setNewLmstudioApiKey(e.target.value)}
+                        placeholder="leave empty unless your LM Studio is behind auth"
+                        data-testid="lmstudio-api-key"
+                        className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => saveLmstudioApiKey(newLmstudioApiKey)}
+                        disabled={!newLmstudioApiKey.trim()}
+                        className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                        data-testid="lmstudio-api-key-save"
+                      >
+                        Save
+                      </button>
+                      {editingLmstudioApiKey && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditingLmstudioApiKey(false);
+                            setNewLmstudioApiKey("");
+                          }}
+                          className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                        >
+                          Cancel
+                        </button>
+                      )}
+                    </div>
+                  )}
                   <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
-                    Sent as a Bearer token. Only needed for reverse-proxied or LM Studio Cloud setups.
+                    Sent as a Bearer token from the server (never exposed to the browser after save). Only needed for reverse-proxied or LM Studio Cloud setups.
                   </p>
                 </div>
 

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -140,9 +140,17 @@ export default function ChatWidget() {
       ]);
     } finally {
       setLoading(false);
-      inputRef.current?.focus();
     }
   }
+
+  // Re-focus the input once loading drops back to false. Calling .focus() in the
+  // sendMessage finally block fires before React re-renders the (disabled) textarea,
+  // so the focus is a no-op. Doing it via an effect runs after the DOM update.
+  useEffect(() => {
+    if (isOpen && !loading) {
+      inputRef.current?.focus();
+    }
+  }, [loading, isOpen]);
 
   async function clearChat() {
     try {

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -157,6 +157,7 @@ function getDb(): DatabaseType {
       role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
       content TEXT NOT NULL,
       provider TEXT,
+      responseId TEXT,
       createdAt TEXT NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_chat_messages_createdAt ON chat_messages(createdAt);
@@ -182,6 +183,11 @@ function getDb(): DatabaseType {
   const clozeCols = _db.prepare("PRAGMA table_info(clozeSentences)").all() as { name: string }[];
   if (!clozeCols.some(c => c.name === 'blacklisted')) {
     _db.exec('ALTER TABLE clozeSentences ADD COLUMN blacklisted INTEGER DEFAULT 0');
+  }
+
+  const chatCols = _db.prepare("PRAGMA table_info(chat_messages)").all() as { name: string }[];
+  if (!chatCols.some(c => c.name === 'responseId')) {
+    _db.exec('ALTER TABLE chat_messages ADD COLUMN responseId TEXT');
   }
 
   const collectionCols = _db.prepare("PRAGMA table_info(collections)").all() as { name: string }[];
@@ -567,5 +573,6 @@ export interface ChatMessageRow {
   role: 'user' | 'assistant';
   content: string;
   provider: string | null;
+  responseId: string | null;
   createdAt: string;
 }


### PR DESCRIPTION
Adds LM Studio (https://lmstudio.ai) as a fourth LLM provider alongside Ollama, Anthropic, and Apfel.

## Summary
- New `LMStudioProvider` with stateless `complete()` (OpenAI-compat `/v1/chat/completions`) and stateful `chatStateful()` (native `/api/v1/chat` with `previous_response_id` threading); 60s default timeout via `AbortController`; optional Bearer auth.
- Chat widget now uses LM Studio's stateful endpoint when the provider is selected — only the latest user message + the prior `response_id` is sent each turn. If LM Studio rejects an expired `response_id`, the route falls back to stateless `complete()` with the recent history.
- Settings UI: endpoint, Configured/Replace/Clear API key (matching the Anthropic credential pattern), model dropdown populated by "Fetch models", and an explicit "Load" button with a status pill (idle / loading / loaded / errored).
- Endpoint or API-key changes clear the saved model so the dropdown can't show a stale selection.
- `responseId TEXT` nullable column added to `chat_messages` (migrated in both Hono and Next sides).
- `lmstudioApiKey` is in `SENSITIVE_KEYS`; `GET /api/settings` returns `true` instead of the plaintext, matching the v1.16.0 credential-leak fix (#79). The browser never ships the saved key — the Hono proxy reads it from settings DB.
- `playwright.config.ts` now starts both Next (3456) and Hono (3457) so chat-route integration tests can run against the real backend.

## Test plan
- [ ] Select LM Studio in Settings → endpoint, API key, model fields appear; status pill starts at "Idle"
- [ ] Click "Fetch models" against a running LM Studio → dropdown populates with installed model IDs
- [ ] Pick a model and click "Load" → status pill goes Loading → Loaded; LM Studio shows the model loaded
- [ ] Save an API key → Settings shows "Configured" badge with Replace/Clear; `GET /api/settings` returns `lmstudioApiKey: true` (not the plaintext)
- [ ] Open the chat widget with provider = LM Studio → message #1 succeeds; message #2 includes `previous_response_id` from #1 (verified in network/`docs.lukeboyle.com/proof`)
- [ ] Restart LM Studio mid-conversation → next chat message falls back to stateless full-history call and still succeeds
- [ ] Switch provider away from LM Studio → existing Ollama / Anthropic / Apfel flows unchanged

## Tests
- 21 unit tests on `LMStudioProvider` (constructor, complete, chatStateful with/without previous_response_id, expired-id error class, healthCheck, listModels, loadModel, timeout)
- 11 e2e on the settings flow (proxy mocked at `page.route`)
- 2 e2e on the chat path with a stub HTTP server pretending to be LM Studio (verifies `previous_response_id` threading and the fallback behaviour)
- Full e2e suite locally: 125 passed, 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
