### PR TITLE
fix: cloze counter exceeding total on retry (#57)

### DIFF
--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -650,11 +650,90 @@ test.describe("Practice - Incorrect Type Answer Feedback", () => {
     }
 
     // The round should eventually complete, and the wrong answer should have
-    // appeared again in the retry queue. The progress counter should show
-    // more than 10 total (10 original + at least 1 retry).
+    // appeared again in the retry queue. The progress counter should stay
+    // capped at the round size (10) — retried sentences must not count again
+    // (issue #57).
     await expect(page.getByText("Round Complete!")).toBeVisible({
       timeout: 15000,
     });
+  });
+
+  test("retried sentences do not push the progress counter past round size (issue #57)", async ({
+    page,
+  }) => {
+    await waitForSetup(page);
+
+    const ROUND_SIZE = 10;
+    await page.getByRole("button", { name: String(ROUND_SIZE), exact: true }).click();
+    await page.getByRole("button", { name: "Type" }).click();
+    await page.getByRole("button", { name: "Start" }).click();
+
+    await expect(page.getByText("Fill in the blank")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Get the first sentence wrong so it lands in the retry queue.
+    const input = page.locator('input[placeholder="..."]');
+    await input.fill("zzzzz");
+    await input.press("Enter");
+    await expect(
+      page.getByRole("heading", { name: "Incorrect" })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Drive the round to completion using hints. Track the highest counter
+    // value seen — it must never exceed ROUND_SIZE.
+    let maxProgress = 0;
+    const counter = page.locator("span", { hasText: new RegExp(`^\\d+/${ROUND_SIZE}$`) });
+
+    for (let i = 0; i < 60; i++) {
+      const text = await counter.textContent().catch(() => null);
+      if (text) {
+        const num = parseInt(text.split("/")[0], 10);
+        if (!Number.isNaN(num) && num > maxProgress) maxProgress = num;
+        expect(num, `progress counter exceeded ${ROUND_SIZE}`).toBeLessThanOrEqual(
+          ROUND_SIZE
+        );
+      }
+
+      if (await page.getByText("Round Complete!").isVisible().catch(() => false)) break;
+
+      const nextBtn = page.getByRole("button", { name: "Next Sentence" });
+      if (await nextBtn.isVisible().catch(() => false)) {
+        await nextBtn.click();
+        await page.waitForTimeout(150);
+        continue;
+      }
+
+      const inputEl = page.locator('input[placeholder="..."]');
+      if (await inputEl.isVisible().catch(() => false)) {
+        const hintBtn = page.getByRole("button", { name: /Hint/ });
+        for (let h = 0; h < 25; h++) {
+          const submitBtn = page.getByRole("button", { name: "Submit" });
+          if (await submitBtn.isVisible().catch(() => false)) {
+            await submitBtn.click();
+            break;
+          }
+          if (await hintBtn.isVisible().catch(() => false)) {
+            await hintBtn.click();
+          }
+          await page.waitForTimeout(40);
+        }
+        await page.waitForTimeout(150);
+        continue;
+      }
+
+      await page.waitForTimeout(150);
+    }
+
+    await expect(page.getByText("Round Complete!")).toBeVisible({ timeout: 15000 });
+    expect(maxProgress).toBeLessThanOrEqual(ROUND_SIZE);
+
+    // Completion summary uses "{roundCorrect}/{roundProgress} correct" — must
+    // be capped at ROUND_SIZE since only first-pass attempts count.
+    const summary = await page.getByText(/\d+\/\d+ correct/).textContent();
+    expect(summary).toBeTruthy();
+    const [, denom] = summary!.match(/(\d+)\/(\d+) correct/)!.slice(1).map(Number);
+    expect(denom).toBeLessThanOrEqual(ROUND_SIZE);
   });
 });
 

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -206,6 +206,7 @@ export default function PracticePage() {
   const [ankiError, setAnkiError] = useState<string | null>(null);
   const [hintLetters, setHintLetters] = useState(0);
   const [retryQueue, setRetryQueue] = useState<ClozeSentence[]>([]);
+  const [isRetryPhase, setIsRetryPhase] = useState(false);
   const [blacklistToast, setBlacklistToast] = useState(false);
 
   // Word definition tooltip state
@@ -353,6 +354,7 @@ export default function PracticePage() {
     setRoundProgress(0);
     setRoundCorrect(0);
     setRetryQueue([]);
+    setIsRetryPhase(false);
     setRecentWords([]);
 
     try {
@@ -426,6 +428,7 @@ export default function PracticePage() {
       const retryList = [...retryQueue];
       setRetryQueue([]);
       setQueue(retryList);
+      setIsRetryPhase(true);
       loadNextSentence(retryList);
     } else {
       setState('complete');
@@ -468,9 +471,12 @@ export default function PracticePage() {
       await incrementDailyStat('points', earnedPoints);
     }
 
-    // Update local state
-    setRoundProgress((prev) => prev + 1);
-    if (isCorrect) setRoundCorrect((prev) => prev + 1);
+    // Update local state — only count first-pass answers toward round progress,
+    // so retried sentences don't push the counter past roundSize (issue #57).
+    if (!isRetryPhase) {
+      setRoundProgress((prev) => prev + 1);
+      if (isCorrect) setRoundCorrect((prev) => prev + 1);
+    }
     if (earnedPoints > 0) {
       setPoints((prev) => prev + earnedPoints);
     }
@@ -542,8 +548,10 @@ export default function PracticePage() {
         await incrementDailyStat('points', earnedPoints);
       }
 
-      setRoundProgress((prev) => prev + 1);
-      if (isCorrect) setRoundCorrect((prev) => prev + 1);
+      if (!isRetryPhase) {
+        setRoundProgress((prev) => prev + 1);
+        if (isCorrect) setRoundCorrect((prev) => prev + 1);
+      }
       if (earnedPoints > 0) {
         setPoints((prev) => prev + earnedPoints);
       }
@@ -564,7 +572,7 @@ export default function PracticePage() {
         speak(current.sentence.sentence);
       }
     }, delay);
-  }, [mcLocked, current, mcOptions, mcCorrectIdx]);
+  }, [mcLocked, current, mcOptions, mcCorrectIdx, isRetryPhase]);
 
   // Handle next sentence
   const handleNext = useCallback(async () => {
@@ -584,6 +592,7 @@ export default function PracticePage() {
       const retryList = [...retryQueue];
       setRetryQueue([]);
       setQueue(retryList);
+      setIsRetryPhase(true);
       loadNextSentence(retryList);
     } else {
       setState('complete');


### PR DESCRIPTION
## Summary
- Closes #57
- Retried sentences were incrementing `roundProgress` past `roundSize` (e.g. the user's reported `22/20` after retrying 2 incorrect answers in a round of 20).
- Add an `isRetryPhase` state flag (set when the queue transitions from the original list to the retry queue) and gate the `roundProgress` / `roundCorrect` increments in both `processAnswer` (type mode) and `handleMcSelect` (MC mode) on it. Only first-pass attempts now count toward the round total.

## Test plan
- [x] Updated the existing "should add incorrect answer to retry queue and re-test it" comment (it previously documented the buggy behavior).
- [x] Added a regression test that asserts the progress counter stays `<= roundSize` throughout a round with a forced wrong answer + retry, and that the completion summary denominator is also capped.
- [x] Manually drove the practice page in the browser: typed `zzzzz` for sentence 1, completed the remaining 9 via hints, retried the wrong one. Counter sampled at every iteration — capped at `10/10`. Completion summary showed `9/10 correct` (correct: 1 wrong on first pass, retry attempt does not count toward score).
- [ ] Full Playwright suite was still running at push time — please confirm green on CI.
