### PR TITLE
fix: snappy popup, always-on In context button, CEFR Known tooltip

### DIFF
--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -47,6 +47,7 @@ export default function ReadPage({
   const [readerRefreshTrigger, setReaderRefreshTrigger] = useState(0);
   const wordPanelRef = useRef<HTMLDivElement>(null);
   const translationRequestId = useRef(0);
+  const existingEntryLookup = useRef<Promise<VocabEntry | undefined> | null>(null);
 
   const [wordPanel, setWordPanel] = useState<WordPanelState>({
     isOpen: false,
@@ -99,23 +100,34 @@ export default function ReadPage({
     const wordsToSpeak = word.split(/\s+/).slice(0, 15).join(' ');
     speak(wordsToSpeak);
 
-    const existingEntry = await getVocabByText(word.toLowerCase());
-    const hasTranslation = existingEntry?.translation && existingEntry.translation.length > 0;
-
+    // Open popup immediately in loading state so keyboard shortcuts (K/X) are responsive
     setWordPanel({
       isOpen: true,
       word,
       sentence,
-      translation: hasTranslation ? existingEntry.translation : null,
+      translation: null,
       partOfSpeech: isPhrase ? 'phrase' : null,
-      isLoading: !hasTranslation,
+      isLoading: true,
       isContextLoading: false,
       isDictionaryResult: false,
       error: null,
-      existingEntry: existingEntry || null,
+      existingEntry: null,
     });
 
-    await incrementDailyStat('dictionaryLookups');
+    incrementDailyStat('dictionaryLookups');
+
+    const lookupPromise = getVocabByText(word.toLowerCase());
+    existingEntryLookup.current = lookupPromise;
+    const existingEntry = await lookupPromise;
+    if (requestId !== translationRequestId.current) return;
+    const hasTranslation = existingEntry?.translation && existingEntry.translation.length > 0;
+
+    setWordPanel((prev) => ({
+      ...prev,
+      translation: hasTranslation ? existingEntry.translation : null,
+      isLoading: !hasTranslation,
+      existingEntry: existingEntry || null,
+    }));
 
     if (!hasTranslation) {
       if (isPhrase) {
@@ -201,23 +213,35 @@ export default function ReadPage({
     }
   }, [wordPanel.word, wordPanel.sentence]);
 
+  // Resolves the existing vocab entry, awaiting an in-flight lookup if needed.
+  // Prevents duplicate-row races when the user acts before getVocabByText returns.
+  const resolveExistingEntry = useCallback(async (): Promise<VocabEntry | undefined> => {
+    if (wordPanel.existingEntry) return wordPanel.existingEntry;
+    if (existingEntryLookup.current) {
+      const fromLookup = await existingEntryLookup.current;
+      if (fromLookup) return fromLookup;
+    }
+    return undefined;
+  }, [wordPanel.existingEntry]);
+
   const saveWordToVocab = useCallback(async () => {
     if (!wordPanel.translation) return;
 
+    const existing = await resolveExistingEntry();
     const isPhrase = wordPanel.word.includes(' ');
     const entry: VocabEntry = {
-      id: wordPanel.existingEntry?.id || uuidv4(),
+      id: existing?.id || uuidv4(),
       text: wordPanel.word.toLowerCase(),
       type: isPhrase ? 'phrase' : 'word',
       sentence: wordPanel.sentence,
       translation: wordPanel.translation,
-      state: wordPanel.existingEntry?.state || 'level1',
+      state: existing?.state || 'level1',
       stateUpdatedAt: new Date(),
-      reviewCount: wordPanel.existingEntry?.reviewCount || 0,
+      reviewCount: existing?.reviewCount || 0,
       bookId: lessonId,
-      createdAt: wordPanel.existingEntry?.createdAt || new Date(),
-      pushedToAnki: wordPanel.existingEntry?.pushedToAnki || false,
-      ankiNoteId: wordPanel.existingEntry?.ankiNoteId,
+      createdAt: existing?.createdAt || new Date(),
+      pushedToAnki: existing?.pushedToAnki || false,
+      ankiNoteId: existing?.ankiNoteId,
     };
 
     await saveVocab(entry);
@@ -228,15 +252,14 @@ export default function ReadPage({
       existingEntry: entry,
     }));
     setReaderRefreshTrigger(prev => prev + 1);
-  }, [wordPanel, lessonId]);
+  }, [wordPanel, lessonId, resolveExistingEntry]);
 
   const markAsKnown = useCallback(async () => {
-    let entryId = wordPanel.existingEntry?.id;
+    const existing = await resolveExistingEntry();
 
-    if (!entryId) {
-      const newId = uuidv4();
+    if (!existing) {
       const entry: VocabEntry = {
-        id: newId,
+        id: uuidv4(),
         text: wordPanel.word.toLowerCase(),
         type: 'word',
         sentence: wordPanel.sentence,
@@ -249,18 +272,19 @@ export default function ReadPage({
         pushedToAnki: false,
       };
       await saveVocab(entry);
-      entryId = newId;
     } else {
-      await updateVocabState(entryId, 'known');
+      await updateVocabState(existing.id, 'known');
     }
 
     await incrementDailyStat('wordsMarkedKnown');
     setReaderRefreshTrigger(prev => prev + 1);
     closeWordPanel();
-  }, [wordPanel, lessonId, closeWordPanel]);
+  }, [wordPanel, lessonId, closeWordPanel, resolveExistingEntry]);
 
   const ignoreWord = useCallback(async () => {
-    if (!wordPanel.existingEntry) {
+    const existing = await resolveExistingEntry();
+
+    if (!existing) {
       const entry: VocabEntry = {
         id: uuidv4(),
         text: wordPanel.word.toLowerCase(),
@@ -276,19 +300,20 @@ export default function ReadPage({
       };
       await saveVocab(entry);
     } else {
-      await updateVocabState(wordPanel.existingEntry.id, 'ignored');
+      await updateVocabState(existing.id, 'ignored');
     }
 
     setReaderRefreshTrigger(prev => prev + 1);
     closeWordPanel();
-  }, [wordPanel, lessonId, closeWordPanel]);
+  }, [wordPanel, lessonId, closeWordPanel, resolveExistingEntry]);
 
   const setWordLevel = useCallback(async (level: 1 | 2 | 3 | 4) => {
     if (!wordPanel.translation) return;
 
     const state = `level${level}` as 'level1' | 'level2' | 'level3' | 'level4';
+    const existing = await resolveExistingEntry();
 
-    if (!wordPanel.existingEntry) {
+    if (!existing) {
       const entry: VocabEntry = {
         id: uuidv4(),
         text: wordPanel.word.toLowerCase(),
@@ -306,15 +331,15 @@ export default function ReadPage({
       await incrementDailyStat('newWordsSaved');
       setWordPanel((prev) => ({ ...prev, existingEntry: entry }));
     } else {
-      await updateVocabState(wordPanel.existingEntry.id, state);
+      await updateVocabState(existing.id, state);
       setWordPanel((prev) => ({
         ...prev,
-        existingEntry: prev.existingEntry ? { ...prev.existingEntry, state } : null,
+        existingEntry: prev.existingEntry ? { ...prev.existingEntry, state } : { ...existing, state },
       }));
     }
 
     setReaderRefreshTrigger(prev => prev + 1);
-  }, [wordPanel, lessonId]);
+  }, [wordPanel, lessonId, resolveExistingEntry]);
 
   const handleClose = useCallback(() => {
     if (lesson?.collectionId) {
@@ -452,7 +477,7 @@ export default function ReadPage({
                       {wordPanel.translation || '\u2014'}
                     </span>
                   )}
-                  {wordPanel.isDictionaryResult && !wordPanel.isContextLoading && (
+                  {!wordPanel.word.includes(' ') && !wordPanel.isLoading && !wordPanel.isContextLoading && wordPanel.translation && (
                     <button
                       onClick={requestContextTranslation}
                       className="ml-1 px-2 py-0.5 text-xs font-medium rounded-md

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -307,7 +307,17 @@ function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
           <div data-testid="fluency-known-count" className="text-2xl font-bold text-green-600 dark:text-green-400">
             {totalKnownWords.toLocaleString()}
           </div>
-          <div className="text-sm text-zinc-500 dark:text-zinc-400">Known</div>
+          <div className="text-sm text-zinc-500 dark:text-zinc-400 inline-flex items-center gap-1">
+            Known
+            <span
+              title="CEFR level uses all known words including bulk-imported lists (e.g., frequency-list imports from Settings). The 'Words Known' tile below counts only entries you've interacted with directly in your vocabulary."
+              className="cursor-help text-zinc-400 dark:text-zinc-500"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </span>
+          </div>
         </div>
         <div className="text-center p-3 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg">
           <div data-testid="fluency-learning-count" className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">


### PR DESCRIPTION
## Summary

Three on-the-go reading UX fixes Luke surfaced while using Lector mobile:

- **Definition popup opens optimistically.** `handleWordClick` previously waited for `getVocabByText` before setting `wordPanel.isOpen = true`, so K (known) and X (ignore) shortcuts ate keystrokes during fast tap sequences. Popup now opens before any await; the in-flight lookup is stashed on a ref so action handlers can await it and avoid duplicate-row races when the user acts before the lookup resolves.
- **"In context" button always shows for single words.** Was gated on `isDictionaryResult`; now shows for any single-word translation (dictionary, LLM, or cached), hidden for phrases.
- **CEFR "Known" tooltip on stats.** The CEFR-level Known count reads from the `knownWords` table (includes bulk-imported frequency lists from Settings); the Words Known StatCard below reads from the `vocab` table (only entries you've interacted with). Added an info icon explaining the difference rather than silently reconciling.

## Test plan
- [x] Optimistic popup: clicking a word opens the panel immediately even when `/api/vocab` is slow — [proof](https://github.com/heuwels/lector/pull/97#issuecomment-4580785921)
- [x] "In context" button visible on a single-word lookup — [proof](https://github.com/heuwels/lector/pull/97#issuecomment-4580786064)
- [x] "In context" button hidden on a multi-word phrase — [proof](https://github.com/heuwels/lector/pull/97#issuecomment-4580786064)
- [x] CEFR "Known" tooltip explains the divergence — [proof](https://github.com/heuwels/lector/pull/97#issuecomment-4580786176)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
