### PR TITLE
feat: inline text editing in reader (closes #67)

### DIFF
--- a/e2e/reader-inline-edit.spec.ts
+++ b/e2e/reader-inline-edit.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, Page } from '@playwright/test';
+
+const TEST_TITLE = 'Inline Edit Test';
+const ORIGINAL_TEXT = 'Die son skyn helder vandag. Ek loop deur die veld.';
+const EDITED_TEXT = 'Die maan skyn helder vannag. Ek loop deur die straat.';
+
+async function createLesson(page: Page): Promise<{ collectionId: string; lessonId: string }> {
+  const colRes = await page.request.post('/api/collections', {
+    data: { title: TEST_TITLE, language: 'af' },
+  });
+  const { id: collectionId } = await colRes.json();
+
+  await page.request.post(`/api/collections/${collectionId}/lessons`, {
+    data: { title: 'Hoofstuk 1', textContent: ORIGINAL_TEXT },
+  });
+
+  const lessonsRes = await page.request.get(`/api/collections/${collectionId}/lessons`);
+  const lessons = await lessonsRes.json();
+  return { collectionId, lessonId: lessons[0].id };
+}
+
+async function cleanupExisting(page: Page) {
+  const res = await page.request.get('/api/collections');
+  const collections = await res.json();
+  for (const c of collections) {
+    if (c.title === TEST_TITLE) {
+      await page.request.delete(`/api/collections/${c.id}`);
+    }
+  }
+}
+
+test.describe('Reader inline editing (issue #67)', () => {
+  let collectionId: string;
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await cleanupExisting(page);
+    const created = await createLesson(page);
+    collectionId = created.collectionId;
+    await page.goto(`/read/${created.lessonId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('helder', { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (collectionId) {
+      await page.request.delete(`/api/collections/${collectionId}`);
+    }
+  });
+
+  test('edit button toggles textarea, save persists changes', async ({ page }) => {
+    const editButton = page.getByTestId('edit-text-button');
+    await expect(editButton).toBeVisible();
+
+    // Article rendered, textarea not yet present
+    await expect(page.locator('article')).toBeVisible();
+    await expect(page.getByTestId('edit-text-textarea')).toHaveCount(0);
+
+    await editButton.click();
+
+    // Textarea now visible with the original content
+    const textarea = page.getByTestId('edit-text-textarea');
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue(ORIGINAL_TEXT);
+
+    // Article (tokenized view) is hidden in edit mode
+    await expect(page.locator('article')).toHaveCount(0);
+
+    // Edit button itself is gone, replaced by Cancel/Save
+    await expect(page.getByTestId('edit-text-button')).toHaveCount(0);
+    await expect(page.getByTestId('edit-text-cancel')).toBeVisible();
+    await expect(page.getByTestId('edit-text-save')).toBeVisible();
+
+    // Modify and save
+    await textarea.fill(EDITED_TEXT);
+    await page.getByTestId('edit-text-save').click();
+
+    // Back to read mode, new content visible in the article
+    await expect(page.getByTestId('edit-text-textarea')).toHaveCount(0);
+    await expect(page.locator('article')).toBeVisible();
+    await expect(page.locator('article')).toContainText('maan');
+    await expect(page.locator('article')).toContainText('straat');
+    await expect(page.locator('article')).not.toContainText('son skyn helder vandag');
+
+    // Persisted in DB
+    const lessonId = page.url().split('/').pop()!;
+    const checkRes = await page.request.get(`/api/lessons/${lessonId}`);
+    const persisted = await checkRes.json();
+    expect(persisted.textContent).toBe(EDITED_TEXT);
+  });
+
+  test('cancel discards changes and restores the article', async ({ page }) => {
+    await page.getByTestId('edit-text-button').click();
+    const textarea = page.getByTestId('edit-text-textarea');
+    await expect(textarea).toBeVisible();
+
+    await textarea.fill('totally different text that should not persist');
+    await page.getByTestId('edit-text-cancel').click();
+
+    // Article restored with original content
+    await expect(page.getByTestId('edit-text-textarea')).toHaveCount(0);
+    await expect(page.locator('article')).toContainText('vandag');
+    await expect(page.locator('article')).not.toContainText('totally different');
+
+    // DB still has the original
+    const lessonId = page.url().split('/').pop()!;
+    const checkRes = await page.request.get(`/api/lessons/${lessonId}`);
+    const persisted = await checkRes.json();
+    expect(persisted.textContent).toBe(ORIGINAL_TEXT);
+  });
+
+  test('back button is disabled while editing', async ({ page }) => {
+    const backButton = page.getByRole('button', { name: /back/i }).first();
+    await expect(backButton).toBeEnabled();
+
+    await page.getByTestId('edit-text-button').click();
+    await expect(backButton).toBeDisabled();
+
+    await page.getByTestId('edit-text-cancel').click();
+    await expect(backButton).toBeEnabled();
+  });
+});

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -12,6 +12,7 @@ import {
   saveVocab,
   getVocabByText,
   updateVocabState,
+  updateLesson,
   incrementDailyStat,
 } from '@/lib/data-layer';
 import { translateWord, translatePhrase } from '@/lib/claude';
@@ -324,6 +325,18 @@ export default function ReadPage({
     }
   }, [router, lesson]);
 
+  const handleSaveText = useCallback(async (newContent: string) => {
+    await updateLesson(lessonId, { textContent: newContent });
+    setLesson((prev) => (prev ? { ...prev, textContent: newContent } : prev));
+    setReaderRefreshTrigger((prev) => prev + 1);
+  }, [lessonId]);
+
+  const handleEditingChange = useCallback((editing: boolean) => {
+    if (editing) {
+      setWordPanel((prev) => ({ ...prev, isOpen: false }));
+    }
+  }, []);
+
   // Navigate to prev/next lesson in collection
   const currentIndex = siblings.findIndex(l => l.id === lessonId);
   const prevLesson = currentIndex > 0 ? siblings[currentIndex - 1] : null;
@@ -402,6 +415,8 @@ export default function ReadPage({
           lesson={lesson}
           onWordClick={handleWordClick}
           onClose={handleClose}
+          onSaveText={handleSaveText}
+          onEditingChange={handleEditingChange}
           refreshTrigger={readerRefreshTrigger}
           prevLesson={prevLesson}
           nextLesson={nextLesson}

--- a/src/components/MarkdownReader.tsx
+++ b/src/components/MarkdownReader.tsx
@@ -64,6 +64,8 @@ interface MarkdownReaderProps {
   lesson: Lesson;
   onWordClick: (word: string, sentence: string) => void;
   onClose: () => void;
+  onSaveText?: (textContent: string) => Promise<void>;
+  onEditingChange?: (isEditing: boolean) => void;
   refreshTrigger?: number;
   prevLesson?: LessonSummary | null;
   nextLesson?: LessonSummary | null;
@@ -73,6 +75,8 @@ export default function MarkdownReader({
   lesson,
   onWordClick,
   onClose,
+  onSaveText,
+  onEditingChange,
   refreshTrigger = 0,
   prevLesson,
   nextLesson,
@@ -83,6 +87,41 @@ export default function MarkdownReader({
   const [highlightedPhrase, setHighlightedPhrase] = useState<string[]>([]);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [scrollPercentage, setScrollPercentage] = useState(0);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftContent, setDraftContent] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const startEdit = useCallback(() => {
+    setDraftContent(lesson.textContent);
+    setSaveError(null);
+    setIsEditing(true);
+    onEditingChange?.(true);
+  }, [lesson.textContent, onEditingChange]);
+
+  const cancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setDraftContent('');
+    setSaveError(null);
+    onEditingChange?.(false);
+  }, [onEditingChange]);
+
+  const saveEdit = useCallback(async () => {
+    if (!onSaveText) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await onSaveText(draftContent);
+      setIsEditing(false);
+      setDraftContent('');
+      onEditingChange?.(false);
+    } catch (err) {
+      console.error('Failed to save lesson text:', err);
+      setSaveError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [draftContent, onSaveText, onEditingChange]);
 
   // Detect dark mode
   useEffect(() => {
@@ -246,10 +285,12 @@ export default function MarkdownReader({
       <header className="flex items-center justify-between px-4 py-2 border-b border-zinc-200 dark:border-zinc-700">
         <button
           onClick={onClose}
+          disabled={isEditing}
           className="flex items-center gap-2 px-3 py-2 rounded-lg
             text-zinc-600 dark:text-zinc-400
             hover:bg-zinc-100 dark:hover:bg-zinc-800
-            transition-colors"
+            transition-colors
+            disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
@@ -261,9 +302,56 @@ export default function MarkdownReader({
           {lesson.title}
         </h1>
 
-        <div className="text-sm text-zinc-500 dark:text-zinc-400">
-          {scrollPercentage}%
-        </div>
+        {isEditing ? (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={cancelEdit}
+              disabled={isSaving}
+              data-testid="edit-text-cancel"
+              className="px-3 py-1.5 text-sm rounded-lg
+                text-zinc-700 dark:text-zinc-300
+                hover:bg-zinc-100 dark:hover:bg-zinc-800
+                transition-colors
+                disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={saveEdit}
+              disabled={isSaving}
+              data-testid="edit-text-save"
+              className="px-3 py-1.5 text-sm font-medium rounded-lg
+                bg-blue-600 text-white
+                hover:bg-blue-700
+                transition-colors
+                disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isSaving ? 'Saving…' : 'Save changes'}
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <div className="text-sm text-zinc-500 dark:text-zinc-400">
+              {scrollPercentage}%
+            </div>
+            {onSaveText && (
+              <button
+                onClick={startEdit}
+                data-testid="edit-text-button"
+                title="Edit text"
+                aria-label="Edit text"
+                className="p-2 rounded-lg
+                  text-zinc-600 dark:text-zinc-400
+                  hover:bg-zinc-100 dark:hover:bg-zinc-800
+                  transition-colors"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
+            )}
+          </div>
+        )}
       </header>
 
       {/* Content */}
@@ -273,26 +361,59 @@ export default function MarkdownReader({
         onMouseUp={handleMouseUp}
         className="flex-1 overflow-auto"
       >
-        <article className="max-w-[38em] mx-auto px-4 sm:px-8 py-8 sm:py-16 prose prose-zinc dark:prose-invert
-          prose-p:text-lg sm:prose-p:text-2xl prose-p:leading-[1.9] prose-p:text-zinc-700 dark:prose-p:text-zinc-300
-          prose-headings:font-sans prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100
-          prose-li:text-lg sm:prose-li:text-xl prose-li:leading-relaxed"
-          style={{ fontFamily: 'var(--font-literata), Georgia, serif' }}>
-          <ReactMarkdown
-            components={{
-              p: ({ children }) => <p>{typeof children === 'string' ? renderText(children) : children}</p>,
-              li: ({ children }) => <li>{typeof children === 'string' ? renderText(children) : children}</li>,
-              h1: ({ children }) => <h1>{children}</h1>,
-              h2: ({ children }) => <h2>{children}</h2>,
-              h3: ({ children }) => <h3>{children}</h3>,
-            }}
-          >
-            {content}
-          </ReactMarkdown>
-        </article>
+        {isEditing ? (
+          <div className="max-w-[38em] mx-auto px-4 sm:px-8 py-8 sm:py-12">
+            <textarea
+              data-testid="edit-text-textarea"
+              value={draftContent}
+              onChange={(e) => setDraftContent(e.target.value)}
+              disabled={isSaving}
+              autoFocus
+              spellCheck={false}
+              className="w-full min-h-[60vh] p-4 rounded-lg
+                border border-zinc-300 dark:border-zinc-600
+                bg-white dark:bg-zinc-800
+                text-zinc-800 dark:text-zinc-200
+                text-base leading-relaxed
+                font-mono
+                focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                disabled:opacity-60 disabled:cursor-not-allowed
+                resize-y"
+            />
+            {saveError && (
+              <p
+                data-testid="edit-text-error"
+                className="mt-2 text-sm text-red-500 dark:text-red-400"
+              >
+                {saveError}
+              </p>
+            )}
+            <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
+              Markdown is supported. Vocab state is keyed by word, so edits don&apos;t reset your progress.
+            </p>
+          </div>
+        ) : (
+          <article className="max-w-[38em] mx-auto px-4 sm:px-8 py-8 sm:py-16 prose prose-zinc dark:prose-invert
+            prose-p:text-lg sm:prose-p:text-2xl prose-p:leading-[1.9] prose-p:text-zinc-700 dark:prose-p:text-zinc-300
+            prose-headings:font-sans prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100
+            prose-li:text-lg sm:prose-li:text-xl prose-li:leading-relaxed"
+            style={{ fontFamily: 'var(--font-literata), Georgia, serif' }}>
+            <ReactMarkdown
+              components={{
+                p: ({ children }) => <p>{typeof children === 'string' ? renderText(children) : children}</p>,
+                li: ({ children }) => <li>{typeof children === 'string' ? renderText(children) : children}</li>,
+                h1: ({ children }) => <h1>{children}</h1>,
+                h2: ({ children }) => <h2>{children}</h2>,
+                h3: ({ children }) => <h3>{children}</h3>,
+              }}
+            >
+              {content}
+            </ReactMarkdown>
+          </article>
+        )}
 
         {/* Prev/Next navigation at bottom */}
-        {(prevLesson || nextLesson) && (
+        {!isEditing && (prevLesson || nextLesson) && (
           <div className="max-w-[38em] mx-auto px-4 sm:px-8 pb-16 flex items-center justify-between gap-4">
             {prevLesson ? (
               <button


### PR DESCRIPTION
## Summary
- Adds a pencil-icon Edit button to the reader header. Click → swaps the tokenized `MarkdownReader` article for a `<textarea>` pre-filled with the lesson markdown. Save calls `updateLesson()` and returns to the tokenized view; Cancel discards the draft.
- New `MarkdownReader` props: `onSaveText`, `onEditingChange`. Word panel auto-closes when editing starts; Back button + prev/next nav are hidden/disabled during edit.
- Vocab is keyed by word string (not position) in the existing data model, so text edits do **not** reset SRS state.

## Test plan
- [x] `e2e/reader-inline-edit.spec.ts` — happy path: edit → save → DB persisted, tokenized view shows new content
- [x] Cancel discards changes (DB unchanged, original article restored)
- [x] Back button disabled while editing
- [x] Full e2e suite passes locally: `npx playwright test` → **129 passed / 1 skipped / 0 failed** (5.1 min)
- [ ] Manual smoke on mobile viewport
- [ ] Verify undo/redo work inside the textarea (browser-native)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
