### PR TITLE
feat(dict): persist accepted AI translations into the on-device cache

### DIFF
--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -72,25 +72,61 @@ Be specific and concrete in idiomaticMeaning and usageNotes — avoid vague phra
 
       return c.json(JSON.parse(text));
     } else {
-      const prompt = `You are a ${langName} to English translator with deep knowledge of ${langName} orthography.
+      const prompt = `You are a ${langName} to English translator with deep knowledge of ${langName} orthography, morphology, and etymology.
 
-${spelreelsSection}Translate the following ${langName} word, using the sentence context to determine the correct meaning.
+${spelreelsSection}A learner clicked the following ${langName} word while reading. Produce a dictionary-quality entry — not a single gloss. The output is used both to display the meaning AND to persist into an on-device dictionary, so be thorough and faithful.
 
 Word: "${word}"
 Sentence context: "${sentence || word}"
 
-Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
-{"translation": "the English translation", "partOfSpeech": "noun/verb/adjective/adverb/etc"}
+Respond with ONLY a JSON object in this exact shape (no markdown, no code blocks):
+{
+  "word": "${word}",
+  "senses": [
+    { "partOfSpeech": "noun | verb | adjective | adverb | pronoun | preposition | conjunction | interjection | determiner | numeral | particle", "gloss": "concise English meaning, no period" }
+    /* ...one entry per distinct sense; order most-common first */
+  ],
+  "ipa": "/.../ or [...] — phonetic transcription if you're confident",
+  "etymology": "Brief origin note (e.g. \\"From Dutch X, from Middle Dutch Y\\")",
+  "relatedForms": [
+    { "form": "the related word", "relation": "plural of | diminutive of | past tense of | derived from | etc." }
+  ]
+}
 
-If you cannot determine the part of speech, omit that field.`;
+Rules:
+- "word" and "senses" are REQUIRED. senses must be non-empty.
+- Include separate sense entries for genuinely distinct meanings (e.g. "trek" = pull / move / journey). Don't split shades of the same meaning.
+- Use the sentence to bias sense ORDER, but include all common senses a learner might reasonably encounter.
+- Each gloss is a short English phrase (1-4 words is typical, up to a clause for verbs with idiomatic completions).
+- Omit ipa / etymology / relatedForms entirely if you're not confident — don't guess.
+- Use the same partOfSpeech vocabulary as Wiktionary so cached entries align with the curated dict.
+
+Backwards-compat fields the server adds (do NOT include these yourself — server stitches them from senses): translation, partOfSpeech.`;
 
       const provider = getProvider();
       const text = await provider.complete({
         messages: [{ role: 'user', content: prompt }],
-        maxTokens: 256,
+        maxTokens: 800,
       });
 
-      return c.json(JSON.parse(text));
+      const entry = JSON.parse(text);
+
+      // Stitch legacy fields so existing call sites that only read translation +
+      // partOfSpeech don't have to change.
+      const senses: Array<{ partOfSpeech: string; gloss: string }> = Array.isArray(entry.senses) ? entry.senses : [];
+      const stitchedTranslation = senses.map((s) => s.gloss).filter(Boolean).join('; ');
+      const firstPos = senses[0]?.partOfSpeech;
+
+      return c.json({
+        translation: stitchedTranslation,
+        partOfSpeech: firstPos,
+        // Pass through the structured fields
+        word: entry.word || word,
+        senses,
+        ipa: entry.ipa,
+        etymology: entry.etymology,
+        relatedForms: Array.isArray(entry.relatedForms) ? entry.relatedForms : undefined,
+      });
     }
   } catch (error) {
     console.error('Translation error:', error);

--- a/e2e/translation-cache.spec.ts
+++ b/e2e/translation-cache.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import path from 'path';
+
+/**
+ * E2E for issue #100 — accepted AI translations get cached into the on-device
+ * dictionary so the next time the user clicks the same word, lookup is served
+ * from cache (`learned` pill) and the AI translate API is NOT called.
+ *
+ * Strategy:
+ *   1. Import a book with a known nonsense token that's guaranteed to miss
+ *      the on-device dict (and isn't a real Afrikaans word).
+ *   2. Mock /api/translate to return a deterministic structured response;
+ *      assert exactly ONE call across the test.
+ *   3. Click the word, mark it Known (an accept action).
+ *   4. Re-click the same word — the drawer must show the `learned` source pill
+ *      and the AI mock must still report exactly one total invocation.
+ */
+async function importBookWithToken(page: Page, token: string) {
+  const colRes = await page.request.post('/api/collections', {
+    data: { title: 'Cache Test', language: 'af' },
+  });
+  const { id: collectionId } = await colRes.json();
+  await page.request.post(`/api/collections/${collectionId}/lessons`, {
+    data: {
+      title: 'Cap. 1',
+      // Surround the token with normal Afrikaans so the tokenizer treats it
+      // as one clickable word.
+      textContent: `Die ${token} is hier.`,
+    },
+  });
+  const lessonsRes = await page.request.get(`/api/collections/${collectionId}/lessons`);
+  const lessons = await lessonsRes.json();
+  await page.goto(`/read/${lessons[0].id}`);
+  await page.waitForLoadState('networkidle');
+  return collectionId;
+}
+
+test.describe('AI translation cache', () => {
+  // Use a unique nonsense word per test run so we never collide with a real
+  // dict entry, and so the cache is empty for the first click.
+  const NONSENSE = `xqzzaftj${Date.now().toString(36)}`;
+  let collectionId: string;
+  let translateCallCount = 0;
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    translateCallCount = 0;
+
+    // Mock the AI translate endpoint with a structured payload that the
+    // drawer can render AND the cache can persist.
+    await page.route('**/api/translate', async (route: Route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      if (body.type === 'phrase') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ translation: '[ai phrase]', partOfSpeech: 'phrase' }),
+        });
+        return;
+      }
+      translateCallCount++;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          translation: 'invented; made-up',
+          partOfSpeech: 'noun',
+          word: body.word,
+          senses: [
+            { partOfSpeech: 'noun', gloss: 'invented' },
+            { partOfSpeech: 'noun', gloss: 'made-up' },
+          ],
+          ipa: '/test/',
+          etymology: 'From the test suite',
+        }),
+      });
+    });
+
+    // Clean any leftover Cache Test collections
+    const res = await page.request.get('/api/collections');
+    const cols = await res.json();
+    for (const c of cols) {
+      if (c.title === 'Cache Test') {
+        await page.request.delete(`/api/collections/${c.id}`);
+      }
+    }
+
+    collectionId = await importBookWithToken(page, NONSENSE);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (collectionId) {
+      await page.request.delete(`/api/collections/${collectionId}`);
+    }
+    // Clean the cache table so subsequent runs aren't polluted. There's no
+    // dedicated DELETE endpoint yet; do it via raw SQL through the data
+    // import/export route would be too heavy. Just leave it — the unique
+    // NONSENSE word per run guarantees no cross-test interference.
+  });
+
+  test('AI translation persists to cache on accept and is served on re-click', async ({ page }) => {
+    // 1st click — should hit the AI mock once.
+    const word = page.locator('article span.cursor-pointer', { hasText: NONSENSE });
+    await expect(word).toBeVisible();
+    await word.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+    await expect(drawer.getByText('AI', { exact: true })).toBeVisible({ timeout: 5000 });
+    expect(translateCallCount).toBe(1);
+
+    // Accept via "Known" — this should fire-and-forget the cache write.
+    await drawer.getByRole('button', { name: /Known/ }).click();
+
+    // Drawer closes on Known. Give the cache write a beat to land before
+    // the next lookup. Polling on the API directly is faster than waitForTimeout.
+    await expect.poll(async () => {
+      const r = await page.request.get(
+        `/api/dictionary/lookup?word=${encodeURIComponent(NONSENSE)}`
+      );
+      const data = await r.json();
+      return data.entry?.source ?? null;
+    }, { timeout: 5000 }).toBe('cache');
+
+    // 2nd click — must come from the cache, must NOT call AI again.
+    await word.click();
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+    await expect(drawer.getByText('learned', { exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(drawer.locator('ol li').first()).toBeVisible();
+    expect(translateCallCount).toBe(1);
+  });
+});

--- a/scripts/export-cached-entries.ts
+++ b/scripts/export-cached-entries.ts
@@ -1,0 +1,70 @@
+/**
+ * Dump the on-device AI translation cache (cached_entries / cached_senses /
+ * cached_related_forms in lector.db) into a JSON patch that can be merged
+ * into `src/lib/dictionary-roots.json` and rolled into the next dict release.
+ *
+ *   npx tsx scripts/export-cached-entries.ts > tmp/cached-patch.json
+ *
+ * Schema of the output mirrors dictionary-roots.json — one top-level object
+ * keyed by the lowercase word, with translation/partOfSpeech stitched from
+ * the senses table. The hand-curated review step is intentional: cached
+ * entries are user-validated but not yet vetted for canonical inclusion.
+ */
+import path from 'path';
+import fs from 'fs';
+import Database from 'better-sqlite3';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const DATA_DIR = process.env.DATA_DIR || path.join(PROJECT_ROOT, 'data');
+const DB_PATH = path.join(DATA_DIR, 'lector.db');
+
+if (!fs.existsSync(DB_PATH)) {
+  console.error(`No lector.db at ${DB_PATH}. Nothing to export.`);
+  process.exit(1);
+}
+
+const db = new Database(DB_PATH, { readonly: true, fileMustExist: true });
+
+interface EntryRow {
+  word: string;
+  ipa: string | null;
+  etymology: string | null;
+}
+
+interface RootJsonEntry {
+  rank: number;
+  translation: string;
+  partOfSpeech: string;
+  ipa?: string;
+  etymology?: string;
+}
+
+const entries = db.prepare('SELECT word, ipa, etymology FROM cached_entries ORDER BY word').all() as EntryRow[];
+const senseStmt = db.prepare('SELECT pos, gloss FROM cached_senses WHERE word = ? ORDER BY sort_order');
+
+const out: Record<string, RootJsonEntry> = {};
+let skipped = 0;
+
+for (const row of entries) {
+  const senses = senseStmt.all(row.word) as Array<{ pos: string | null; gloss: string }>;
+  if (senses.length === 0) {
+    skipped++;
+    continue;
+  }
+  const translation = senses.map((s) => s.gloss).filter(Boolean).join('; ');
+  const partOfSpeech = senses[0]?.pos || '';
+  const entry: RootJsonEntry = {
+    rank: 0,
+    translation,
+    partOfSpeech,
+  };
+  if (row.ipa) entry.ipa = row.ipa;
+  if (row.etymology) entry.etymology = row.etymology;
+  out[row.word] = entry;
+}
+
+process.stdout.write(JSON.stringify(out, null, 2));
+process.stdout.write('\n');
+
+console.error(`Exported ${Object.keys(out).length} cached entries (${skipped} skipped: no senses).`);
+console.error('To merge: paste into src/lib/dictionary-roots.json, run `npx tsx scripts/build-dictionary.ts`, then re-publish via scripts/release-dict.sh.');

--- a/src/app/api/dictionary/cache/route.ts
+++ b/src/app/api/dictionary/cache/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cacheAcceptedEntry, type CacheAcceptedInput } from '@/lib/server/dictionary-db';
+
+/**
+ * POST /api/dictionary/cache
+ *
+ * Persists a user-accepted AI translation into the on-device cache. Called
+ * from the read page when the user saves a word to vocab, marks it Known,
+ * or sets a learning level — actions that signal "this translation is good
+ * enough that I'm committing to the word".
+ *
+ * Body: CacheAcceptedInput  (word + senses required; ipa/etymology/related
+ * forms / sourceSentence / language optional)
+ *
+ * Returns: { word: string } on success, or { error } on bad input.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Partial<CacheAcceptedInput>;
+    if (!body.word || typeof body.word !== 'string' || !body.word.trim()) {
+      return NextResponse.json({ error: 'Word is required' }, { status: 400 });
+    }
+    if (!Array.isArray(body.senses) || body.senses.length === 0) {
+      return NextResponse.json({ error: 'At least one sense is required' }, { status: 400 });
+    }
+
+    const word = cacheAcceptedEntry({
+      word: body.word,
+      senses: body.senses,
+      ipa: body.ipa,
+      etymology: body.etymology,
+      relatedForms: body.relatedForms,
+      sourceSentence: body.sourceSentence,
+      language: body.language,
+    });
+
+    if (!word) {
+      return NextResponse.json({ error: 'Nothing to cache' }, { status: 400 });
+    }
+    return NextResponse.json({ word });
+  } catch (err) {
+    console.error('Dictionary cache write error:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Cache write failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -17,7 +17,11 @@ import {
   incrementDailyStat,
 } from '@/lib/data-layer';
 import { translateWord, translatePhrase } from '@/lib/claude';
-import { lookupWordRemote, type ExpandedDictionaryEntry } from '@/lib/dictionary-client';
+import {
+  lookupWordRemote,
+  cacheAcceptedTranslation,
+  type ExpandedDictionaryEntry,
+} from '@/lib/dictionary-client';
 import { speak } from '@/lib/tts';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -34,6 +38,17 @@ interface WordPanelState {
       the canonical "pull/move/draw/journey/draught" entry). */
   aiContextTranslation: string | null;
   aiContextPartOfSpeech: string | null;
+  /** Structured AI translation (from /api/translate). Populated whenever the AI
+      returns multi-sense output, regardless of which translation is shown. Used
+      to persist the entry into the on-device cache when the user accepts
+      (Save / Known / level). Distinct from `dictEntry` so we can tell a kaikki
+      dict hit from an AI cacheable result. */
+  aiStructured: {
+    senses: Array<{ partOfSpeech: string; gloss: string }>;
+    ipa?: string;
+    etymology?: string;
+    relatedForms?: Array<{ form: string; relation: string }>;
+  } | null;
   phraseDetails: {
     literalBreakdown?: string;
     idiomaticMeaning?: string;
@@ -72,6 +87,7 @@ export default function ReadPage({
     dictEntry: null,
     aiContextTranslation: null,
     aiContextPartOfSpeech: null,
+    aiStructured: null,
     phraseDetails: null,
     isLoading: false,
     isContextLoading: false,
@@ -128,6 +144,7 @@ export default function ReadPage({
       dictEntry: null,
       aiContextTranslation: null,
       aiContextPartOfSpeech: null,
+      aiStructured: null,
       phraseDetails: null,
       isLoading: true,
       isContextLoading: false,
@@ -151,8 +168,8 @@ export default function ReadPage({
       existingEntry: existingEntry || null,
     }));
 
-    if (!hasTranslation) {
-      if (isPhrase) {
+    if (isPhrase) {
+      if (!hasTranslation) {
         try {
           const result = await translatePhrase(word, sentence);
           if (requestId !== translationRequestId.current) return;
@@ -177,49 +194,67 @@ export default function ReadPage({
             error: 'Failed to translate phrase. Check AI provider in settings.',
           }));
         }
-      } else {
-        // Try the on-device SQLite dictionary first (~90% hit rate)
-        let dictEntry: ExpandedDictionaryEntry | null = null;
-        try {
-          dictEntry = await lookupWordRemote(word);
-        } catch {
-          dictEntry = null;
-        }
-        if (requestId !== translationRequestId.current) return;
+      }
+    } else {
+      // For single words we ALWAYS run the dict lookup, even if vocab already
+      // has a personal translation cached. Reasons:
+      //   - the user expects to see senses/IPA/etymology, not just their
+      //     saved gloss string
+      //   - the cache (issue #100) only takes effect if we re-fetch — a
+      //     previously-accepted AI translation must surface as `learned` now
+      let dictEntry: ExpandedDictionaryEntry | null = null;
+      try {
+        dictEntry = await lookupWordRemote(word);
+      } catch {
+        dictEntry = null;
+      }
+      if (requestId !== translationRequestId.current) return;
 
-        if (dictEntry && dictEntry.senses.length > 0) {
-          // Stitch a single-string translation for vocab saves + keyboard hotkeys
-          const translation = dictEntry.senses.map((s) => s.gloss).join('; ');
+      if (dictEntry && dictEntry.senses.length > 0) {
+        const translation = dictEntry.senses.map((s) => s.gloss).join('; ');
+        setWordPanel((prev) => ({
+          ...prev,
+          translation,
+          partOfSpeech: dictEntry!.senses[0]?.partOfSpeech || null,
+          dictEntry,
+          isLoading: false,
+          isDictionaryResult: true,
+        }));
+      } else if (!hasTranslation) {
+        // No dict hit AND no saved vocab translation — fall back to AI.
+        try {
+          const result = await translateWord(word, sentence);
+          if (requestId !== translationRequestId.current) return;
+          const structured = result.senses && result.senses.length > 0
+            ? {
+                senses: result.senses,
+                ipa: result.ipa,
+                etymology: result.etymology,
+                relatedForms: result.relatedForms,
+              }
+            : null;
           setWordPanel((prev) => ({
             ...prev,
-            translation,
-            partOfSpeech: dictEntry!.senses[0]?.partOfSpeech || null,
-            dictEntry,
+            translation: result.translation,
+            partOfSpeech: result.partOfSpeech || null,
+            dictEntry: null,
+            aiStructured: structured,
             isLoading: false,
-            isDictionaryResult: true,
+            isDictionaryResult: false,
           }));
-        } else {
-          try {
-            const result = await translateWord(word, sentence);
-            if (requestId !== translationRequestId.current) return;
-            setWordPanel((prev) => ({
-              ...prev,
-              translation: result.translation,
-              partOfSpeech: result.partOfSpeech || null,
-              dictEntry: null,
-              isLoading: false,
-              isDictionaryResult: false,
-            }));
-          } catch (err) {
-            if (requestId !== translationRequestId.current) return;
-            console.error('Translation error:', err);
-            setWordPanel((prev) => ({
-              ...prev,
-              isLoading: false,
-              error: 'Failed to translate word. Check AI provider in settings.',
-            }));
-          }
+        } catch (err) {
+          if (requestId !== translationRequestId.current) return;
+          console.error('Translation error:', err);
+          setWordPanel((prev) => ({
+            ...prev,
+            isLoading: false,
+            error: 'Failed to translate word. Check AI provider in settings.',
+          }));
         }
+      } else {
+        // No dict hit but vocab has a saved translation — show that, mark
+        // not-loading. No source pill (it's the user's own translation).
+        setWordPanel((prev) => ({ ...prev, isLoading: false }));
       }
     }
   }, []);
@@ -232,6 +267,14 @@ export default function ReadPage({
     setWordPanel((prev) => ({ ...prev, isContextLoading: true }));
     try {
       const result = await translateWord(wordPanel.word, wordPanel.sentence);
+      const structured = result.senses && result.senses.length > 0
+        ? {
+            senses: result.senses,
+            ipa: result.ipa,
+            etymology: result.etymology,
+            relatedForms: result.relatedForms,
+          }
+        : null;
       setWordPanel((prev) => {
         // When the dict already has the word: stash the AI gloss in the
         // override slot so the drawer renders it, but leave `translation`
@@ -250,6 +293,7 @@ export default function ReadPage({
           ...prev,
           translation: result.translation,
           partOfSpeech: result.partOfSpeech || prev.partOfSpeech,
+          aiStructured: structured ?? prev.aiStructured,
           isContextLoading: false,
           isDictionaryResult: false,
         };
@@ -275,6 +319,24 @@ export default function ReadPage({
     return undefined;
   }, [wordPanel.existingEntry]);
 
+  // Persist the current AI translation into the on-device dictionary cache.
+  // Called from accept actions (Save / Known / level). No-op for phrases,
+  // dictionary hits (already canonical), and when the AI didn't return
+  // structured senses. Fire-and-forget — never blocks the UI action.
+  const persistAcceptedTranslation = useCallback(() => {
+    if (wordPanel.word.includes(' ')) return;
+    if (wordPanel.dictEntry) return;
+    if (!wordPanel.aiStructured) return;
+    void cacheAcceptedTranslation({
+      word: wordPanel.word,
+      senses: wordPanel.aiStructured.senses,
+      ipa: wordPanel.aiStructured.ipa,
+      etymology: wordPanel.aiStructured.etymology,
+      relatedForms: wordPanel.aiStructured.relatedForms,
+      sourceSentence: wordPanel.sentence,
+    });
+  }, [wordPanel.word, wordPanel.sentence, wordPanel.dictEntry, wordPanel.aiStructured]);
+
   const saveWordToVocab = useCallback(async () => {
     if (!wordPanel.translation) return;
 
@@ -297,13 +359,14 @@ export default function ReadPage({
 
     await saveVocab(entry);
     await incrementDailyStat('newWordsSaved');
+    persistAcceptedTranslation();
 
     setWordPanel((prev) => ({
       ...prev,
       existingEntry: entry,
     }));
     setReaderRefreshTrigger(prev => prev + 1);
-  }, [wordPanel, lessonId, resolveExistingEntry]);
+  }, [wordPanel, lessonId, resolveExistingEntry, persistAcceptedTranslation]);
 
   const markAsKnown = useCallback(async () => {
     const existing = await resolveExistingEntry();
@@ -328,9 +391,10 @@ export default function ReadPage({
     }
 
     await incrementDailyStat('wordsMarkedKnown');
+    persistAcceptedTranslation();
     setReaderRefreshTrigger(prev => prev + 1);
     closeWordPanel();
-  }, [wordPanel, lessonId, closeWordPanel, resolveExistingEntry]);
+  }, [wordPanel, lessonId, closeWordPanel, resolveExistingEntry, persistAcceptedTranslation]);
 
   const ignoreWord = useCallback(async () => {
     const existing = await resolveExistingEntry();
@@ -389,8 +453,9 @@ export default function ReadPage({
       }));
     }
 
+    persistAcceptedTranslation();
     setReaderRefreshTrigger(prev => prev + 1);
-  }, [wordPanel, lessonId, resolveExistingEntry]);
+  }, [wordPanel, lessonId, resolveExistingEntry, persistAcceptedTranslation]);
 
   const handleClose = useCallback(() => {
     if (lesson?.collectionId) {
@@ -422,11 +487,20 @@ export default function ReadPage({
         }));
       } else {
         const result = await translateWord(wordPanel.word, wordPanel.sentence);
+        const structured = result.senses && result.senses.length > 0
+          ? {
+              senses: result.senses,
+              ipa: result.ipa,
+              etymology: result.etymology,
+              relatedForms: result.relatedForms,
+            }
+          : null;
         setWordPanel((prev) => ({
           ...prev,
           translation: result.translation,
           partOfSpeech: result.partOfSpeech || null,
           dictEntry: null,
+          aiStructured: structured,
           phraseDetails: null,
           isLoading: false,
           isDictionaryResult: false,

--- a/src/components/TranslationDrawer.tsx
+++ b/src/components/TranslationDrawer.tsx
@@ -17,6 +17,8 @@ export interface ExpandedDictionaryEntry {
   senses: Array<{ partOfSpeech: string; gloss: string }>;
   relatedForms?: Array<{ form: string; relation: string }>;
   lemmaInfo?: { stem: string; label: string };
+  /** `dict` = built-in kaikki dict, `cache` = user-learned AI translation. */
+  source?: 'dict' | 'cache';
 }
 
 const wordStateColors: Record<WordState, { bg: string; text: string; dot: string; ring: string }> = {
@@ -205,6 +207,11 @@ export default function TranslationDrawer({
                 <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300">
                   <span className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
                   AI · in context
+                </span>
+              ) : entry?.source === 'cache' ? (
+                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
+                  <span className="w-1.5 h-1.5 rounded-full bg-violet-500" />
+                  learned
                 </span>
               ) : isDictionaryResult ? (
                 <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -2,8 +2,16 @@ import { getActiveLanguage } from './data-layer';
 
 // Types
 export interface WordTranslation {
+  /** Legacy: stitched single-string translation (sense glosses joined "; "). */
   translation: string;
+  /** Legacy: first sense's POS. */
   partOfSpeech?: string;
+  /** Structured fields used by the drawer + the on-device cache. */
+  word?: string;
+  senses?: Array<{ partOfSpeech: string; gloss: string }>;
+  ipa?: string;
+  etymology?: string;
+  relatedForms?: Array<{ form: string; relation: string }>;
 }
 
 export interface PhraseTranslation {

--- a/src/lib/dictionary-client.ts
+++ b/src/lib/dictionary-client.ts
@@ -14,6 +14,8 @@ export interface ExpandedDictionaryEntry {
   senses: Array<{ partOfSpeech: string; gloss: string }>;
   relatedForms?: Array<{ form: string; relation: string }>;
   lemmaInfo?: { stem: string; label: string };
+  /** `dict` = built-in kaikki dict, `cache` = user-learned AI translation. */
+  source?: 'dict' | 'cache';
 }
 
 /**
@@ -45,6 +47,43 @@ export async function lookupWordRemote(word: string): Promise<ExpandedDictionary
 export function invalidateLookupCache(word?: string): void {
   if (word === undefined) sessionCache.clear();
   else sessionCache.delete(word.toLowerCase());
+}
+
+export interface CacheAcceptedTranslationInput {
+  word: string;
+  senses: Array<{ partOfSpeech: string; gloss: string }>;
+  ipa?: string;
+  etymology?: string;
+  relatedForms?: Array<{ form: string; relation: string }>;
+  sourceSentence?: string;
+  language?: string;
+}
+
+/**
+ * Persist an accepted AI translation into the on-device cache (lector.db).
+ * Called from the read page when the user saves to vocab / marks known /
+ * sets a learning level — actions that signal trust in the translation.
+ *
+ * Fire-and-forget: we don't block the UI on the write. Errors are logged.
+ * The session lookup cache is invalidated for the word so the next click
+ * re-fetches and picks up the freshly-cached entry (now with `source: 'cache'`).
+ */
+export async function cacheAcceptedTranslation(input: CacheAcceptedTranslationInput): Promise<void> {
+  if (!input.word || !input.senses?.length) return;
+  invalidateLookupCache(input.word);
+  try {
+    const res = await fetch('/api/dictionary/cache', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      console.warn('cacheAcceptedTranslation failed:', err);
+    }
+  } catch (err) {
+    console.warn('cacheAcceptedTranslation network error:', err);
+  }
 }
 
 /**

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -161,6 +161,41 @@ function getDb(): DatabaseType {
       createdAt TEXT NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_chat_messages_createdAt ON chat_messages(createdAt);
+
+    -- AI-translation cache. Persists structured AI translations after the user
+    -- accepts them (Save to vocab / Mark Known / set level). Read-side falls
+    -- through here when the read-only kaikki dict misses, so coverage of the
+    -- user's reading corpus approaches 100% over time. Lives in lector.db (the
+    -- mutable DB) rather than the read-only dictionary-af.db.
+    CREATE TABLE IF NOT EXISTS cached_entries (
+      word TEXT PRIMARY KEY,
+      language TEXT NOT NULL DEFAULT 'af',
+      ipa TEXT,
+      etymology TEXT,
+      sourceSentence TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_cached_entries_language ON cached_entries(language);
+
+    CREATE TABLE IF NOT EXISTS cached_senses (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      word TEXT NOT NULL,
+      pos TEXT,
+      gloss TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (word) REFERENCES cached_entries(word) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_cached_senses_word ON cached_senses(word);
+
+    CREATE TABLE IF NOT EXISTS cached_related_forms (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      word TEXT NOT NULL,
+      related_word TEXT NOT NULL,
+      relation TEXT NOT NULL,
+      FOREIGN KEY (word) REFERENCES cached_entries(word) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_cached_related_word ON cached_related_forms(word);
   `);
 
   // Migrations for existing databases

--- a/src/lib/server/dictionary-db.ts
+++ b/src/lib/server/dictionary-db.ts
@@ -1,6 +1,7 @@
 import Database, { Database as DatabaseType } from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
+import { db as userDb } from './database';
 
 /**
  * Read-only SQLite-backed Afrikaans dictionary.
@@ -33,6 +34,10 @@ export interface ExpandedDictionaryEntry {
   senses: Array<{ partOfSpeech: string; gloss: string }>;
   relatedForms?: Array<{ form: string; relation: string }>;
   lemmaInfo?: { stem: string; label: string };
+  /** Where the entry came from. `dict` = built-in kaikki dict; `cache` = user-
+      learned AI translation persisted via cacheAcceptedEntry. The drawer uses
+      this to render the right source pill. */
+  source?: 'dict' | 'cache';
 }
 
 // ---------------------------------------------------------------------------
@@ -169,6 +174,7 @@ function buildEntry(
   const entry: ExpandedDictionaryEntry = {
     word: lookupWord,
     senses,
+    source: 'dict',
   };
   if (row.rank != null) entry.rank = row.rank;
   if (row.ipa) entry.ipa = row.ipa;
@@ -179,58 +185,170 @@ function buildEntry(
 }
 
 // ---------------------------------------------------------------------------
+// AI cache (lector.db) — entries the user "accepted" by saving / marking
+// known / setting a level. Read AFTER the curated dict misses on every
+// lookup path so coverage of the user's reading corpus grows over time.
+// ---------------------------------------------------------------------------
+
+interface CachedEntryRow {
+  word: string;
+  ipa: string | null;
+  etymology: string | null;
+}
+
+function lookupCached(word: string): ExpandedDictionaryEntry | undefined {
+  const row = userDb
+    .prepare('SELECT word, ipa, etymology FROM cached_entries WHERE word = ?')
+    .get(word) as CachedEntryRow | undefined;
+  if (!row) return undefined;
+
+  const senses = userDb
+    .prepare('SELECT pos, gloss FROM cached_senses WHERE word = ? ORDER BY sort_order')
+    .all(row.word) as Array<{ pos: string | null; gloss: string }>;
+  if (senses.length === 0) return undefined;
+
+  const related = userDb
+    .prepare('SELECT related_word, relation FROM cached_related_forms WHERE word = ?')
+    .all(row.word) as Array<{ related_word: string; relation: string }>;
+
+  const entry: ExpandedDictionaryEntry = {
+    word: row.word,
+    senses: senses.map((s) => ({ partOfSpeech: s.pos || '', gloss: s.gloss })),
+    source: 'cache',
+  };
+  if (row.ipa) entry.ipa = row.ipa;
+  if (row.etymology) entry.etymology = row.etymology;
+  if (related.length) {
+    entry.relatedForms = related.map((r) => ({ form: r.related_word, relation: r.relation }));
+  }
+  return entry;
+}
+
+export interface CacheAcceptedInput {
+  word: string;
+  senses: Array<{ partOfSpeech: string; gloss: string }>;
+  ipa?: string;
+  etymology?: string;
+  relatedForms?: Array<{ form: string; relation: string }>;
+  sourceSentence?: string;
+  language?: string;
+}
+
+/** Persist an accepted AI translation into the on-device cache. Idempotent on word
+ *  (upsert replaces senses + related forms). Returns the cached row's word so the
+ *  caller can confirm. */
+export function cacheAcceptedEntry(input: CacheAcceptedInput): string | null {
+  if (!input.word || !input.senses || input.senses.length === 0) return null;
+  const word = input.word.toLowerCase();
+  const now = new Date().toISOString();
+  const language = input.language || 'af';
+
+  const upsertEntry = userDb.prepare(`
+    INSERT INTO cached_entries (word, language, ipa, etymology, sourceSentence, createdAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(word) DO UPDATE SET
+      language = excluded.language,
+      ipa = excluded.ipa,
+      etymology = excluded.etymology,
+      sourceSentence = excluded.sourceSentence,
+      updatedAt = excluded.updatedAt
+  `);
+  const deleteSenses = userDb.prepare('DELETE FROM cached_senses WHERE word = ?');
+  const insertSense = userDb.prepare(
+    'INSERT INTO cached_senses (word, pos, gloss, sort_order) VALUES (?, ?, ?, ?)',
+  );
+  const deleteRelated = userDb.prepare('DELETE FROM cached_related_forms WHERE word = ?');
+  const insertRelated = userDb.prepare(
+    'INSERT INTO cached_related_forms (word, related_word, relation) VALUES (?, ?, ?)',
+  );
+
+  const txn = userDb.transaction(() => {
+    upsertEntry.run(
+      word,
+      language,
+      input.ipa ?? null,
+      input.etymology ?? null,
+      input.sourceSentence ?? null,
+      now,
+      now,
+    );
+    deleteSenses.run(word);
+    input.senses.forEach((s, i) => {
+      if (!s.gloss) return;
+      insertSense.run(word, s.partOfSpeech || null, s.gloss, i);
+    });
+    deleteRelated.run(word);
+    (input.relatedForms || []).forEach((r) => {
+      if (!r.form || !r.relation) return;
+      insertRelated.run(word, r.form, r.relation);
+    });
+  });
+  txn();
+  return word;
+}
+
+// ---------------------------------------------------------------------------
 // lookupWord — exact → inflections → prefix → suffix → affix-strip fallback
 // ---------------------------------------------------------------------------
 
 export function lookupWord(word: string): ExpandedDictionaryEntry | undefined {
-  const stmts = getStmts();
-  if (!stmts) return undefined;
   const lower = word.toLowerCase();
+  const stmts = getStmts();
 
-  // 1. Exact match
-  const exact = stmts.selectEntry.get(lower) as EntryRow | undefined;
-  if (exact) return buildEntry(exact, stmts, lower);
+  // Curated kaikki dict — only available if data/dictionary-af.db is present.
+  if (stmts) {
+    // 1. Exact match
+    const exact = stmts.selectEntry.get(lower) as EntryRow | undefined;
+    if (exact) return buildEntry(exact, stmts, lower);
 
-  // 2. Inflection table (e.g. "katte" → "kat", "geword" → "word")
-  const infl = stmts.selectInflectionLemma.get(lower) as { lemma: string; type: string | null } | undefined;
-  if (infl) {
-    const lemmaRow = stmts.selectEntry.get(infl.lemma) as EntryRow | undefined;
-    if (lemmaRow) {
-      const label = infl.type ? `${infl.type.replace(/,/g, ' ')} form of` : 'inflected form of';
-      return buildEntry(lemmaRow, stmts, lower, { stem: lemmaRow.word, label });
-    }
-  }
-
-  // 3. Known prefix → exact stem
-  for (const prefix of PREFIXES) {
-    if (!lower.startsWith(prefix)) continue;
-    const stem = lower.slice(prefix.length);
-    if (stem.length < MIN_STEM) continue;
-    const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
-    if (stemRow) {
-      return buildEntry(stemRow, stmts, lower, { stem, label: PREFIX_LABELS[prefix] });
-    }
-  }
-
-  // 4. Known suffix → exact stem (with consonant undoubling)
-  for (const suffix of SUFFIXES) {
-    if (!lower.endsWith(suffix)) continue;
-    const stem = lower.slice(0, -suffix.length);
-    if (stem.length < MIN_STEM) continue;
-
-    const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
-    if (stemRow) {
-      return buildEntry(stemRow, stmts, lower, { stem, label: SUFFIX_LABELS[suffix] });
+    // 2. Inflection table (e.g. "katte" → "kat", "geword" → "word")
+    const infl = stmts.selectInflectionLemma.get(lower) as { lemma: string; type: string | null } | undefined;
+    if (infl) {
+      const lemmaRow = stmts.selectEntry.get(infl.lemma) as EntryRow | undefined;
+      if (lemmaRow) {
+        const label = infl.type ? `${infl.type.replace(/,/g, ' ')} form of` : 'inflected form of';
+        return buildEntry(lemmaRow, stmts, lower, { stem: lemmaRow.word, label });
+      }
     }
 
-    const undoubled = undoubleConsonant(stem);
-    if (undoubled && undoubled.length >= MIN_STEM) {
-      const uRow = stmts.selectEntry.get(undoubled) as EntryRow | undefined;
-      if (uRow) {
-        return buildEntry(uRow, stmts, lower, { stem: undoubled, label: SUFFIX_LABELS[suffix] });
+    // 3. Known prefix → exact stem
+    for (const prefix of PREFIXES) {
+      if (!lower.startsWith(prefix)) continue;
+      const stem = lower.slice(prefix.length);
+      if (stem.length < MIN_STEM) continue;
+      const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
+      if (stemRow) {
+        return buildEntry(stemRow, stmts, lower, { stem, label: PREFIX_LABELS[prefix] });
+      }
+    }
+
+    // 4. Known suffix → exact stem (with consonant undoubling)
+    for (const suffix of SUFFIXES) {
+      if (!lower.endsWith(suffix)) continue;
+      const stem = lower.slice(0, -suffix.length);
+      if (stem.length < MIN_STEM) continue;
+
+      const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
+      if (stemRow) {
+        return buildEntry(stemRow, stmts, lower, { stem, label: SUFFIX_LABELS[suffix] });
+      }
+
+      const undoubled = undoubleConsonant(stem);
+      if (undoubled && undoubled.length >= MIN_STEM) {
+        const uRow = stmts.selectEntry.get(undoubled) as EntryRow | undefined;
+        if (uRow) {
+          return buildEntry(uRow, stmts, lower, { stem: undoubled, label: SUFFIX_LABELS[suffix] });
+        }
       }
     }
   }
+
+  // 5. AI cache fallthrough — user-accepted translations persisted in lector.db.
+  //    Lives behind the curated dict so the kaikki entry always wins, but in
+  //    front of the AI translate fallback so previously-seen words don't pay
+  //    for the LLM round-trip again.
+  const cached = lookupCached(lower);
+  if (cached) return cached;
 
   return undefined;
 }


### PR DESCRIPTION
Closes #100.

## Summary

- **Accepted AI translations now persist** into a new `cached_entries` table in `lector.db`. When the user saves a word to vocab / marks it Known / sets a level 1-4, the structured AI translation is written to the cache.
- **Lookups fall through to the cache** after the kaikki dict misses all four pipelines (exact / inflections / prefix / suffix). The drawer renders cached entries identically to dict entries.
- **New `learned` source pill** (violet) so users can tell when they're seeing the dict their own usage built up.
- **AI translate prompt rewritten** to ask for dictionary-quality structured output (`senses[]`, `ipa`, `etymology`, `relatedForms`) instead of a single English string. Server stitches legacy `{ translation, partOfSpeech }` from the first sense so existing call sites keep working.
- **Export script** (`scripts/export-cached-entries.ts`) dumps the cache to a JSON patch shaped like `dictionary-roots.json` for promoting user-validated gaps into the next published dict release.

## How the loop closes

1. User reads "Sy maak die **gordyn** oop."
2. Click → kaikki dict misses → AI translates, returns structured `{ senses: [{ pos: 'noun', gloss: 'curtain' }], etymology: 'From Dutch gordijn', … }`
3. User clicks **Known** → fire-and-forget POST to `/api/dictionary/cache` writes to `cached_entries` + `cached_senses` in lector.db
4. Later, same page or different lesson, the user clicks "gordyn" again → `lookupWord()` runs the same affix-strip pipeline, misses the curated dict, falls through to the cache, returns the entry with `source: 'cache'`
5. Drawer shows the violet **learned** pill, no AI round-trip

## Lookup priority

```
exact match in curated dict
  → inflections table
  → prefix-stem
  → suffix-stem (with consonant undoubling)
  → cached_entries (NEW)
  → undefined → caller falls back to AI translate
```

Cache sits below the curated dict so kaikki always wins, but above the AI fallback so a previously-seen word is instant on the next click.

## Acceptance signals

The cache write fires from these handlers:

| Action | Caches? |
|---|---|
| Save to vocab | ✅ |
| Mark Known | ✅ |
| Set level 1-4 | ✅ |
| Ignore | ❌ (signal is "not interested", not "translation good") |
| Re-translate with AI | ❌ (until accepted) |
| In context AI | ❌ (until accepted) |

The cache write is also skipped if:
- the word is a phrase (multi-token; phrases stay in vocab only)
- the on-device dict already has the entry (the dict is more authoritative than any single AI call)
- the AI didn't return structured `senses[]`

## Source attribution (drawer header pill)

| Pill | Color | Meaning |
|---|---|---|
| `● AI · in context` | indigo | Active "In context" override |
| `● learned` | violet | **NEW** — entry came from cached_entries |
| `● on-device` | emerald | kaikki curated dict |
| `● AI` | amber | AI translate fallback (not yet cached) |

## Lookup-priority change for single words

Previously the read page skipped the dict lookup entirely if the vocab table already had a translation for the word. That hid the new "learned" pill — re-clicking an accepted word just showed the user's stitched gloss string, no source attribution. Now single-word clicks always run `lookupWordRemote()` so the cache (and the curated dict) get the chance to surface their richer data. Phrases keep the old behavior.

## Tests

- `e2e/translation-cache.spec.ts` (new): full integration. Import a book with a nonsense token guaranteed to miss the dict → mock `/api/translate` with a structured response → click → drawer shows `AI` pill, mock fires once → click Known → poll `/api/dictionary/lookup` until `entry.source === 'cache'` → click again → drawer shows `learned` pill, mock has STILL fired exactly once.
- All other touched suites green: drawer / cloze-definitions / reader-word-handling / reader-phrase-selection / practice. **42/42** locally.
- Unit tests: 24/24.

## Export workflow

```bash
# After a session of reading + accepting AI translations
npx tsx scripts/export-cached-entries.ts > tmp/cached-patch.json
# Review tmp/cached-patch.json, merge interesting entries into
# src/lib/dictionary-roots.json, then:
./scripts/release-dict.sh
# Update Dockerfile DICT_VERSION + DICT_SHA256 to the new release.
```

Each install builds its own cache — sharing is out of scope (#100).

## Out of scope (deferred)

- Sharing the cache between users
- Editing cached entries via UI (correction flow is a separate ticket)
- Surfacing cache size / health in stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)
