### PR TITLE
fix(anki): honor the ankiConnectUrl setting at request time

### DIFF
--- a/e2e/vocab-anki-export.spec.ts
+++ b/e2e/vocab-anki-export.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect, Page, Route } from '@playwright/test';
+
+/**
+ * E2E for the /vocab page → Anki bulk-export flow.
+ *
+ * Covers:
+ *   - The Export-to-Anki modal opens with a selected-count summary
+ *   - Basic and Cloze tile-style options render and toggle
+ *   - Confirming with Basic calls AnkiConnect with the Basic model + Basic deck
+ *   - Confirming with Cloze calls AnkiConnect with the Cloze model + Cloze deck
+ *   - The user's card-type choice persists across page reloads (localStorage)
+ *   - Already-synced entries are skipped (notification + no extra AnkiConnect call)
+ *
+ * AnkiConnect is mocked (Anki isn't running in CI). The mock inspects the
+ * action name in the request body and returns a deterministic noteId.
+ */
+
+interface AnkiCall {
+  action: string;
+  params?: { note?: { deckName?: string; modelName?: string } };
+}
+
+async function seedVocabEntry(page: Page, text: string, sentence: string, translation: string) {
+  // Use a deterministic id so we can target the row and clean up reliably.
+  const id = `e2e-vocab-${text}-${Date.now().toString(36)}`;
+  const res = await page.request.post('http://localhost:3456/api/vocab', {
+    data: {
+      id,
+      text,
+      type: 'word',
+      sentence,
+      translation,
+      state: 'level1',
+      stateUpdatedAt: new Date().toISOString(),
+      reviewCount: 0,
+      createdAt: new Date().toISOString(),
+      pushedToAnki: false,
+      language: 'af',
+    },
+  });
+  expect(res.ok()).toBeTruthy();
+  return id;
+}
+
+async function deleteVocabEntry(page: Page, id: string) {
+  await page.request.delete(`http://localhost:3456/api/vocab/${id}`);
+}
+
+/**
+ * Install an AnkiConnect mock. Returns the calls array so the test can assert
+ * on what was sent. Each entry mirrors the JSON body the browser POSTed.
+ */
+async function mockAnkiConnect(page: Page): Promise<AnkiCall[]> {
+  const calls: AnkiCall[] = [];
+  // Browser fetches AnkiConnect at http://localhost:8765 (the default URL when
+  // no ankiConnectUrl setting is configured). Match by host:port.
+  await page.route('**://localhost:8765/**', async (route: Route) => {
+    return handleAnkiRoute(route);
+  });
+  await page.route('http://localhost:8765/', async (route: Route) => {
+    return handleAnkiRoute(route);
+  });
+
+  async function handleAnkiRoute(route: Route) {
+    const body = JSON.parse(route.request().postData() || '{}') as AnkiCall;
+    calls.push(body);
+    const action = body.action;
+    const headers = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': '*',
+      'Content-Type': 'application/json',
+    };
+    if (route.request().method() === 'OPTIONS') {
+      await route.fulfill({ status: 200, headers });
+      return;
+    }
+    if (action === 'version') {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 6, error: null }) });
+    } else if (action === 'deckNames') {
+      await route.fulfill({
+        status: 200,
+        headers,
+        body: JSON.stringify({ result: ['Afrikaans', 'Afrikaans::Cloze', 'Default'], error: null }),
+      });
+    } else if (action === 'createDeck') {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 1, error: null }) });
+    } else if (action === 'addNote') {
+      // Return a real-looking timestamp-ish noteId.
+      await route.fulfill({
+        status: 200,
+        headers,
+        body: JSON.stringify({ result: Date.now(), error: null }),
+      });
+    } else {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: null, error: null }) });
+    }
+  }
+
+  return calls;
+}
+
+test.describe('Vocab → Anki bulk export', () => {
+  let vocabId: string;
+  let ankiCalls: AnkiCall[];
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    ankiCalls = await mockAnkiConnect(page);
+
+    // Reset the user's persisted card-type choice so tests start from a known
+    // state. NOTE: do not use addInitScript here — that would also fire on
+    // page.reload() and defeat the persistence-across-reloads test below. We
+    // clear once per test after the first navigation via page.evaluate.
+
+    // Clear any stale ankiConnectUrl setting so the mock at localhost:8765
+    // catches the requests. (Live dev may have configured a non-default port.)
+    await page.request.delete('http://localhost:3456/api/settings/ankiConnectUrl').catch(() => {});
+
+    vocabId = await seedVocabEntry(
+      page,
+      `e2etestword${Date.now().toString(36)}`,
+      'Dit is \'n e2e toets sin.',
+      'This is an e2e test sentence.'
+    );
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (vocabId) await deleteVocabEntry(page, vocabId);
+  });
+
+  test('opens the export modal and renders both card-type options', async ({ page }) => {
+    await page.goto('/vocab');
+
+    // Select our seeded entry via its checkbox.
+    const row = page.getByRole('row').filter({ hasText: /e2etestword/ });
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+
+    const modal = page.getByRole('dialog', { name: /Export to Anki/i });
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(/1 word selected/i);
+    await expect(modal.getByTestId('anki-card-type-basic')).toBeVisible();
+    await expect(modal.getByTestId('anki-card-type-cloze')).toBeVisible();
+    await expect(modal.getByTestId('anki-export-confirm')).toBeVisible();
+  });
+
+  test('Basic export sends an addNote with the Basic model to the Basic deck', async ({ page }) => {
+    await page.goto('/vocab');
+    const row = page.getByRole('row').filter({ hasText: /e2etestword/ });
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+
+    const modal = page.getByRole('dialog', { name: /Export to Anki/i });
+    await modal.getByTestId('anki-card-type-basic').click();
+    await modal.getByTestId('anki-export-confirm').click();
+
+    await expect(page.getByText(/Exported 1 basic card to "Afrikaans"/)).toBeVisible({ timeout: 5000 });
+
+    const addNote = ankiCalls.find((c) => c.action === 'addNote');
+    expect(addNote).toBeDefined();
+    expect(addNote!.params?.note?.modelName).toBe('Basic');
+    expect(addNote!.params?.note?.deckName).toBe('Afrikaans');
+  });
+
+  test('Cloze export sends an addNote with the Cloze model to the Cloze deck', async ({ page }) => {
+    await page.goto('/vocab');
+    const row = page.getByRole('row').filter({ hasText: /e2etestword/ });
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+
+    const modal = page.getByRole('dialog', { name: /Export to Anki/i });
+    await modal.getByTestId('anki-card-type-cloze').click();
+    await modal.getByTestId('anki-export-confirm').click();
+
+    await expect(page.getByText(/Exported 1 cloze card to "Afrikaans::Cloze"/)).toBeVisible({ timeout: 5000 });
+
+    const addNote = ankiCalls.find((c) => c.action === 'addNote');
+    expect(addNote).toBeDefined();
+    expect(addNote!.params?.note?.modelName).toBe('Cloze');
+    expect(addNote!.params?.note?.deckName).toBe('Afrikaans::Cloze');
+  });
+
+  test('card type choice persists to localStorage across reloads', async ({ page }) => {
+    // First visit — pick Cloze inside the modal.
+    await page.goto('/vocab');
+    const row = page.getByRole('row').filter({ hasText: /e2etestword/ });
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+    const modal = page.getByRole('dialog', { name: /Export to Anki/i });
+    await modal.getByTestId('anki-card-type-cloze').click();
+
+    // Verify the persisted value before exporting.
+    const stored = await page.evaluate(() => localStorage.getItem('lector-anki-card-type'));
+    expect(stored).toBe('cloze');
+
+    // Reopen the modal — Cloze should be pre-selected. The tile's
+    // `aria-pressed` attribute reflects the selected state.
+    await modal.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await page.reload();
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+    const modal2 = page.getByRole('dialog', { name: /Export to Anki/i });
+    const clozeTile = modal2.getByTestId('anki-card-type-cloze');
+    await expect(clozeTile).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('already-synced entries are skipped on re-export', async ({ page }) => {
+    await page.goto('/vocab');
+    const row = page.getByRole('row').filter({ hasText: /e2etestword/ });
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+
+    // First export succeeds.
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+    let modal = page.getByRole('dialog', { name: /Export to Anki/i });
+    await modal.getByTestId('anki-card-type-basic').click();
+    await modal.getByTestId('anki-export-confirm').click();
+    await expect(page.getByText(/Exported 1 basic card/)).toBeVisible({ timeout: 5000 });
+
+    const addNoteCallsAfterFirst = ankiCalls.filter((c) => c.action === 'addNote').length;
+    expect(addNoteCallsAfterFirst).toBe(1);
+
+    // Refresh so the row reflects pushedToAnki=true. Then try to export again.
+    await page.reload();
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /Export to Anki/ }).click();
+    modal = page.getByRole('dialog', { name: /Export to Anki/i });
+    await modal.getByTestId('anki-export-confirm').click();
+
+    // Expect the "already synced" notification, and NO additional addNote calls.
+    await expect(page.getByText(/already been synced/i)).toBeVisible({ timeout: 5000 });
+    const addNoteCallsAfterSecond = ankiCalls.filter((c) => c.action === 'addNote').length;
+    expect(addNoteCallsAfterSecond).toBe(1);
+  });
+});

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import NavHeader from "@/components/NavHeader";
-import { getDeckNames, isAnkiConnected } from "@/lib/anki";
+import { getDeckNames, isAnkiConnected, refreshAnkiUrl } from "@/lib/anki";
 import { getTTSMode, setTTSMode, isGoogleTTSConfigured, speak, type TTSMode } from "@/lib/tts";
 import {
   exportAllData,
@@ -1332,6 +1332,9 @@ export default function SettingsPage() {
                 onChange={(e) => {
                   setAnkiConnectUrl(e.target.value);
                   setSetting('ankiConnectUrl', e.target.value);
+                  // Invalidate the anki.ts URL cache so the next request
+                  // (e.g. the connection check below) uses the new value.
+                  refreshAnkiUrl();
                 }}
                 placeholder="http://localhost:8765"
                 className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"

--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/data-layer";
 import {
   addBasicCard,
+  addClozeCard,
   syncWordStates,
   isAnkiConnected,
   getDeckNames,
@@ -308,6 +309,7 @@ export default function VocabPage() {
   const [selectedEntry, setSelectedEntry] = useState<VocabEntry | null>(null);
   const [ankiConnected, setAnkiConnected] = useState<boolean | null>(null);
   const [ankiDeck, setAnkiDeck] = useState("Afrikaans");
+  const [ankiClozeDeck, setAnkiClozeDeck] = useState("Afrikaans::Cloze");
   const [notification, setNotification] = useState<{
     type: "success" | "error";
     message: string;
@@ -317,10 +319,14 @@ export default function VocabPage() {
   useEffect(() => {
     loadData();
     checkAnkiConnection();
-    // Load deck name from settings
+    // Load deck names from settings — match the keys the settings page writes
     const savedDeck = localStorage.getItem("lector-anki-deck");
     if (savedDeck) {
       setAnkiDeck(savedDeck);
+    }
+    const savedClozeDeck = localStorage.getItem("lector-anki-cloze-deck");
+    if (savedClozeDeck) {
+      setAnkiClozeDeck(savedClozeDeck);
     }
   }, []);
 
@@ -414,9 +420,12 @@ export default function VocabPage() {
     }
   };
 
-  // Export selected entries to Anki
+  // Export selected entries to Anki. cardType controls which Anki model
+  // (and which deck) is used — Basic front/back cards go to the user's
+  // configured Basic deck (ankiDeck); Cloze deletions go to the Cloze deck
+  // (ankiClozeDeck). The choice is made via the toggle in VocabList.
   const handleExportToAnki = useCallback(
-    async (ids: string[]) => {
+    async (ids: string[], cardType: 'basic' | 'cloze') => {
       if (!ankiConnected) {
         showNotification(
           "error",
@@ -436,17 +445,21 @@ export default function VocabPage() {
         return;
       }
 
+      const targetDeck = cardType === 'cloze' ? ankiClozeDeck : ankiDeck;
+      const addCard = cardType === 'cloze' ? addClozeCard : addBasicCard;
+      const cardLabel = cardType === 'cloze' ? 'cloze' : 'basic';
+
       let successCount = 0;
       let errorCount = 0;
 
       for (const entry of entriesToExport) {
         try {
-          const noteId = await addBasicCard(
-            ankiDeck,
+          const noteId = await addCard(
+            targetDeck,
             entry.sentence,
             entry.text,
             entry.translation,
-            entry.translation // word meaning - using translation for now
+            entry.translation // word meaning — using translation for now
           );
           await markVocabPushedToAnki(entry.id, noteId);
           successCount++;
@@ -461,16 +474,16 @@ export default function VocabPage() {
       if (errorCount === 0) {
         showNotification(
           "success",
-          `Successfully exported ${successCount} cards to Anki`
+          `Exported ${successCount} ${cardLabel} card${successCount === 1 ? '' : 's'} to "${targetDeck}"`
         );
       } else {
         showNotification(
           "error",
-          `Exported ${successCount} cards, ${errorCount} failed`
+          `Exported ${successCount} ${cardLabel} cards, ${errorCount} failed`
         );
       }
     },
-    [entries, ankiConnected, ankiDeck]
+    [entries, ankiConnected, ankiDeck, ankiClozeDeck]
   );
 
   // Mark selected entries as known

--- a/src/components/VocabList.tsx
+++ b/src/components/VocabList.tsx
@@ -71,8 +71,9 @@ export default function VocabList({
   const [isMarkingKnown, setIsMarkingKnown] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
 
-  // Which Anki card type the bulk-export builds. Persisted across reloads so
-  // users who always push as Cloze don't have to flip the toggle every time.
+  // Export-to-Anki modal state. Card type pre-selects the user's last choice
+  // (persisted to localStorage) so heavy Cloze users don't flip on every open.
+  const [exportModalOpen, setExportModalOpen] = useState(false);
   const [cardType, setCardType] = useState<AnkiCardType>(() => {
     if (typeof window === 'undefined') return 'basic';
     const saved = localStorage.getItem('lector-anki-card-type');
@@ -212,9 +213,15 @@ export default function VocabList({
     );
   };
 
-  // Bulk action handlers
-  const handleExportToAnki = async () => {
+  // Bulk action handlers. The export button opens a modal that confirms the
+  // card type; the actual onExportToAnki call fires from the modal's Export
+  // action so the user has a moment to switch Basic <-> Cloze.
+  const openExportModal = () => {
     if (selectedIds.size === 0) return;
+    setExportModalOpen(true);
+  };
+  const confirmExportToAnki = async () => {
+    setExportModalOpen(false);
     setIsExporting(true);
     try {
       await onExportToAnki(Array.from(selectedIds), cardType);
@@ -296,37 +303,8 @@ export default function VocabList({
 
       {/* Bulk Actions */}
       <div className="flex flex-wrap items-center gap-3">
-        {/* Anki card-type toggle. Drives the export button below — Basic adds
-            front/back cards to the configured Basic deck, Cloze adds cloze
-            deletions to the Cloze deck. Choice is persisted to localStorage. */}
-        <div className="inline-flex items-center rounded-lg border border-zinc-200 bg-white p-0.5 dark:border-zinc-700 dark:bg-zinc-800">
-          <button
-            onClick={() => updateCardType('basic')}
-            disabled={isExporting}
-            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-              cardType === 'basic'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
-            } disabled:cursor-not-allowed disabled:opacity-50`}
-            title="Export selected words as Basic (front/back) cards"
-          >
-            Basic
-          </button>
-          <button
-            onClick={() => updateCardType('cloze')}
-            disabled={isExporting}
-            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-              cardType === 'cloze'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
-            } disabled:cursor-not-allowed disabled:opacity-50`}
-            title="Export selected words as Cloze deletion cards"
-          >
-            Cloze
-          </button>
-        </div>
         <button
-          onClick={handleExportToAnki}
+          onClick={openExportModal}
           disabled={!someSelected || isExporting}
           className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400 dark:disabled:bg-gray-600"
         >
@@ -544,6 +522,92 @@ export default function VocabList({
           </tbody>
         </table>
       </div>
+
+      {/* Export-to-Anki modal */}
+      {exportModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setExportModalOpen(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Export to Anki"
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-zinc-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              Export to Anki
+            </h2>
+            <p className="mb-5 text-sm text-zinc-500 dark:text-zinc-400">
+              {selectedIds.size} {selectedIds.size === 1 ? 'word' : 'words'} selected. Choose a card type.
+            </p>
+
+            <div className="mb-6 grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={() => updateCardType('basic')}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  cardType === 'basic'
+                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
+                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-zinc-900 dark:text-zinc-100">Basic</span>
+                  {cardType === 'basic' && (
+                    <svg className="h-4 w-4 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Front/back card. Sentence on front, translation on back.
+                </p>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => updateCardType('cloze')}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  cardType === 'cloze'
+                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
+                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-zinc-900 dark:text-zinc-100">Cloze</span>
+                  {cardType === 'cloze' && (
+                    <svg className="h-4 w-4 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Word is hidden in the sentence; recall it from context.
+                </p>
+              </button>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setExportModalOpen(false)}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmExportToAnki}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Export {selectedIds.size} {selectedIds.size === 1 ? 'card' : 'cards'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/VocabList.tsx
+++ b/src/components/VocabList.tsx
@@ -8,11 +8,13 @@ import { type VocabEntry, type WordState, type Collection } from "@/lib/data-lay
 type SortField = "text" | "createdAt" | "state" | "bookId";
 type SortDirection = "asc" | "desc";
 
+export type AnkiCardType = 'basic' | 'cloze';
+
 interface VocabListProps {
   entries: VocabEntry[];
   collections: Collection[];
   onEntryClick: (entry: VocabEntry) => void;
-  onExportToAnki: (ids: string[]) => Promise<void>;
+  onExportToAnki: (ids: string[], cardType: AnkiCardType) => Promise<void>;
   onMarkAsKnown: (ids: string[]) => Promise<void>;
   onSyncWithAnki: () => Promise<void>;
   isLoading?: boolean;
@@ -68,6 +70,20 @@ export default function VocabList({
   const [isExporting, setIsExporting] = useState(false);
   const [isMarkingKnown, setIsMarkingKnown] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
+
+  // Which Anki card type the bulk-export builds. Persisted across reloads so
+  // users who always push as Cloze don't have to flip the toggle every time.
+  const [cardType, setCardType] = useState<AnkiCardType>(() => {
+    if (typeof window === 'undefined') return 'basic';
+    const saved = localStorage.getItem('lector-anki-card-type');
+    return saved === 'cloze' ? 'cloze' : 'basic';
+  });
+  const updateCardType = (next: AnkiCardType) => {
+    setCardType(next);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('lector-anki-card-type', next);
+    }
+  };
 
   // Create a map of collectionId to title for display
   const bookTitleMap = useMemo(() => {
@@ -201,7 +217,7 @@ export default function VocabList({
     if (selectedIds.size === 0) return;
     setIsExporting(true);
     try {
-      await onExportToAnki(Array.from(selectedIds));
+      await onExportToAnki(Array.from(selectedIds), cardType);
       setSelectedIds(new Set());
     } finally {
       setIsExporting(false);
@@ -280,6 +296,35 @@ export default function VocabList({
 
       {/* Bulk Actions */}
       <div className="flex flex-wrap items-center gap-3">
+        {/* Anki card-type toggle. Drives the export button below — Basic adds
+            front/back cards to the configured Basic deck, Cloze adds cloze
+            deletions to the Cloze deck. Choice is persisted to localStorage. */}
+        <div className="inline-flex items-center rounded-lg border border-zinc-200 bg-white p-0.5 dark:border-zinc-700 dark:bg-zinc-800">
+          <button
+            onClick={() => updateCardType('basic')}
+            disabled={isExporting}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              cardType === 'basic'
+                ? 'bg-blue-600 text-white shadow-sm'
+                : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
+            } disabled:cursor-not-allowed disabled:opacity-50`}
+            title="Export selected words as Basic (front/back) cards"
+          >
+            Basic
+          </button>
+          <button
+            onClick={() => updateCardType('cloze')}
+            disabled={isExporting}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              cardType === 'cloze'
+                ? 'bg-blue-600 text-white shadow-sm'
+                : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100'
+            } disabled:cursor-not-allowed disabled:opacity-50`}
+            title="Export selected words as Cloze deletion cards"
+          >
+            Cloze
+          </button>
+        </div>
         <button
           onClick={handleExportToAnki}
           disabled={!someSelected || isExporting}

--- a/src/components/VocabList.tsx
+++ b/src/components/VocabList.tsx
@@ -546,6 +546,8 @@ export default function VocabList({
             <div className="mb-6 grid grid-cols-2 gap-3">
               <button
                 type="button"
+                data-testid="anki-card-type-basic"
+                aria-pressed={cardType === 'basic'}
                 onClick={() => updateCardType('basic')}
                 className={`rounded-lg border p-4 text-left transition-colors ${
                   cardType === 'basic'
@@ -568,6 +570,8 @@ export default function VocabList({
 
               <button
                 type="button"
+                data-testid="anki-card-type-cloze"
+                aria-pressed={cardType === 'cloze'}
                 onClick={() => updateCardType('cloze')}
                 className={`rounded-lg border p-4 text-left transition-colors ${
                   cardType === 'cloze'
@@ -599,6 +603,7 @@ export default function VocabList({
               </button>
               <button
                 type="button"
+                data-testid="anki-export-confirm"
                 onClick={confirmExportToAnki}
                 className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
               >

--- a/src/lib/anki.ts
+++ b/src/lib/anki.ts
@@ -1,8 +1,54 @@
-// AnkiConnect API client — direct browser-to-local connection
-// AnkiConnect must be running on localhost:8765
-// In Anki: Tools > Add-ons > AnkiConnect > Config, ensure webCorsOriginList includes "*" or your app origin
+// AnkiConnect API client — direct browser-to-local connection.
+// AnkiConnect must be running on localhost:8765 by default.
+// In Anki: Tools > Add-ons > AnkiConnect > Config, ensure webCorsOriginList
+// includes "*" or your app origin.
+//
+// The URL is overridable via the `ankiConnectUrl` setting so a user with a
+// remote Anki install (e.g. over Tailscale) can point at http://100.x.x.x:8765.
 
-const ANKI_CONNECT_URL = 'http://localhost:8765';
+const DEFAULT_ANKI_CONNECT_URL = 'http://localhost:8765';
+
+let _cachedUrl: string | null = null;
+let _inflight: Promise<string> | null = null;
+
+/**
+ * Resolve the AnkiConnect URL, reading from /api/settings on first call and
+ * caching the result. Call `refreshAnkiUrl()` after the user updates the
+ * setting so the next request uses the new value.
+ */
+async function getAnkiUrl(): Promise<string> {
+  if (_cachedUrl) return _cachedUrl;
+  if (_inflight) return _inflight;
+
+  _inflight = (async () => {
+    try {
+      const res = await fetch('/api/settings/ankiConnectUrl');
+      if (res.ok) {
+        const value = (await res.json()) as string | null | undefined;
+        if (typeof value === 'string' && value.trim()) {
+          _cachedUrl = value.trim();
+          return _cachedUrl;
+        }
+      }
+    } catch {
+      // Fall through to default
+    }
+    _cachedUrl = DEFAULT_ANKI_CONNECT_URL;
+    return _cachedUrl;
+  })();
+
+  try {
+    return await _inflight;
+  } finally {
+    _inflight = null;
+  }
+}
+
+/** Invalidate the cached URL so the next AnkiConnect call re-reads the setting. */
+export function refreshAnkiUrl(): void {
+  _cachedUrl = null;
+  _inflight = null;
+}
 
 interface AnkiConnectResponse<T = unknown> {
   result: T;
@@ -24,7 +70,8 @@ async function ankiRequest<T>(
   action: string,
   params?: Record<string, unknown>
 ): Promise<T> {
-  const response = await fetch(ANKI_CONNECT_URL, {
+  const url = await getAnkiUrl();
+  const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action, version: 6, params }),
@@ -48,7 +95,8 @@ async function ankiRequest<T>(
  */
 export async function isAnkiConnected(): Promise<boolean> {
   try {
-    const response = await fetch(ANKI_CONNECT_URL, {
+    const url = await getAnkiUrl();
+    const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'version', version: 6 }),


### PR DESCRIPTION
Three Anki-related fixes/improvements bundled together (all touch the same surfaces — settings, anki.ts, vocab page).

## 1. `fix(anki)`: honor the `ankiConnectUrl` setting

The settings page exposed an `AnkiConnect URL` input and persisted the value to `/api/settings/ankiConnectUrl`, but `src/lib/anki.ts` ignored it — every request used the hardcoded `http://localhost:8765`. Users running AnkiConnect on a non-default port (or remote via Tailscale) had no way to override.

- Replaced the module-level constant with `getAnkiUrl()` — reads the setting once, caches the result, falls back to `http://localhost:8765`.
- Exported `refreshAnkiUrl()` so the settings page can invalidate the cache after the URL changes.
- `ankiRequest()` and `isAnkiConnected()` now await `getAnkiUrl()`.

Verified locally — typing `http://localhost:8899` in Settings now actually pushes to that URL, the deck `Afrikaans` got the cards, and the noteId returned by AnkiConnect (`1780878827293`) lined up with a real note in Anki.

## 2. `feat(vocab)`: Basic / Cloze card type toggle

Vocab page push was hardcoded to `addBasicCard` → Basic deck (`ankiDeck`). Users with a Cloze-only workflow had no path to export as Cloze deletions without manually moving cards.

- `onExportToAnki` callback signature gains a `cardType: 'basic' | 'cloze'` argument.
- `vocab/page.tsx` loads both `ankiDeck` (Basic) and `ankiClozeDeck` (Cloze) settings. The handler branches on `cardType` to call `addBasicCard` or `addClozeCard` with the matching deck.
- Success toast names the type and deck (`Exported 2 cloze cards to "Afrikaans::Cloze"`).

## 3. `feat(vocab)`: Export-to-Anki modal

Initial implementation placed the Basic/Cloze toggle inline next to the Export button. That cluttered the bulk-action bar and made the type choice feel persistent when it's really per-export. Moved into a confirmation modal:

- Click "Export to Anki" → modal opens with selected-count summary.
- Two clickable tiles (Basic / Cloze) with one-line descriptions of each.
- Selected tile is highlighted; user's previous choice is pre-selected (localStorage `lector-anki-card-type`).
- `Cancel` + `Export N cards` actions; backdrop click dismisses.

## Out of scope

`api/src/routes/anki.ts` (server-side Hono route used by collection sync) still reads `process.env.ANKI_CONNECT_URL`. Separate concern from this client-side user setting; left untouched.

## Test plan

- [x] Settings → set `AnkiConnect URL` to a non-default port → click Refresh → status pill reflects the new URL's connectivity
- [x] Vocab page → select word(s) → Export to Anki → modal opens
- [x] Modal → Basic → Export → card appears in `Afrikaans` deck (Basic model)
- [x] Modal → Cloze → Export → card appears in `Afrikaans::Cloze` deck (Cloze model with `{{c1::word}}`)
- [x] Pre-selection persists across reloads (localStorage)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` — 0 errors on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
