### PR TITLE
Library: collapsible groups, add-to-group tile, drag-reorder collections & lessons (#115)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "lector",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@mozilla/readability": "^0.6.0",
         "@sentry/nextjs": "^10",
         "adm-zip": "^0.5.17",
@@ -271,6 +274,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "cli": "bun run cli/src/index.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@mozilla/readability": "^0.6.0",
     "@sentry/nextjs": "^10",
     "adm-zip": "^0.5.17",

--- a/src/app/api/__tests__/library-reorder.test.ts
+++ b/src/app/api/__tests__/library-reorder.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+
+// ── In-memory DB wiring ─────────────────────────────────────────────────────
+
+let sqlite: InstanceType<typeof Database>;
+
+vi.mock('@/lib/server/database', () => {
+  return {
+    get db() {
+      return sqlite;
+    },
+  };
+});
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE collections (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      author TEXT NOT NULL DEFAULT 'Unknown',
+      coverUrl TEXT,
+      groupId TEXT,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      language TEXT NOT NULL DEFAULT 'af',
+      createdAt TEXT NOT NULL,
+      lastReadAt TEXT NOT NULL
+    );
+
+    CREATE TABLE lessons (
+      id TEXT PRIMARY KEY,
+      collectionId TEXT,
+      title TEXT NOT NULL,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      language TEXT NOT NULL DEFAULT 'af',
+      textContent TEXT NOT NULL DEFAULT '',
+      progress_scrollPosition INTEGER DEFAULT 0,
+      progress_percentComplete REAL DEFAULT 0,
+      wordCount INTEGER DEFAULT 0,
+      createdAt TEXT NOT NULL,
+      lastReadAt TEXT NOT NULL
+    );
+
+    CREATE TABLE collection_groups (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      createdAt TEXT NOT NULL
+    );
+
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO settings (key, value) VALUES ('targetLanguage', 'af');
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(':memory:');
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new Request(`http://localhost${url}`, init) as unknown as import('next/server').NextRequest;
+}
+
+function insertCollection(
+  id: string,
+  opts: { sortOrder?: number; lastReadAt?: string; groupId?: string | null } = {}
+) {
+  const now = '2026-01-01T00:00:00Z';
+  sqlite
+    .prepare(
+      `INSERT INTO collections (id, title, author, coverUrl, groupId, sortOrder, language, createdAt, lastReadAt)
+       VALUES (?, ?, 'Author', NULL, ?, ?, 'af', ?, ?)`
+    )
+    .run(id, `Title ${id}`, opts.groupId ?? null, opts.sortOrder ?? 0, now, opts.lastReadAt ?? now);
+}
+
+function insertLesson(id: string, collectionId: string, sortOrder: number) {
+  const now = '2026-01-01T00:00:00Z';
+  sqlite
+    .prepare(
+      `INSERT INTO lessons (id, collectionId, title, sortOrder, language, createdAt, lastReadAt)
+       VALUES (?, ?, ?, ?, 'af', ?, ?)`
+    )
+    .run(id, collectionId, `Lesson ${id}`, sortOrder, now, now);
+}
+
+function sortOrderOf(table: 'collections' | 'lessons', id: string): number {
+  const row = sqlite.prepare(`SELECT sortOrder FROM ${table} WHERE id = ?`).get(id) as { sortOrder: number };
+  return row.sortOrder;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COLLECTION REORDER + CREATE-WITH-GROUP
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('PUT /api/collections/reorder', () => {
+  let route: typeof import('@/app/api/collections/reorder/route');
+  beforeEach(async () => {
+    route = await import('@/app/api/collections/reorder/route');
+  });
+
+  it('assigns sortOrder by array index', async () => {
+    insertCollection('a', { sortOrder: 0 });
+    insertCollection('b', { sortOrder: 1 });
+    insertCollection('c', { sortOrder: 2 });
+
+    const res = await route.PUT(
+      makeRequest('/api/collections/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: ['c', 'a', 'b'] }),
+      })
+    );
+    expect(res.status).toBe(200);
+
+    expect(sortOrderOf('collections', 'c')).toBe(0);
+    expect(sortOrderOf('collections', 'a')).toBe(1);
+    expect(sortOrderOf('collections', 'b')).toBe(2);
+  });
+
+  it('rejects a non-array body with 400', async () => {
+    const res = await route.PUT(
+      makeRequest('/api/collections/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: 'nope' }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/collections ordering', () => {
+  let route: typeof import('@/app/api/collections/route');
+  beforeEach(async () => {
+    route = await import('@/app/api/collections/route');
+  });
+
+  it('orders by sortOrder ASC, then lastReadAt DESC as a tiebreaker', async () => {
+    // Explicit sortOrder wins.
+    insertCollection('a', { sortOrder: 2 });
+    insertCollection('b', { sortOrder: 0 });
+    insertCollection('c', { sortOrder: 1 });
+    // Two at the same sortOrder fall back to most-recently-read first.
+    insertCollection('d', { sortOrder: 0, lastReadAt: '2026-05-01T00:00:00Z' });
+
+    const res = await route.GET(makeRequest('/api/collections?language=af'));
+    const data = (await res.json()) as { id: string }[];
+    expect(data.map((c) => c.id)).toEqual(['d', 'b', 'c', 'a']);
+  });
+});
+
+describe('POST /api/collections with groupId', () => {
+  let route: typeof import('@/app/api/collections/route');
+  beforeEach(async () => {
+    route = await import('@/app/api/collections/route');
+  });
+
+  it('persists the groupId when provided', async () => {
+    const res = await route.POST(
+      makeRequest('/api/collections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'New', groupId: 'grp-1', language: 'af' }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const { id } = await res.json();
+
+    const row = sqlite.prepare('SELECT groupId FROM collections WHERE id = ?').get(id) as { groupId: string | null };
+    expect(row.groupId).toBe('grp-1');
+  });
+
+  it('defaults groupId to null when omitted', async () => {
+    const res = await route.POST(
+      makeRequest('/api/collections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Loose', language: 'af' }),
+      })
+    );
+    const { id } = await res.json();
+    const row = sqlite.prepare('SELECT groupId FROM collections WHERE id = ?').get(id) as { groupId: string | null };
+    expect(row.groupId).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LESSON REORDER
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('PUT /api/collections/[id]/lessons/reorder', () => {
+  let route: typeof import('@/app/api/collections/[id]/lessons/reorder/route');
+  beforeEach(async () => {
+    route = await import('@/app/api/collections/[id]/lessons/reorder/route');
+  });
+
+  it('assigns lesson sortOrder by array index', async () => {
+    insertCollection('col-1');
+    insertLesson('l1', 'col-1', 0);
+    insertLesson('l2', 'col-1', 1);
+    insertLesson('l3', 'col-1', 2);
+
+    const res = await route.PUT(
+      makeRequest('/api/collections/col-1/lessons/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: ['l3', 'l1', 'l2'] }),
+      }),
+      { params: Promise.resolve({ id: 'col-1' }) }
+    );
+    expect(res.status).toBe(200);
+
+    expect(sortOrderOf('lessons', 'l3')).toBe(0);
+    expect(sortOrderOf('lessons', 'l1')).toBe(1);
+    expect(sortOrderOf('lessons', 'l2')).toBe(2);
+  });
+
+  it('is scoped to the collection — cannot reorder another collection\'s lesson', async () => {
+    insertCollection('col-1');
+    insertCollection('col-2');
+    insertLesson('mine', 'col-1', 0);
+    insertLesson('theirs', 'col-2', 7);
+
+    await route.PUT(
+      makeRequest('/api/collections/col-1/lessons/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: ['theirs', 'mine'] }),
+      }),
+      { params: Promise.resolve({ id: 'col-1' }) }
+    );
+
+    // `theirs` belongs to col-2, so the col-1-scoped update must not touch it.
+    expect(sortOrderOf('lessons', 'theirs')).toBe(7);
+    // `mine` was at index 1 in the submitted order.
+    expect(sortOrderOf('lessons', 'mine')).toBe(1);
+  });
+
+  it('rejects a non-array body with 400', async () => {
+    insertCollection('col-1');
+    const res = await route.PUT(
+      makeRequest('/api/collections/col-1/lessons/reorder', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: 42 }),
+      }),
+      { params: Promise.resolve({ id: 'col-1' }) }
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/collections/[id]/lessons/reorder/route.ts
+++ b/src/app/api/collections/[id]/lessons/reorder/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+
+// PUT /api/collections/[id]/lessons/reorder - persist a new lesson order.
+// Body: { ids: string[] } — the collection's lessons in their new order.
+// sortOrder is set to the array index for each id; the update is scoped to the
+// collection so a stray id can't reorder another collection's lessons.
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: collectionId } = await params;
+  const body = await request.json();
+  const ids = body.ids;
+
+  if (!Array.isArray(ids) || ids.some((id) => typeof id !== 'string')) {
+    return NextResponse.json({ error: 'ids must be an array of strings' }, { status: 400 });
+  }
+
+  const update = db.prepare('UPDATE lessons SET sortOrder = ? WHERE id = ? AND collectionId = ?');
+  const reorder = db.transaction((orderedIds: string[]) => {
+    orderedIds.forEach((lessonId, index) => update.run(index, lessonId, collectionId));
+  });
+  reorder(ids);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/collections/reorder/route.ts
+++ b/src/app/api/collections/reorder/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+
+// PUT /api/collections/reorder - persist a new collection order.
+// Body: { ids: string[] } — the collections (typically one group's worth) in
+// their new order. sortOrder is set to the array index for each id.
+export async function PUT(request: NextRequest) {
+  const body = await request.json();
+  const ids = body.ids;
+
+  if (!Array.isArray(ids) || ids.some((id) => typeof id !== 'string')) {
+    return NextResponse.json({ error: 'ids must be an array of strings' }, { status: 400 });
+  }
+
+  const update = db.prepare('UPDATE collections SET sortOrder = ? WHERE id = ?');
+  const reorder = db.transaction((orderedIds: string[]) => {
+    orderedIds.forEach((id, index) => update.run(index, id));
+  });
+  reorder(ids);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
     LEFT JOIN lessons l ON l.collectionId = c.id AND l.language = c.language
     WHERE c.language = ?
     GROUP BY c.id
-    ORDER BY c.lastReadAt DESC
+    ORDER BY c.sortOrder ASC, c.lastReadAt DESC
   `).all(lang) as (CollectionRow & { groupName: string | null; lessonCount: number; avgProgress: number })[];
 
   return NextResponse.json(collections);
@@ -30,9 +30,9 @@ export async function POST(request: NextRequest) {
   const lang = resolveLanguage(body.language);
 
   db.prepare(`
-    INSERT INTO collections (id, title, author, coverUrl, language, createdAt, lastReadAt)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
-  `).run(id, body.title, body.author || 'Unknown', body.coverUrl || null, lang, now, now);
+    INSERT INTO collections (id, title, author, coverUrl, groupId, language, createdAt, lastReadAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, body.title, body.author || 'Unknown', body.coverUrl || null, body.groupId || null, lang, now, now);
 
   return NextResponse.json({ id });
 }

--- a/src/app/collection/[id]/page.tsx
+++ b/src/app/collection/[id]/page.tsx
@@ -6,6 +6,23 @@ import Link from 'next/link';
 import NavHeader from '@/components/NavHeader';
 import LessonFormModal from '@/components/LessonFormModal';
 import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
   getCollection,
   getLessonsForCollection,
   getLesson,
@@ -13,6 +30,7 @@ import {
   updateLesson,
   deleteCollection,
   deleteLesson,
+  reorderLessons,
   updateCollection,
   getAllGroups,
   createGroup,
@@ -35,6 +53,11 @@ export default function CollectionPage({
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [editingLessonId, setEditingLessonId] = useState<string | null>(null);
   const [editingInitial, setEditingInitial] = useState<{ title: string; textContent: string } | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   useEffect(() => {
     async function load() {
@@ -93,6 +116,19 @@ export default function CollectionPage({
     if (!editingLessonId) return;
     await updateLesson(editingLessonId, data);
     await refreshLessons();
+  }
+
+  function handleLessonDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setLessons((prev) => {
+      const oldIndex = prev.findIndex((l) => l.id === active.id);
+      const newIndex = prev.findIndex((l) => l.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return prev;
+      const next = arrayMove(prev, oldIndex, newIndex);
+      reorderLessons(id, next.map((l) => l.id));
+      return next;
+    });
   }
 
   async function handleGroupChange(value: string) {
@@ -204,85 +240,19 @@ export default function CollectionPage({
 
         {/* Lesson list */}
         <div className="space-y-2">
-          {lessons.map((lesson, i) => {
-            const progress = Math.round(lesson.progress_percentComplete);
-            const isComplete = progress >= 95;
-
-            return (
-              <div
-                key={lesson.id}
-                className="group flex items-center gap-4 rounded-xl border border-zinc-200 bg-white px-5 py-4 transition-all hover:border-zinc-300 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700"
-              >
-                <Link
-                  href={`/read/${lesson.id}`}
-                  className="flex flex-1 items-center gap-4 min-w-0"
-                >
-                  {/* Lesson number */}
-                  <div className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-medium
-                    ${isComplete
-                      ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                      : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
-                    }`}>
-                    {isComplete ? (
-                      <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                    ) : (
-                      i + 1
-                    )}
-                  </div>
-
-                  {/* Lesson info */}
-                  <div className="flex-1 min-w-0">
-                    <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
-                      {lesson.title}
-                    </h3>
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {lesson.wordCount.toLocaleString()} words
-                      {progress > 0 && !isComplete && ` · ${progress}%`}
-                    </p>
-                  </div>
-
-                  {/* Progress bar */}
-                  {progress > 0 && !isComplete && (
-                    <div className="w-20 h-1.5 rounded-full bg-zinc-100 dark:bg-zinc-800">
-                      <div
-                        className="h-full rounded-full bg-zinc-400 dark:bg-zinc-500"
-                        style={{ width: `${progress}%` }}
-                      />
-                    </div>
-                  )}
-
-                  <svg className="h-4 w-4 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </Link>
-
-                {/* Edit button */}
-                <button
-                  onClick={() => openEditLesson(lesson.id)}
-                  className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all hover:bg-zinc-100 hover:text-zinc-700 group-hover:opacity-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
-                  title="Edit lesson"
-                  data-testid={`edit-lesson-${lesson.id}`}
-                >
-                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
-                </button>
-
-                {/* Delete button */}
-                <button
-                  onClick={() => handleDeleteLesson(lesson.id, lesson.title)}
-                  className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-                  title="Delete lesson"
-                >
-                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </button>
-              </div>
-            );
-          })}
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleLessonDragEnd}>
+            <SortableContext items={lessons.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+              {lessons.map((lesson, i) => (
+                <SortableLessonRow
+                  key={lesson.id}
+                  lesson={lesson}
+                  index={i}
+                  onEdit={openEditLesson}
+                  onDelete={handleDeleteLesson}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
 
           {/* Add lesson button */}
           <button
@@ -314,6 +284,114 @@ export default function CollectionPage({
           onSave={handleEditLesson}
         />
       </main>
+    </div>
+  );
+}
+
+function SortableLessonRow({
+  lesson,
+  index,
+  onEdit,
+  onDelete,
+}: {
+  lesson: LessonSummary;
+  index: number;
+  onEdit: (id: string) => void;
+  onDelete: (id: string, title: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } =
+    useSortable({ id: lesson.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+  };
+  const progress = Math.round(lesson.progress_percentComplete);
+  const isComplete = progress >= 95;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-3 py-4 transition-all hover:border-zinc-300 hover:shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 sm:px-4 ${isDragging ? 'opacity-60 shadow-md' : ''}`}
+    >
+      <button
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag to reorder ${lesson.title}`}
+        data-testid={`drag-lesson-${lesson.id}`}
+        className="flex-shrink-0 cursor-grab touch-none rounded-md p-1 text-zinc-300 hover:text-zinc-500 active:cursor-grabbing dark:text-zinc-600 dark:hover:text-zinc-400"
+      >
+        <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M7 4a1 1 0 11-2 0 1 1 0 012 0zM7 10a1 1 0 11-2 0 1 1 0 012 0zM7 16a1 1 0 11-2 0 1 1 0 012 0zM13 4a1 1 0 11-2 0 1 1 0 012 0zM13 10a1 1 0 11-2 0 1 1 0 012 0zM13 16a1 1 0 11-2 0 1 1 0 012 0z" />
+        </svg>
+      </button>
+
+      <Link href={`/read/${lesson.id}`} className="flex flex-1 items-center gap-4 min-w-0">
+        {/* Lesson number */}
+        <div className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-medium
+          ${isComplete
+            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+            : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
+          }`}>
+          {isComplete ? (
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            index + 1
+          )}
+        </div>
+
+        {/* Lesson info */}
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
+            {lesson.title}
+          </h3>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            {lesson.wordCount.toLocaleString()} words
+            {progress > 0 && !isComplete && ` · ${progress}%`}
+          </p>
+        </div>
+
+        {/* Progress bar */}
+        {progress > 0 && !isComplete && (
+          <div className="w-20 h-1.5 rounded-full bg-zinc-100 dark:bg-zinc-800">
+            <div
+              className="h-full rounded-full bg-zinc-400 dark:bg-zinc-500"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+
+        <svg className="h-4 w-4 flex-shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </Link>
+
+      {/* Edit button */}
+      <button
+        onClick={() => onEdit(lesson.id)}
+        className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all hover:bg-zinc-100 hover:text-zinc-700 group-hover:opacity-100 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+        title="Edit lesson"
+        data-testid={`edit-lesson-${lesson.id}`}
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+      </button>
+
+      {/* Delete button */}
+      <button
+        onClick={() => onDelete(lesson.id, lesson.title)}
+        className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+        title="Delete lesson"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      </button>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,11 +8,30 @@ import ImportDropdown from '@/components/ImportDropdown';
 import WebImportModal from '@/components/WebImportModal';
 import PasteImportModal from '@/components/PasteImportModal';
 import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
   getAllCollections,
   getAllGroups,
+  createCollection,
   createGroup,
   updateGroup,
   deleteGroup,
+  reorderCollections,
   createStandaloneLesson,
   importEpub,
   getVocabStats,
@@ -32,11 +51,43 @@ export default function Home() {
   const [isPasteImportOpen, setIsPasteImportOpen] = useState(false);
   const [newGroupName, setNewGroupName] = useState('');
   const [isCreatingGroup, setIsCreatingGroup] = useState(false);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [addingToGroupId, setAddingToGroupId] = useState<string | null>(null);
+  const [newCollectionTitle, setNewCollectionTitle] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   useEffect(() => {
     loadData();
   }, []);
+
+  // Restore collapsed-group state client-side (avoids SSR/hydration mismatch).
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('lector-collapsed-groups');
+      if (raw) setCollapsedGroups(new Set(JSON.parse(raw) as string[]));
+    } catch {
+      // ignore malformed storage
+    }
+  }, []);
+
+  function toggleGroup(groupId: string) {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      try {
+        localStorage.setItem('lector-collapsed-groups', JSON.stringify([...next]));
+      } catch {
+        // ignore storage failure
+      }
+      return next;
+    });
+  }
 
   async function loadData() {
     try {
@@ -175,6 +226,34 @@ export default function Home() {
     ]);
     setGroups(updatedGroups);
     setCollections(updatedCollections);
+  }
+
+  async function handleAddCollectionToGroup(groupId: string) {
+    const title = newCollectionTitle.trim();
+    if (!title) return;
+    await createCollection({ title, groupId });
+    setNewCollectionTitle('');
+    setAddingToGroupId(null);
+    const updated = await getAllCollections();
+    setCollections(updated);
+  }
+
+  // Reorder collections within a single group. The library buckets `collections`
+  // by groupId in array order, so we splice the reordered bucket back into the
+  // members' original slots and persist the new order optimistically.
+  function handleCollectionDragEnd(groupId: string, event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setCollections((prev) => {
+      const bucket = prev.filter((c) => c.groupId === groupId);
+      const oldIndex = bucket.findIndex((c) => c.id === active.id);
+      const newIndex = bucket.findIndex((c) => c.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return prev;
+      const newBucket = arrayMove(bucket, oldIndex, newIndex);
+      reorderCollections(newBucket.map((c) => c.id));
+      let bi = 0;
+      return prev.map((c) => (c.groupId === groupId ? newBucket[bi++] : c));
+    });
   }
 
   // Group collections by groupId
@@ -330,12 +409,29 @@ export default function Home() {
               {/* Grouped sections */}
               {groups.map((group) => {
                 const items = groupedCollections.get(group.id) || [];
+                const isCollapsed = collapsedGroups.has(group.id);
                 return (
                   <div key={group.id} data-testid={`group-${group.id}`}>
                     <div className="mb-4 flex items-center gap-3">
-                      <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200">
-                        {group.name}
-                      </h3>
+                      <button
+                        onClick={() => toggleGroup(group.id)}
+                        aria-expanded={!isCollapsed}
+                        aria-label={isCollapsed ? `Expand ${group.name}` : `Collapse ${group.name}`}
+                        data-testid={`group-toggle-${group.id}`}
+                        className="-ml-1 flex items-center gap-2 rounded-lg px-1 py-0.5 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                      >
+                        <svg
+                          className={`h-4 w-4 text-zinc-400 transition-transform ${isCollapsed ? '-rotate-90' : ''}`}
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                        <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200">
+                          {group.name}
+                        </h3>
+                      </button>
                       <span className="text-sm text-zinc-400 dark:text-zinc-500">
                         {items.length} {items.length === 1 ? 'item' : 'items'}
                       </span>
@@ -345,16 +441,46 @@ export default function Home() {
                         onDelete={() => handleDeleteGroup(group.id, group.name)}
                       />
                     </div>
-                    {items.length > 0 ? (
-                      <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                        {items.map((collection) => (
-                          <CollectionCard key={collection.id} collection={collection} />
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="rounded-xl border border-dashed border-zinc-200 py-8 text-center text-sm text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
-                        No collections in this group yet. Assign collections from their detail page.
-                      </p>
+                    {!isCollapsed && (
+                      <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={(e) => handleCollectionDragEnd(group.id, e)}
+                      >
+                        <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                          <SortableContext items={items.map((c) => c.id)} strategy={rectSortingStrategy}>
+                            {items.map((collection) => (
+                              <SortableCollectionCard key={collection.id} collection={collection} />
+                            ))}
+                          </SortableContext>
+                          {addingToGroupId === group.id ? (
+                            <AddCollectionTile
+                              value={newCollectionTitle}
+                              onChange={setNewCollectionTitle}
+                              onSubmit={() => handleAddCollectionToGroup(group.id)}
+                              onCancel={() => {
+                                setAddingToGroupId(null);
+                                setNewCollectionTitle('');
+                              }}
+                            />
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setAddingToGroupId(group.id);
+                                setNewCollectionTitle('');
+                              }}
+                              data-testid={`add-collection-${group.id}`}
+                              className="group flex min-h-[14rem] flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-zinc-300 text-zinc-400 transition-all hover:border-zinc-400 hover:bg-white hover:text-zinc-600 dark:border-zinc-700 dark:hover:border-zinc-600 dark:hover:bg-zinc-900 dark:hover:text-zinc-300"
+                            >
+                              <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 4v16m8-8H4" />
+                              </svg>
+                              <span className="text-sm font-medium">New collection</span>
+                            </button>
+                          )}
+                        </div>
+                      </DndContext>
                     )}
                   </div>
                 );
@@ -430,6 +556,86 @@ function GroupMenu({ onRename, onDelete }: { onRename: () => void; onDelete: () 
         </div>
       )}
     </div>
+  );
+}
+
+function SortableCollectionCard({ collection }: { collection: Collection }) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } =
+    useSortable({ id: collection.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className={`group relative ${isDragging ? 'opacity-60' : ''}`}>
+      <CollectionCard collection={collection} />
+      <button
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag to reorder ${collection.title}`}
+        data-testid={`drag-collection-${collection.id}`}
+        className="absolute left-2 top-2 cursor-grab touch-none rounded-md bg-white/90 p-1 text-zinc-400 opacity-70 shadow-sm transition-opacity hover:text-zinc-700 focus-visible:opacity-100 group-hover:opacity-100 active:cursor-grabbing dark:bg-zinc-800/90 dark:hover:text-zinc-200"
+      >
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M7 4a1 1 0 11-2 0 1 1 0 012 0zM7 10a1 1 0 11-2 0 1 1 0 012 0zM7 16a1 1 0 11-2 0 1 1 0 012 0zM13 4a1 1 0 11-2 0 1 1 0 012 0zM13 10a1 1 0 11-2 0 1 1 0 012 0zM13 16a1 1 0 11-2 0 1 1 0 012 0z" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+function AddCollectionTile({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+      className="flex min-h-[14rem] flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-zinc-300 p-4 dark:border-zinc-700"
+    >
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onCancel();
+        }}
+        placeholder="Collection title"
+        autoFocus
+        data-testid="new-collection-input"
+        className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+      />
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          data-testid="new-collection-submit"
+          className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          Create
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg px-3 py-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -64,7 +64,7 @@ export async function getCollection(id: string): Promise<Collection | undefined>
   return res.json();
 }
 
-export async function createCollection(data: { title: string; author?: string }): Promise<string> {
+export async function createCollection(data: { title: string; author?: string; groupId?: string | null }): Promise<string> {
   const res = await fetch('/api/collections', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -72,6 +72,14 @@ export async function createCollection(data: { title: string; author?: string })
   });
   const { id } = await res.json();
   return id;
+}
+
+export async function reorderCollections(ids: string[]): Promise<void> {
+  await fetch('/api/collections/reorder', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids }),
+  });
 }
 
 export async function deleteCollection(id: string): Promise<void> {
@@ -158,6 +166,14 @@ export async function updateLesson(
 
 export async function deleteLesson(id: string): Promise<void> {
   await fetch(`/api/lessons/${id}`, { method: 'DELETE' });
+}
+
+export async function reorderLessons(collectionId: string, ids: string[]): Promise<void> {
+  await fetch(`/api/collections/${collectionId}/lessons/reorder`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids }),
+  });
 }
 
 export async function updateLessonProgress(

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,6 +17,7 @@ export interface Collection {
   coverUrl?: string;
   groupId?: string | null;
   groupName?: string | null;
+  sortOrder?: number;
   language?: string;
   lessonCount: number;
   avgProgress: number;

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -35,6 +35,7 @@ function getDb(): DatabaseType {
       title TEXT NOT NULL,
       author TEXT NOT NULL DEFAULT 'Unknown',
       coverUrl TEXT,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
       createdAt TEXT NOT NULL,
       lastReadAt TEXT NOT NULL
     );
@@ -228,6 +229,9 @@ function getDb(): DatabaseType {
   const collectionCols = _db.prepare("PRAGMA table_info(collections)").all() as { name: string }[];
   if (!collectionCols.some(c => c.name === 'groupId')) {
     _db.exec('ALTER TABLE collections ADD COLUMN groupId TEXT REFERENCES collection_groups(id) ON DELETE SET NULL');
+  }
+  if (!collectionCols.some(c => c.name === 'sortOrder')) {
+    _db.exec('ALTER TABLE collections ADD COLUMN sortOrder INTEGER NOT NULL DEFAULT 0');
   }
 
   // Remove FK constraint on vocab.bookId that references old books table
@@ -494,6 +498,7 @@ export interface CollectionRow {
   author: string;
   coverUrl: string | null;
   groupId: string | null;
+  sortOrder: number;
   createdAt: string;
   lastReadAt: string;
 }


### PR DESCRIPTION
Closes #115. Part of #107.

Adds the four Library-page enhancements from #115.

## What's new

- **Collapsible groups** — each group header is a chevron toggle; collapsed state persists in `localStorage` (`lector-collapsed-groups`). Loaded in a post-mount `useEffect` so the initial render matches the server and there's no hydration mismatch.
- **Add-to-group "+" tile** — a dashed tile in every group's grid opens an inline title form and creates a collection straight into that group.
- **Drag-reorder collections within a group** — each card gets a grip handle (the card itself stays click-to-open); reordering is optimistic and persisted.
- **Drag-reorder lessons** — same pattern on the collection detail page.

## Backend

- Add a `sortOrder` column to `collections` (migration mirroring the existing `groupId` one + fresh-schema default). Lessons and `collection_groups` already had `sortOrder`.
- List collections by `sortOrder ASC, lastReadAt DESC` — un-reordered libraries render exactly as before.
- `POST /api/collections` now accepts an optional `groupId`.
- New transactional endpoints: `PUT /api/collections/reorder` and `PUT /api/collections/[id]/lessons/reorder` (lesson reorder is scoped to its collection so a stray id can't touch another collection's lessons). Both 400 on a non-array body.

## Frontend

- `@dnd-kit/core` + `@dnd-kit/sortable` (new dep), with `PointerSensor` (6px activation) and `KeyboardSensor` for keyboard-accessible dragging.
- DnD is **group-scoped** per the issue; ungrouped collections stay non-draggable (cross-group moves remain via the detail-page group selector).

## Testing

- `tsc --noEmit`, `eslint` (0 new warnings), and `next build` all green; both new routes register.
- **8 unit tests** in `src/app/api/__tests__/library-reorder.test.ts` cover index-based reordering, lesson-reorder collection scoping, create-with-`groupId`, list ordering, and 400s on bad input. Run: `npx vitest run src/app/api/__tests__/library-reorder.test.ts`.
- Manually verified in the browser against an **isolated `DATA_DIR`** (collapse persistence, the + tile, and both drag-reorders surviving reload).

## Notes

- No Playwright e2e spec yet: the mandated pre-PR e2e run currently executes against the real dev database (#110), so adding one is unsafe until that `DATA_DIR` isolation lands. Easy to add afterwards.
- The "+" tile creates an empty collection in the group; lessons are then added on the detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
