### PR TITLE
Fix hydration mismatch (SetupGuard) and React 19 script-tag warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, Literata } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import ChatWidget from "@/components/ChatWidget";
 import SetupGuard from "@/components/SetupGuard";
@@ -27,7 +28,13 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: `(function(){if(!localStorage.getItem('lector-migrated')){var m={'afrikaans-reader-api-key':'lector-api-key','afrikaans-reader-google-api-key':'lector-google-api-key','afrikaans-reader-anki-deck':'lector-anki-deck','afrikaans-reader-anki-cloze-deck':'lector-anki-cloze-deck','afrikaans-reader-card-type':'lector-card-type','afrikaans-reader-tts-speed':'lector-tts-speed','afrikaans-reader-theme':'lector-theme','afrikaans-reader-tts-voice':'lector-tts-voice','afrikaans-reader-tts-mode':'lector-tts-mode'};for(var k in m){var v=localStorage.getItem(k);if(v!==null){localStorage.setItem(m[k],v);localStorage.removeItem(k)}}localStorage.setItem('lector-migrated','1')}var t=localStorage.getItem('theme')||'system';var d=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')})()` }} />
+        {/* Runs before paint to migrate legacy localStorage keys and apply the
+            saved theme, preventing a flash of the wrong colour scheme. Uses
+            next/script (beforeInteractive) rather than a raw <script> so React
+            19 doesn't warn about a script tag inside the component tree. */}
+        <Script id="lector-theme-init" strategy="beforeInteractive">
+          {`(function(){if(!localStorage.getItem('lector-migrated')){var m={'afrikaans-reader-api-key':'lector-api-key','afrikaans-reader-google-api-key':'lector-google-api-key','afrikaans-reader-anki-deck':'lector-anki-deck','afrikaans-reader-anki-cloze-deck':'lector-anki-cloze-deck','afrikaans-reader-card-type':'lector-card-type','afrikaans-reader-tts-speed':'lector-tts-speed','afrikaans-reader-theme':'lector-theme','afrikaans-reader-tts-voice':'lector-tts-voice','afrikaans-reader-tts-mode':'lector-tts-mode'};for(var k in m){var v=localStorage.getItem(k);if(v!==null){localStorage.setItem(m[k],v);localStorage.removeItem(k)}}localStorage.setItem('lector-migrated','1')}var t=localStorage.getItem('theme')||'system';var d=t==='dark'||(t==='system'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')})()`}
+        </Script>
       </head>
       <body
         className={`${inter.variable} ${literata.variable} font-sans antialiased bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen`}

--- a/src/components/SetupGuard.tsx
+++ b/src/components/SetupGuard.tsx
@@ -4,16 +4,14 @@ import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { getSetting } from '@/lib/data-layer';
 
-function getInitialChecked(pathname: string): boolean {
-  if (pathname === '/setup') return true;
-  if (typeof window === 'undefined') return false;
-  return !!localStorage.getItem('lector-target-language');
-}
-
 export default function SetupGuard({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
-  const [checked, setChecked] = useState(() => getInitialChecked(pathname));
+  // The first render must be identical on the server and the client, so we must
+  // not read localStorage here — doing so rendered the spinner on the server but
+  // the children on the client, which was the hydration mismatch. /setup is
+  // always allowed through; every other route resolves in the effect below.
+  const [checked, setChecked] = useState(pathname === '/setup');
   const [error, setError] = useState(false);
 
   useEffect(() => {
@@ -22,6 +20,13 @@ export default function SetupGuard({ children }: { children: React.ReactNode }) 
     let cancelled = false;
 
     async function checkLanguage() {
+      // Fast path: a cached language means setup is already done — skip the
+      // network round-trip in the common case.
+      if (localStorage.getItem('lector-target-language')) {
+        setChecked(true);
+        return;
+      }
+
       try {
         const serverLang = await getSetting<string>('targetLanguage');
         if (cancelled) return;


### PR DESCRIPTION
Fixes the two console errors that showed up during local verification (both pre-existing on `master`, unrelated to #115).

## 1. Hydration mismatch (`SetupGuard`)

`SetupGuard` read `localStorage` in its `useState` initializer:

```ts
const [checked, setChecked] = useState(() => getInitialChecked(pathname));
// getInitialChecked → server: false (no window), client: !!localStorage.getItem(...)
```

So when a language was cached, the **server rendered the loading spinner** while the **client's first render rendered the children** → `Hydration failed because the server rendered HTML didn't match the client`.

Fix: make the first render deterministic — only `/setup` starts `checked`; every other route starts unchecked on both server and client. The `localStorage` fast-path moves into the post-mount effect (kept inside the async `checkLanguage` so it doesn't trip `react-hooks/set-state-in-effect`). Behaviour is unchanged: cached language → no spinner/network; no language → redirect to `/setup`.

## 2. React 19 "script tag while rendering" warning (`layout.tsx`)

The theme / legacy-localStorage-migration script was a raw `<script dangerouslySetInnerHTML>` in `<head>`, which React 19 flags (`Scripts inside React components are never executed when rendering on the client`). Switched to `next/script` with `strategy="beforeInteractive"` — still injected into the initial HTML and run before paint (no theme flash), but no longer part of the React-reconciled tree.

`ThemeToggle` (mounted-guard) and `NavHeader` (`useSyncExternalStore` with a server snapshot) were already hydration-safe and are untouched.

## Verification

`tsc --noEmit`, `eslint` (0 errors), and `next build` all clean. Verified in the browser on an isolated `DATA_DIR`:
- Loading `/` with a cached language **and** `theme=dark` → **0 console errors**, `<html class="dark">` applied before paint (no FOUC), library rendered (not stuck on the spinner).
- Clearing the language → still redirects to `/setup` cleanly, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
