### PR TITLE
fix(srs): learning-loop correctness — TZ-aware days, retry demotion, Anki cloze, unified streaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,4 +28,16 @@ Tests live in:
 - Desktop sidebar is 56 units wide (`sm:ml-56` on page wrapper)
 - Dark mode uses `.dark` class on `<html>`, toggled via `ThemeToggle`
 - Practice page has type and MC modes with a fallback MC option
-- SRS intervals: 0/1/3/7/14 days for mastery levels 0/25/50/75/100
+
+## SRS Behaviour (implemented in `src/app/practice/page.tsx`)
+
+- Intervals: 0/1/3/7/14 days for mastery levels 0/25/50/75/100, scheduled at the exact review time (no midnight flooring). Mastery-100 cards keep a 14-day maintenance review and are served when due.
+- Correct answers move up one level (+25). A miss hard-resets the card to mastery 0 and re-queues it at the end of the round; the retry runs from mastery 0 and awards no points (the answer was just shown).
+- Cloze words from the bank can carry trailing punctuation — always strip via `splitTrailingPunctuation` (`src/lib/words.ts`) before matching, displaying, or persisting them.
+- Note: `src/lib/srs.ts` is dead code that describes a different scheme; deletion is tracked in #114. This section documents the live behaviour.
+
+## Dates, Streaks & Time Zone
+
+- Day rollover (daily stats, streaks, review days) uses the `timezone` setting (Settings → Time Zone), falling back to the server's zone — never raw UTC. Helpers: `src/lib/server/dates.ts` / `api/src/lib/dates.ts` (`getTodayDate()`), pure math in `src/lib/dates.ts`.
+- One streak definition app-wide: a day is active if it has any dictionary lookups, cloze practice, or reading minutes. Computed by `computeStreaks` (`src/lib/streak.ts`, mirrored in `api/src/lib/streak.ts`), served by `/api/stats/streak` (current + longest). Pages must not compute their own streaks.
+- The pure helpers are mirrored between `src/lib/` and `api/src/lib/` (the servers share the SQLite file but not source) — keep both copies in sync when editing.

--- a/api/src/lib/dates.ts
+++ b/api/src/lib/dates.ts
@@ -1,0 +1,63 @@
+import { db } from '../db';
+
+// Mirror of src/lib/dates.ts + src/lib/server/dates.ts for the Bun API (the
+// two servers share the SQLite file but not source — same pattern as the
+// crypto module). Keep the implementations in sync.
+//
+// All "day" boundaries (daily stats, streaks) are calendar dates in the
+// user's configured time zone — never raw UTC (issue #108).
+
+export function isValidTimeZone(timeZone: string): boolean {
+  if (!timeZone) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Format a Date as YYYY-MM-DD in the given IANA time zone. */
+export function dateStringInTimeZone(date: Date, timeZone: string): string {
+  // The en-CA locale formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+/** Add days to a YYYY-MM-DD string. Calendar math only — time-zone independent. */
+export function addDaysToDateString(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00Z'); // noon UTC avoids DST edge cases
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().split('T')[0];
+}
+
+// Day-rollover time zone. Configurable via the `timezone` setting (Settings →
+// Time Zone); falls back to the server's local zone.
+export function getConfiguredTimeZone(): string {
+  try {
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('timezone') as
+      | { value: string }
+      | undefined;
+    if (row) {
+      let value: unknown = row.value;
+      try {
+        value = JSON.parse(row.value);
+      } catch {
+        // legacy raw-string value
+      }
+      if (typeof value === 'string' && isValidTimeZone(value)) return value;
+    }
+  } catch {
+    // fall through to the server zone
+  }
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/** Today's date (YYYY-MM-DD) in the configured time zone. */
+export function getTodayDate(): string {
+  return dateStringInTimeZone(new Date(), getConfiguredTimeZone());
+}

--- a/api/src/lib/streak.ts
+++ b/api/src/lib/streak.ts
@@ -1,0 +1,63 @@
+// Mirror of src/lib/streak.ts for the Bun API — keep in sync.
+// Single source of truth for streak math (issue #108): a day counts toward
+// the streak when any study activity happened (lookup, practice, or reading).
+
+import { addDaysToDateString } from './dates';
+
+export interface DailyActivityRow {
+  date: string;
+  dictionaryLookups?: number | null;
+  clozePracticed?: number | null;
+  minutesRead?: number | null;
+}
+
+export function isActiveDay(row: DailyActivityRow): boolean {
+  return (
+    (row.dictionaryLookups ?? 0) > 0 ||
+    (row.clozePracticed ?? 0) > 0 ||
+    (row.minutesRead ?? 0) > 0
+  );
+}
+
+export function activeDateSet(rows: DailyActivityRow[]): Set<string> {
+  const set = new Set<string>();
+  for (const row of rows) {
+    if (isActiveDay(row)) set.add(row.date);
+  }
+  return set;
+}
+
+export interface StreakResult {
+  current: number;
+  longest: number;
+  activeToday: boolean;
+}
+
+/**
+ * Compute current and longest streaks from a set of active YYYY-MM-DD dates.
+ * `today` must already be expressed in the user's configured time zone.
+ */
+export function computeStreaks(activeDates: Set<string>, today: string): StreakResult {
+  const activeToday = activeDates.has(today);
+
+  let current = 0;
+  let cursor = activeToday ? today : addDaysToDateString(today, -1);
+  while (activeDates.has(cursor)) {
+    current++;
+    cursor = addDaysToDateString(cursor, -1);
+  }
+
+  let longest = 0;
+  for (const date of activeDates) {
+    if (activeDates.has(addDaysToDateString(date, -1))) continue; // not a run start
+    let length = 1;
+    let next = addDaysToDateString(date, 1);
+    while (activeDates.has(next)) {
+      length++;
+      next = addDaysToDateString(next, 1);
+    }
+    if (length > longest) longest = length;
+  }
+
+  return { current, longest, activeToday };
+}

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -1,12 +1,10 @@
 import { Hono } from 'hono';
 import { db, DailyStatsRow } from '../db';
 import { resolveLanguage } from '../lib/active-language';
+import { getTodayDate, addDaysToDateString } from '../lib/dates';
+import { activeDateSet, computeStreaks } from '../lib/streak';
 
 const app = new Hono();
-
-function getTodayDate(): string {
-  return new Date().toISOString().split('T')[0];
-}
 
 // GET /api/stats
 app.get('/', (c) => {
@@ -22,10 +20,8 @@ app.get('/', (c) => {
     query += ' AND date BETWEEN ? AND ?';
     params.push(startDate, endDate);
   } else if (days) {
-    const d = new Date();
-    d.setDate(d.getDate() - parseInt(days) + 1);
-    const start = d.toISOString().split('T')[0];
-    const end = new Date().toISOString().split('T')[0];
+    const end = getTodayDate();
+    const start = addDaysToDateString(end, -(parseInt(days) - 1));
     query += ' AND date BETWEEN ? AND ?';
     params.push(start, end);
   }
@@ -125,17 +121,9 @@ app.get('/fluency', (c) => {
 
   // Weekly growth: words marked known in last 7 days vs previous 7 days
   const today = getTodayDate();
-  const d7 = new Date();
-  d7.setDate(d7.getDate() - 6);
-  const weekStart = d7.toISOString().split('T')[0];
-
-  const d14 = new Date();
-  d14.setDate(d14.getDate() - 13);
-  const prevWeekStart = d14.toISOString().split('T')[0];
-
-  const d8 = new Date();
-  d8.setDate(d8.getDate() - 7);
-  const prevWeekEnd = d8.toISOString().split('T')[0];
+  const weekStart = addDaysToDateString(today, -6);
+  const prevWeekStart = addDaysToDateString(today, -13);
+  const prevWeekEnd = addDaysToDateString(today, -7);
 
   const thisWeekRow = db.prepare(
     'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?'
@@ -163,46 +151,20 @@ app.get('/fluency', (c) => {
 });
 
 // GET /api/stats/streak
+// Unified streak definition (issue #108): a day is active when it has any
+// study activity (lookups, practice, or reading time), with day rollover in
+// the configured time zone. Keep in sync with src/app/api/stats/streak.
 app.get('/streak', (c) => {
   const lang = resolveLanguage(c.req.query('language'));
   const today = getTodayDate();
 
   const rows = db.prepare(
-    'SELECT date, clozePracticed FROM dailyStats WHERE clozePracticed > 0 AND language = ? ORDER BY date DESC'
-  ).all(lang) as Pick<DailyStatsRow, 'date' | 'clozePracticed'>[];
+    'SELECT date, dictionaryLookups, clozePracticed, minutesRead FROM dailyStats WHERE language = ?'
+  ).all(lang) as Pick<DailyStatsRow, 'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead'>[];
 
-  if (rows.length === 0) {
-    return c.json({ streak: 0, practicedToday: false });
-  }
+  const { current, longest, activeToday } = computeStreaks(activeDateSet(rows), today);
 
-  const practicedDates = new Set(rows.map(r => r.date));
-  const practicedToday = practicedDates.has(today);
-
-  let streak = 0;
-  const checkDate = new Date(today + 'T12:00:00');
-
-  if (practicedToday) {
-    streak = 1;
-    checkDate.setDate(checkDate.getDate() - 1);
-  } else {
-    checkDate.setDate(checkDate.getDate() - 1);
-    const yesterday = checkDate.toISOString().split('T')[0];
-    if (!practicedDates.has(yesterday)) {
-      return c.json({ streak: 0, practicedToday: false });
-    }
-  }
-
-  while (true) {
-    const dateStr = checkDate.toISOString().split('T')[0];
-    if (practicedDates.has(dateStr)) {
-      streak++;
-      checkDate.setDate(checkDate.getDate() - 1);
-    } else {
-      break;
-    }
-  }
-
-  return c.json({ streak, practicedToday });
+  return c.json({ streak: current, longest, practicedToday: activeToday });
 });
 
 export default app;

--- a/e2e/vocab-anki-export.spec.ts
+++ b/e2e/vocab-anki-export.spec.ts
@@ -17,7 +17,7 @@ import { test, expect, Page, Route } from '@playwright/test';
 
 interface AnkiCall {
   action: string;
-  params?: { note?: { deckName?: string; modelName?: string } };
+  params?: { note?: { deckName?: string; modelName?: string; fields?: Record<string, string> } };
 }
 
 async function seedVocabEntry(page: Page, text: string, sentence: string, translation: string) {
@@ -116,10 +116,15 @@ test.describe('Vocab → Anki bulk export', () => {
     // catches the requests. (Live dev may have configured a non-default port.)
     await page.request.delete('http://localhost:3456/api/settings/ankiConnectUrl').catch(() => {});
 
+    // The sentence must contain the word (as real reader-mined vocab always
+    // does) — a cloze note without a {{c1::}} blank is invalid and rejected.
+    // Ending the sentence with the word + full stop regression-tests the
+    // trailing-punctuation cloze bug (#108).
+    const word = `e2etestword${Date.now().toString(36)}`;
     vocabId = await seedVocabEntry(
       page,
-      `e2etestword${Date.now().toString(36)}`,
-      'Dit is \'n e2e toets sin.',
+      word,
+      `Dit is 'n e2e toets sin met ${word}.`,
       'This is an e2e test sentence.'
     );
   });
@@ -182,6 +187,11 @@ test.describe('Vocab → Anki bulk export', () => {
     expect(addNote).toBeDefined();
     expect(addNote!.params?.note?.modelName).toBe('Cloze');
     expect(addNote!.params?.note?.deckName).toBe('Afrikaans::Cloze');
+
+    // The note must contain a real cloze blank, with the sentence-final
+    // punctuation outside it (#108).
+    const text = addNote!.params?.note?.fields?.Text ?? '';
+    expect(text).toMatch(/\{\{c1::e2etestword[a-z0-9]+\}\}\./);
   });
 
   test('card type choice persists to localStorage across reloads', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,11 +28,20 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
+  // Both servers run against an isolated DATA_DIR so the suite never touches
+  // the real data/lector.db (#110). reuseExistingServer is off for the same
+  // reason: an already-running dev server would be using the real data dir.
   webServer: [
     {
-      command: "npm run dev",
+      // Fresh DB every run — several specs assert empty-DB state (e.g.
+      // fluency expects totalKnownWords 0). The dictionary is re-copied since
+      // it's read-only test input. The Bun API opens the DB lazily, so there
+      // is no startup race with this wipe.
+      command:
+        "rm -rf tmp/e2e-data && mkdir -p tmp/e2e-data && (cp data/dictionary-af.db tmp/e2e-data/ 2>/dev/null || true) && npm run dev",
       url: "http://localhost:3456",
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
+      env: { DATA_DIR: "tmp/e2e-data" },
     },
     {
       // Hono API on :3457 — Next.js proxies /api/chat (and a few others) to it.
@@ -40,8 +49,9 @@ export default defineConfig({
       command: "bun run src/index.ts",
       cwd: "./api",
       url: "http://localhost:3457/health",
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 60_000,
+      env: { DATA_DIR: "../tmp/e2e-data" },
     },
   ],
 });

--- a/src/app/api/cloze/counts/route.ts
+++ b/src/app/api/cloze/counts/route.ts
@@ -20,7 +20,8 @@ export async function GET(request: NextRequest) {
       collection,
       COUNT(*) as total,
       SUM(CASE WHEN masteryLevel = 100 THEN 1 ELSE 0 END) as mastered,
-      SUM(CASE WHEN nextReview <= ? AND masteryLevel < 100 AND reviewCount > 0 THEN 1 ELSE 0 END) as due
+      -- Mastery-100 maintenance reviews count as due (issue #108)
+      SUM(CASE WHEN nextReview <= ? AND reviewCount > 0 THEN 1 ELSE 0 END) as due
     FROM clozeSentences
     WHERE (blacklisted = 0 OR blacklisted IS NULL) AND language = ?
     GROUP BY collection

--- a/src/app/api/cloze/due/route.ts
+++ b/src/app/api/cloze/due/route.ts
@@ -24,8 +24,10 @@ export async function GET(request: NextRequest) {
     query = 'SELECT * FROM clozeSentences WHERE reviewCount = 0 AND (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
     params.push(lang);
   } else if (mode === 'review') {
-    // Due for review (already seen at least once)
-    query = 'SELECT * FROM clozeSentences WHERE nextReview <= ? AND reviewCount > 0 AND masteryLevel < 100 AND (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
+    // Due for review (already seen at least once). Mastery-100 cards are
+    // included — the scheduler gives them a 14-day maintenance review, which
+    // could otherwise never be served (issue #108).
+    query = 'SELECT * FROM clozeSentences WHERE nextReview <= ? AND reviewCount > 0 AND (blacklisted = 0 OR blacklisted IS NULL) AND language = ?';
     params.push(now, lang);
   } else {
     // Default: all due

--- a/src/app/api/stats/fluency/route.ts
+++ b/src/app/api/stats/fluency/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/server/database';
 import { resolveLanguage } from '@/lib/server/active-language';
-
-function getTodayDate(): string {
-  return new Date().toISOString().split('T')[0];
-}
+import { getTodayDate } from '@/lib/server/dates';
+import { addDaysToDateString } from '@/lib/dates';
 
 // GET /api/stats/fluency - Get fluency benchmarks (word counts, CEFR level, growth)
 export async function GET(request: NextRequest) {
@@ -54,17 +52,9 @@ export async function GET(request: NextRequest) {
 
   // Weekly growth: words marked known in last 7 days vs previous 7 days
   const today = getTodayDate();
-  const d7 = new Date();
-  d7.setDate(d7.getDate() - 6);
-  const weekStart = d7.toISOString().split('T')[0];
-
-  const d14 = new Date();
-  d14.setDate(d14.getDate() - 13);
-  const prevWeekStart = d14.toISOString().split('T')[0];
-
-  const d8 = new Date();
-  d8.setDate(d8.getDate() - 7);
-  const prevWeekEnd = d8.toISOString().split('T')[0];
+  const weekStart = addDaysToDateString(today, -6);
+  const prevWeekStart = addDaysToDateString(today, -13);
+  const prevWeekEnd = addDaysToDateString(today, -7);
 
   const thisWeekRow = db.prepare(
     'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?'

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, DailyStatsRow, VocabRow } from '@/lib/server/database';
+import { getTodayDate } from '@/lib/server/dates';
+import { addDaysToDateString } from '@/lib/dates';
 
 // GET /api/stats - Get stats for date range
 export async function GET(request: NextRequest) {
@@ -15,10 +17,8 @@ export async function GET(request: NextRequest) {
     query += ' WHERE date BETWEEN ? AND ?';
     params.push(startDate, endDate);
   } else if (days) {
-    const d = new Date();
-    d.setDate(d.getDate() - parseInt(days) + 1);
-    const start = d.toISOString().split('T')[0];
-    const end = new Date().toISOString().split('T')[0];
+    const end = getTodayDate();
+    const start = addDaysToDateString(end, -(parseInt(days) - 1));
     query += ' WHERE date BETWEEN ? AND ?';
     params.push(start, end);
   }

--- a/src/app/api/stats/streak/route.ts
+++ b/src/app/api/stats/streak/route.ts
@@ -1,52 +1,22 @@
 import { NextResponse } from 'next/server';
 import { db, DailyStatsRow } from '@/lib/server/database';
+import { getTodayDate } from '@/lib/server/dates';
+import { activeDateSet, computeStreaks } from '@/lib/streak';
 
-function getTodayDate(): string {
-  return new Date().toISOString().split('T')[0];
-}
-
-// GET /api/stats/streak - Get current practice streak
+// GET /api/stats/streak - Current and longest study streak.
+//
+// One streak definition for the whole app (issue #108): a day is active when
+// it has any study activity (dictionary lookups, cloze practice, or reading
+// time), with day rollover in the configured time zone. The home page and
+// stats page both render from this endpoint instead of computing their own.
 export async function GET() {
   const today = getTodayDate();
 
-  // Get all daily stats ordered by date descending
   const rows = db.prepare(
-    'SELECT date, clozePracticed FROM dailyStats WHERE clozePracticed > 0 ORDER BY date DESC'
-  ).all() as Pick<DailyStatsRow, 'date' | 'clozePracticed'>[];
+    'SELECT date, dictionaryLookups, clozePracticed, minutesRead FROM dailyStats'
+  ).all() as Pick<DailyStatsRow, 'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead'>[];
 
-  if (rows.length === 0) {
-    return NextResponse.json({ streak: 0, practicedToday: false });
-  }
+  const { current, longest, activeToday } = computeStreaks(activeDateSet(rows), today);
 
-  const practicedDates = new Set(rows.map(r => r.date));
-  const practicedToday = practicedDates.has(today);
-
-  // Count consecutive days backwards from today (or yesterday if not practiced today)
-  let streak = 0;
-  const checkDate = new Date(today + 'T12:00:00'); // noon to avoid DST issues
-
-  if (practicedToday) {
-    streak = 1;
-    checkDate.setDate(checkDate.getDate() - 1);
-  } else {
-    // Check if yesterday had practice — if not, streak is 0
-    checkDate.setDate(checkDate.getDate() - 1);
-    const yesterday = checkDate.toISOString().split('T')[0];
-    if (!practicedDates.has(yesterday)) {
-      return NextResponse.json({ streak: 0, practicedToday: false });
-    }
-  }
-
-  // Count backwards
-  while (true) {
-    const dateStr = checkDate.toISOString().split('T')[0];
-    if (practicedDates.has(dateStr)) {
-      streak++;
-      checkDate.setDate(checkDate.getDate() - 1);
-    } else {
-      break;
-    }
-  }
-
-  return NextResponse.json({ streak, practicedToday });
+  return NextResponse.json({ streak: current, longest, practicedToday: activeToday });
 }

--- a/src/app/api/stats/today/route.ts
+++ b/src/app/api/stats/today/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, DailyStatsRow } from '@/lib/server/database';
-
-function getTodayDate(): string {
-  return new Date().toISOString().split('T')[0];
-}
+import { getTodayDate } from '@/lib/server/dates';
 
 // GET /api/stats/today - Get today's stats
 export async function GET() {

--- a/src/app/api/study-ping/route.ts
+++ b/src/app/api/study-ping/route.ts
@@ -1,9 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db, DailyStatsRow } from '@/lib/server/database';
-
-function getTodayDate(): string {
-  return new Date().toISOString().split('T')[0];
-}
+import { getTodayDate } from '@/lib/server/dates';
 
 // GET /api/study-ping
 // Returns whether any language study happened today.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ import {
   createStandaloneLesson,
   importEpub,
   getVocabStats,
-  getRecentStats,
+  getStreak,
   type Collection,
   type CollectionGroup,
 } from '@/lib/data-layer';
@@ -91,11 +91,11 @@ export default function Home() {
 
   async function loadData() {
     try {
-      const [collectionsData, groupsData, vocabStats, recentStats] = await Promise.all([
+      const [collectionsData, groupsData, vocabStats, streakData] = await Promise.all([
         getAllCollections(),
         getAllGroups(),
         getVocabStats(),
-        getRecentStats(30),
+        getStreak(),
       ]);
 
       setCollections(collectionsData);
@@ -107,43 +107,13 @@ export default function Home() {
         vocabStats.byState.known;
       setKnownWordsCount(knownCount);
 
-      const streak = calculateStreak(recentStats);
-      setCurrentStreak(streak);
+      // Unified server-side streak (issue #108) — one definition app-wide.
+      setCurrentStreak(streakData.streak);
     } catch (error) {
       console.error('Error loading data:', error);
     } finally {
       setIsLoading(false);
     }
-  }
-
-  function calculateStreak(stats: { date: string; dictionaryLookups: number }[]): number {
-    if (stats.length === 0) return 0;
-
-    const sorted = [...stats].sort((a, b) => b.date.localeCompare(a.date));
-
-    const today = new Date().toISOString().split('T')[0];
-    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
-
-    const hasActivityToday = sorted.some((s) => s.date === today && s.dictionaryLookups > 0);
-    const hasActivityYesterday = sorted.some(
-      (s) => s.date === yesterday && s.dictionaryLookups > 0
-    );
-
-    if (!hasActivityToday && !hasActivityYesterday) return 0;
-
-    let streak = 0;
-    let checkDate = hasActivityToday ? today : yesterday;
-
-    for (const stat of sorted) {
-      if (stat.date === checkDate && stat.dictionaryLookups > 0) {
-        streak++;
-        const prevDate = new Date(checkDate);
-        prevDate.setDate(prevDate.getDate() - 1);
-        checkDate = prevDate.toISOString().split('T')[0];
-      }
-    }
-
-    return streak;
   }
 
   async function handleImportClick() {

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -24,16 +24,10 @@ import { playCorrectSound, playIncorrectSound } from '@/lib/sounds';
 import { addClozeCard, isAnkiConnected } from '@/lib/anki';
 import { translateWord } from '@/lib/claude';
 import { lookupWordRemote, type ExpandedDictionaryEntry } from '@/lib/dictionary-client';
+import { splitTrailingPunctuation } from '@/lib/words';
 
 const ANKI_CLOZE_DECK_SETTING_KEY = 'lector-anki-cloze-deck';
 const DEFAULT_ANKI_CLOZE_DECK = 'Afrikaans::Cloze';
-
-// Strip trailing punctuation from a word, returning [cleanWord, punctuation]
-function splitTrailingPunctuation(word: string): [string, string] {
-  const match = word.match(/^(.+?)([.,!?;:'")\]]+)$/);
-  if (match) return [match[1], match[2]];
-  return [word, ''];
-}
 
 // Helper function to create blanked sentence, moving punctuation outside the blank
 function createBlankedSentence(sentence: string, wordIndex: number): string {
@@ -222,6 +216,19 @@ export default function PracticePage() {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const submittingRef = useRef(false);
+  // Pending MC feedback timer — must be cancelled on navigation/unmount so a
+  // stale closure can't record a review for a screen the user already left.
+  const mcTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearMcTimer = useCallback(() => {
+    if (mcTimerRef.current !== null) {
+      clearTimeout(mcTimerRef.current);
+      mcTimerRef.current = null;
+    }
+  }, []);
+
+  // Cancel any pending MC timer on unmount
+  useEffect(() => clearMcTimer, [clearMcTimer]);
 
   // Load collection counts and seed on mount
   useEffect(() => {
@@ -353,6 +360,7 @@ export default function PracticePage() {
 
   // Load next sentence from queue
   const loadNextSentence = useCallback((sentenceQueue: ClozeSentence[]) => {
+    clearMcTimer();
     if (sentenceQueue.length === 0) {
       setState('complete');
       return;
@@ -381,7 +389,7 @@ export default function PracticePage() {
     if (practiceMode === 'type') {
       setTimeout(() => inputRef.current?.focus(), 50);
     }
-  }, [practiceMode, generateMcOptionsForSentence]);
+  }, [practiceMode, generateMcOptionsForSentence, clearMcTimer]);
 
   // Start a round with explicit params (used by review buttons)
   const startRoundWith = useCallback(async (collection: ClozeCollection, type: RoundType, size: number) => {
@@ -496,13 +504,17 @@ export default function PracticePage() {
       newMastery = 0;
     }
 
-    const earnedPoints = isCorrect ? calculatePoints(previousMastery) : 0;
+    // No points in the retry phase — the answer was revealed when the card
+    // was first missed this round.
+    const earnedPoints = isCorrect && !isRetryPhase ? calculatePoints(previousMastery) : 0;
     const nextReview = calculateNextReview(newMastery);
 
     // Update database
     await updateClozeAfterReview(current.sentence.id, isCorrect, newMastery, nextReview);
     if (newMastery === 100) {
-      await updateWordState(current.sentence.clozeWord, 'known');
+      // Strip trailing punctuation so the reader's known-word lookup (clean,
+      // lowercased tokens) matches and fluency stats don't double-count.
+      await updateWordState(splitTrailingPunctuation(current.sentence.clozeWord)[0], 'known');
     }
     await incrementDailyStat('clozePracticed');
     if (earnedPoints > 0) {
@@ -534,8 +546,10 @@ export default function PracticePage() {
     if (isCorrect) {
       speak(current.sentence.sentence);
     } else {
-      // Add to retry queue so incorrect answers are re-tested
-      setRetryQueue(prev => [...prev, current.sentence]);
+      // Add to retry queue so incorrect answers are re-tested. The card was
+      // just demoted to mastery 0 in the DB — the queued copy must carry that,
+      // or the retry would promote it straight back from its old level.
+      setRetryQueue(prev => [...prev, { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel }]);
     }
   };
 
@@ -563,7 +577,8 @@ export default function PracticePage() {
 
     // Delay then submit (without duplicate sound)
     const delay = isCorrect ? 600 : 1200;
-    setTimeout(async () => {
+    mcTimerRef.current = setTimeout(async () => {
+      mcTimerRef.current = null;
       if (!current) return;
 
       const previousMastery = current.sentence.masteryLevel;
@@ -574,12 +589,16 @@ export default function PracticePage() {
         newMastery = 0;
       }
 
-      const earnedPoints = isCorrect ? calculatePoints(previousMastery) : 0;
+      // No points in the retry phase — the answer was revealed when the card
+      // was first missed this round.
+      const earnedPoints = isCorrect && !isRetryPhase ? calculatePoints(previousMastery) : 0;
       const nextReview = calculateNextReview(newMastery);
 
       await updateClozeAfterReview(current.sentence.id, isCorrect, newMastery, nextReview);
       if (newMastery === 100) {
-        await updateWordState(current.sentence.clozeWord, 'known');
+        // Strip trailing punctuation so the reader's known-word lookup (clean,
+        // lowercased tokens) matches and fluency stats don't double-count.
+        await updateWordState(splitTrailingPunctuation(current.sentence.clozeWord)[0], 'known');
       }
       await incrementDailyStat('clozePracticed');
       if (earnedPoints > 0) {
@@ -608,6 +627,10 @@ export default function PracticePage() {
 
       if (isCorrect) {
         speak(current.sentence.sentence);
+      } else {
+        // Re-test wrong answers at the end of the round, demoted to mastery 0
+        // (same as type mode).
+        setRetryQueue(prev => [...prev, { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel }]);
       }
     }, delay);
   }, [mcLocked, current, mcOptions, mcCorrectIdx, isRetryPhase]);
@@ -690,12 +713,13 @@ export default function PracticePage() {
     try {
       const deckName = localStorage.getItem(ANKI_CLOZE_DECK_SETTING_KEY) || DEFAULT_ANKI_CLOZE_DECK;
 
+      const cleanWord = splitTrailingPunctuation(current.sentence.clozeWord)[0];
       await addClozeCard(
         deckName,
         current.sentence.sentence,
-        current.sentence.clozeWord,
+        cleanWord,
         current.sentence.translation,
-        current.sentence.clozeWord
+        cleanWord
       );
       setAnkiAdded(true);
     } catch (error) {
@@ -854,7 +878,7 @@ export default function PracticePage() {
           <div className="mb-6">
             <div className="mb-2 flex items-center justify-between">
               <button
-                onClick={async () => { setState('setup'); const counts = await getCollectionCounts(); setCollectionCounts(counts); }}
+                onClick={async () => { clearMcTimer(); setState('setup'); const counts = await getCollectionCounts(); setCollectionCounts(counts); }}
                 className="text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors"
               >
                 &larr; Back

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -129,6 +129,12 @@ export default function SettingsPage() {
   const [googleTTSAvailable, setGoogleTTSAvailable] = useState<boolean | null>(null);
   const [showGoogleApiKey, setShowGoogleApiKey] = useState(false);
 
+  // Time zone state (server-side setting — drives day rollover for daily
+  // stats, streaks and review days; issue #108)
+  const [timezone, setTimezone] = useState<string>("");
+  const [timezones, setTimezones] = useState<string[]>([]);
+  const [browserTimeZone, setBrowserTimeZone] = useState<string>("");
+
   // API Token state
   const [apiTokens, setApiTokens] = useState<ApiTokenMeta[]>([]);
   const [showTokenForm, setShowTokenForm] = useState(false);
@@ -206,7 +212,25 @@ export default function SettingsPage() {
 
     // Load API tokens
     getApiTokens().then(setApiTokens).catch(() => {});
+
+    // Time zone: populate the IANA list and the saved value
+    setBrowserTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    const intlWithSupported = Intl as typeof Intl & {
+      supportedValuesOf?: (key: 'timeZone') => string[];
+    };
+    setTimezones(
+      intlWithSupported.supportedValuesOf ? intlWithSupported.supportedValuesOf('timeZone') : []
+    );
+    getSetting<string>('timezone').then((tz) => {
+      if (tz) setTimezone(tz);
+    });
   }, []);
+
+  // Save the day-rollover time zone ('' = auto, server's zone)
+  const saveTimezone = async (tz: string) => {
+    setTimezone(tz);
+    await setSetting('timezone', tz);
+  };
 
   // Check Anki connection
   const checkAnkiConnection = useCallback(async () => {
@@ -1593,6 +1617,36 @@ export default function SettingsPage() {
                 ))}
               </div>
             </div>
+          </section>
+
+          {/* Time Zone Section */}
+          <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+            <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              Time Zone
+            </h2>
+            <p className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+              Daily stats, streaks and review days roll over at midnight in this time zone.
+            </p>
+            <select
+              value={timezone}
+              onChange={(e) => saveTimezone(e.target.value)}
+              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            >
+              <option value="">Auto — server time zone</option>
+              {timezones.map((tz) => (
+                <option key={tz} value={tz}>
+                  {tz}
+                </option>
+              ))}
+            </select>
+            {browserTimeZone && timezone !== browserTimeZone && (
+              <button
+                onClick={() => saveTimezone(browserTimeZone)}
+                className="mt-3 text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                Use this device&apos;s time zone ({browserTimeZone})
+              </button>
+            )}
           </section>
 
           {/* API Tokens Section */}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -9,11 +9,14 @@ import {
   getAllClozeSentences,
   getCollectionCounts,
   getFluencyStats,
+  getStreak,
+  getSetting,
   type DailyStats,
   type WordState,
   type ClozeCollection,
   type FluencyStats,
 } from '@/lib/data-layer';
+import { addDaysToDateString, dateStringInTimeZone, isValidTimeZone } from '@/lib/dates';
 import ActivityHeatmap from '@/components/ActivityHeatmap';
 import VocabGrowthChart from '@/components/VocabGrowthChart';
 
@@ -330,82 +333,6 @@ function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
   );
 }
 
-// Helper function to calculate streak
-function calculateStreak(dailyStats: DailyStats[]): { current: number; longest: number } {
-  if (dailyStats.length === 0) return { current: 0, longest: 0 };
-
-  // Sort by date descending
-  const sorted = [...dailyStats].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
-
-  // Check if today or yesterday has activity
-  const today = new Date().toISOString().split('T')[0];
-  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
-
-  let currentStreak = 0;
-  let longestStreak = 0;
-  let tempStreak = 0;
-  let lastDate: Date | null = null;
-
-  // Calculate current streak
-  for (const stat of sorted) {
-    const hasActivity = stat.dictionaryLookups > 0 || stat.clozePracticed > 0;
-    if (!hasActivity) continue;
-
-    if (currentStreak === 0) {
-      // First active day must be today or yesterday
-      if (stat.date === today || stat.date === yesterday) {
-        currentStreak = 1;
-        lastDate = new Date(stat.date);
-      }
-    } else if (lastDate) {
-      const statDate = new Date(stat.date);
-      const dayDiff = Math.round(
-        (lastDate.getTime() - statDate.getTime()) / (1000 * 60 * 60 * 24)
-      );
-      if (dayDiff === 1) {
-        currentStreak++;
-        lastDate = statDate;
-      } else {
-        break;
-      }
-    }
-  }
-
-  // Calculate longest streak
-  lastDate = null;
-  for (const stat of sorted) {
-    const hasActivity = stat.dictionaryLookups > 0 || stat.clozePracticed > 0;
-    if (!hasActivity) {
-      longestStreak = Math.max(longestStreak, tempStreak);
-      tempStreak = 0;
-      lastDate = null;
-      continue;
-    }
-
-    const statDate = new Date(stat.date);
-    if (!lastDate) {
-      tempStreak = 1;
-      lastDate = statDate;
-    } else {
-      const dayDiff = Math.round(
-        (lastDate.getTime() - statDate.getTime()) / (1000 * 60 * 60 * 24)
-      );
-      if (dayDiff === 1) {
-        tempStreak++;
-        lastDate = statDate;
-      } else {
-        longestStreak = Math.max(longestStreak, tempStreak);
-        tempStreak = 1;
-        lastDate = statDate;
-      }
-    }
-  }
-  longestStreak = Math.max(longestStreak, tempStreak);
-
-  return { current: currentStreak, longest: longestStreak };
-}
 
 function SkeletonBlock({ className = '' }: { className?: string }) {
   return (
@@ -486,17 +413,23 @@ export default function StatsPage() {
   useEffect(() => {
     async function loadStats() {
       try {
-        const [vocabStats, collectionCounts, fluency] = await Promise.all([
+        const [vocabStats, collectionCounts, fluency, streakData, tzSetting] = await Promise.all([
           getVocabStats(),
           getCollectionCounts(),
           getFluencyStats(),
+          getStreak(),
+          getSetting<string>('timezone'),
         ]);
 
-        // Get all daily stats for the past year
-        const endDate = new Date().toISOString().split('T')[0];
-        const startDate = new Date();
-        startDate.setFullYear(startDate.getFullYear() - 1);
-        const startDateStr = startDate.toISOString().split('T')[0];
+        // Get all daily stats for the past year. "Today" is a calendar date
+        // in the configured time zone (falling back to this device's zone),
+        // not UTC — otherwise the window misses today's row before 10:00
+        // AEST (issue #108).
+        const timeZone = tzSetting && isValidTimeZone(tzSetting)
+          ? tzSetting
+          : Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const endDate = dateStringInTimeZone(new Date(), timeZone);
+        const startDateStr = addDaysToDateString(endDate, -365);
 
         const dailyStats = await getStatsForDateRange(startDateStr, endDate);
 
@@ -507,8 +440,9 @@ export default function StatsPage() {
         const clozeSentences = await getAllClozeSentences();
         const totalClozeCorrect = clozeSentences.reduce((sum, c) => sum + c.timesCorrect, 0);
 
-        // Calculate streaks
-        const { current: currentStreak, longest: longestStreak } = calculateStreak(dailyStats);
+        // Unified server-side streaks (issue #108) — one definition app-wide.
+        const currentStreak = streakData.streak;
+        const longestStreak = streakData.longest;
 
         // Build activity heatmap data (dictionary lookups per day)
         const activityData = dailyStats.map((d) => ({

--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -525,18 +525,34 @@ export default function VocabPage() {
       let updatedCount = 0;
       let matchedCount = 0;
 
-      // Update entries based on Anki intervals
+      // Update entries based on Anki intervals. Sync only ever *upgrades* a
+      // state (issue #108): a freshly-exported card has interval 0 and must
+      // not demote a word the user already marked known.
+      const stateRank: Record<WordState, number> = {
+        new: 0,
+        level1: 1,
+        level2: 2,
+        level3: 3,
+        level4: 4,
+        known: 5,
+        ignored: 5, // never overridden by sync
+      };
+
       for (const entry of entries) {
         const ankiData = wordStates.get(entry.text.toLowerCase());
         if (ankiData) {
           matchedCount++;
+          if (entry.state === "ignored") continue;
+          // New/relearning cards (interval < 1 day) carry no signal yet.
+          if (ankiData.interval < 1) continue;
+
           // Map interval to state:
-          // 0-1 days: level1
+          // 1 day: level1
           // 2-7 days: level2
           // 8-14 days: level3
           // 15-30 days: level4
           // 31+ days: known
-          let newState: WordState = entry.state;
+          let newState: WordState;
           if (ankiData.interval >= 31) {
             newState = "known";
           } else if (ankiData.interval >= 15) {
@@ -545,11 +561,11 @@ export default function VocabPage() {
             newState = "level3";
           } else if (ankiData.interval >= 2) {
             newState = "level2";
-          } else if (ankiData.interval >= 0) {
+          } else {
             newState = "level1";
           }
 
-          if (newState !== entry.state) {
+          if (stateRank[newState] > stateRank[entry.state]) {
             await updateVocabState(entry.id, newState);
             updatedCount++;
           }

--- a/src/lib/__tests__/dates.test.ts
+++ b/src/lib/__tests__/dates.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { dateStringInTimeZone, addDaysToDateString, isValidTimeZone } from '../dates';
+
+describe('dateStringInTimeZone', () => {
+  it('formats a UTC instant as the local calendar date (UTC+10, before local midnight)', () => {
+    // 13:59 UTC = 23:59 in Brisbane (UTC+10, no DST)
+    expect(dateStringInTimeZone(new Date('2026-06-10T13:59:00Z'), 'Australia/Brisbane')).toBe(
+      '2026-06-10'
+    );
+  });
+
+  it('rolls over at local midnight, not UTC midnight', () => {
+    // 14:00 UTC = 00:00 next day in Brisbane
+    expect(dateStringInTimeZone(new Date('2026-06-10T14:00:00Z'), 'Australia/Brisbane')).toBe(
+      '2026-06-11'
+    );
+  });
+
+  it('credits early-morning study to the correct local day (the issue #108 case)', () => {
+    // 09:00 Tuesday in Brisbane is 23:00 Monday UTC — UTC math credited this
+    // to Monday and broke streaks.
+    const tueMorning = new Date('2026-06-09T23:00:00Z');
+    expect(dateStringInTimeZone(tueMorning, 'Australia/Brisbane')).toBe('2026-06-10');
+    expect(dateStringInTimeZone(tueMorning, 'UTC')).toBe('2026-06-09');
+  });
+
+  it('matches toISOString for UTC', () => {
+    const d = new Date('2026-01-05T07:30:00Z');
+    expect(dateStringInTimeZone(d, 'UTC')).toBe('2026-01-05');
+  });
+});
+
+describe('addDaysToDateString', () => {
+  it('subtracts across month boundaries', () => {
+    expect(addDaysToDateString('2026-03-01', -1)).toBe('2026-02-28');
+  });
+
+  it('handles leap years', () => {
+    expect(addDaysToDateString('2024-02-28', 1)).toBe('2024-02-29');
+  });
+
+  it('adds across year boundaries', () => {
+    expect(addDaysToDateString('2026-12-31', 1)).toBe('2027-01-01');
+  });
+
+  it('is identity for zero days', () => {
+    expect(addDaysToDateString('2026-06-10', 0)).toBe('2026-06-10');
+  });
+});
+
+describe('isValidTimeZone', () => {
+  it('accepts IANA zones', () => {
+    expect(isValidTimeZone('Australia/Brisbane')).toBe(true);
+    expect(isValidTimeZone('UTC')).toBe(true);
+  });
+
+  it('rejects junk and empty values', () => {
+    expect(isValidTimeZone('Not/AZone')).toBe(false);
+    expect(isValidTimeZone('')).toBe(false);
+  });
+});

--- a/src/lib/__tests__/streak.test.ts
+++ b/src/lib/__tests__/streak.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { computeStreaks, isActiveDay, activeDateSet } from '../streak';
+
+describe('computeStreaks', () => {
+  it('counts consecutive days through today (the Mon/Tue/Wed issue #108 case)', () => {
+    const active = new Set(['2026-06-08', '2026-06-09', '2026-06-10']);
+    expect(computeStreaks(active, '2026-06-10')).toEqual({
+      current: 3,
+      longest: 3,
+      activeToday: true,
+    });
+  });
+
+  it('keeps the streak alive when today has no activity yet', () => {
+    const active = new Set(['2026-06-08', '2026-06-09']);
+    expect(computeStreaks(active, '2026-06-10')).toEqual({
+      current: 2,
+      longest: 2,
+      activeToday: false,
+    });
+  });
+
+  it('resets current after a full missed day, but longest remembers the run', () => {
+    const active = new Set(['2026-06-05', '2026-06-06', '2026-06-07']);
+    const result = computeStreaks(active, '2026-06-10');
+    expect(result.current).toBe(0);
+    expect(result.longest).toBe(3);
+  });
+
+  it('finds the longest run among several', () => {
+    const active = new Set([
+      '2026-06-01',
+      '2026-06-02',
+      '2026-06-03',
+      '2026-06-06',
+      '2026-06-09',
+      '2026-06-10',
+    ]);
+    expect(computeStreaks(active, '2026-06-10')).toEqual({
+      current: 2,
+      longest: 3,
+      activeToday: true,
+    });
+  });
+
+  it('handles month boundaries inside a run', () => {
+    const active = new Set(['2026-02-28', '2026-03-01']);
+    expect(computeStreaks(active, '2026-03-01').current).toBe(2);
+  });
+
+  it('returns zeros for no activity', () => {
+    expect(computeStreaks(new Set(), '2026-06-10')).toEqual({
+      current: 0,
+      longest: 0,
+      activeToday: false,
+    });
+  });
+});
+
+describe('isActiveDay', () => {
+  it('counts any study activity', () => {
+    expect(isActiveDay({ date: 'd', dictionaryLookups: 1 })).toBe(true);
+    expect(isActiveDay({ date: 'd', clozePracticed: 5 })).toBe(true);
+    expect(isActiveDay({ date: 'd', minutesRead: 12 })).toBe(true);
+  });
+
+  it('is false for zero or missing activity', () => {
+    expect(isActiveDay({ date: 'd', dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0 })).toBe(false);
+    expect(isActiveDay({ date: 'd' })).toBe(false);
+    expect(isActiveDay({ date: 'd', dictionaryLookups: null, minutesRead: null })).toBe(false);
+  });
+});
+
+describe('activeDateSet', () => {
+  it('keeps only active days', () => {
+    const set = activeDateSet([
+      { date: '2026-06-09', clozePracticed: 3 },
+      { date: '2026-06-10', dictionaryLookups: 0, clozePracticed: 0 },
+    ]);
+    expect(set.has('2026-06-09')).toBe(true);
+    expect(set.has('2026-06-10')).toBe(false);
+  });
+});

--- a/src/lib/__tests__/words.test.ts
+++ b/src/lib/__tests__/words.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { splitTrailingPunctuation } from '../words';
+import { buildClozeText } from '../anki';
+
+describe('splitTrailingPunctuation', () => {
+  it('splits a single trailing mark', () => {
+    expect(splitTrailingPunctuation('haar.')).toEqual(['haar', '.']);
+    expect(splitTrailingPunctuation('sê!')).toEqual(['sê', '!']);
+  });
+
+  it('splits runs of trailing punctuation', () => {
+    expect(splitTrailingPunctuation('word.,')).toEqual(['word', '.,']);
+    expect(splitTrailingPunctuation('reg?"')).toEqual(['reg', '?"']);
+  });
+
+  it('returns clean words unchanged', () => {
+    expect(splitTrailingPunctuation('hond')).toEqual(['hond', '']);
+  });
+
+  it("keeps the Afrikaans 'n contraction intact", () => {
+    expect(splitTrailingPunctuation("'n")).toEqual(["'n", '']);
+  });
+});
+
+describe('buildClozeText', () => {
+  it('builds a cloze for a bank word with trailing punctuation (issue #108)', () => {
+    // "gelees." as stored in the bank previously produced \bgelees\.\b, which
+    // never matches — the note had no {{c1::}} and AnkiConnect rejected it.
+    expect(buildClozeText('Hy het die boek gelees.', 'gelees.')).toBe(
+      'Hy het die boek {{c1::gelees}}.'
+    );
+  });
+
+  it('keeps punctuation outside the blank for mid-sentence words', () => {
+    expect(buildClozeText('Sy het haar boek gelees.', 'haar.')).toBe(
+      'Sy het {{c1::haar}} boek gelees.'
+    );
+  });
+
+  it('preserves the original casing via the capture group', () => {
+    expect(buildClozeText('Haar boek is hier.', 'haar.')).toBe('{{c1::Haar}} boek is hier.');
+  });
+
+  it('returns the sentence unchanged when the word is absent', () => {
+    expect(buildClozeText('Geen ooreenkoms hier nie.', 'afwesig')).toBe(
+      'Geen ooreenkoms hier nie.'
+    );
+  });
+});

--- a/src/lib/anki.ts
+++ b/src/lib/anki.ts
@@ -6,6 +6,8 @@
 // The URL is overridable via the `ankiConnectUrl` setting so a user with a
 // remote Anki install (e.g. over Tailscale) can point at http://100.x.x.x:8765.
 
+import { splitTrailingPunctuation } from './words';
+
 const DEFAULT_ANKI_CONNECT_URL = 'http://localhost:8765';
 
 let _cachedUrl: string | null = null;
@@ -143,9 +145,13 @@ export async function addBasicCard(
 
   await ensureDeckExists(deckName);
 
+  // Bank words can carry trailing punctuation ("haar.") which would make the
+  // \b…\b pattern unmatchable — match and display the clean form (#68, #108).
+  const [cleanTarget] = splitTrailingPunctuation(targetWord);
+
   // Highlight the target word in the sentence
   const highlightedSentence = sentence.replace(
-    new RegExp(`\\b(${escapeRegex(targetWord)})\\b`, "gi"),
+    new RegExp(`\\b(${escapeRegex(cleanTarget)})\\b`, "gi"),
     "<b>$1</b>"
   );
 
@@ -154,8 +160,8 @@ export async function addBasicCard(
       deckName,
       modelName: "Basic",
       fields: {
-        Front: `${highlightedSentence}<br><br><small>Word: <b>${targetWord}</b></small>`,
-        Back: `${translation}<br><br><b>${targetWord}</b> = ${wordMeaning}`,
+        Front: `${highlightedSentence}<br><br><small>Word: <b>${cleanTarget}</b></small>`,
+        Back: `${translation}<br><br><b>${cleanTarget}</b> = ${wordMeaning}`,
       },
       options: {
         allowDuplicate: true, // Allow duplicates - same word from different sentences is fine
@@ -171,6 +177,21 @@ export async function addBasicCard(
 
   console.log(`[Anki] Successfully added basic note with ID: ${noteId}`);
   return noteId;
+}
+
+/**
+ * Build the cloze-deletion text for a sentence. Strips trailing punctuation
+ * from the target first — bank words can carry it ("haar."), which would make
+ * the \b…\b pattern unmatchable and produce a cloze-less note that
+ * AnkiConnect rejects (#68, #108). Punctuation stays outside the blank.
+ * Exported for tests.
+ */
+export function buildClozeText(sentence: string, targetWord: string): string {
+  const [cleanTarget] = splitTrailingPunctuation(targetWord);
+  return sentence.replace(
+    new RegExp(`\\b(${escapeRegex(cleanTarget)})\\b`, "gi"),
+    "{{c1::$1}}"
+  );
 }
 
 /**
@@ -193,11 +214,14 @@ export async function addClozeCard(
 
   await ensureDeckExists(deckName);
 
-  // Create cloze deletion by replacing the target word
-  const clozeText = sentence.replace(
-    new RegExp(`\\b(${escapeRegex(targetWord)})\\b`, "gi"),
-    "{{c1::$1}}"
-  );
+  const [cleanTarget] = splitTrailingPunctuation(targetWord);
+  const clozeText = buildClozeText(sentence, targetWord);
+
+  // A note without a {{c1::…}} blank is invalid — fail with a clear message
+  // instead of letting AnkiConnect reject it opaquely.
+  if (!clozeText.includes('{{c1::')) {
+    throw new Error(`Could not build cloze: "${cleanTarget}" not found in sentence`);
+  }
 
   console.log(`[Anki] Cloze text: ${clozeText}`);
 
@@ -207,7 +231,7 @@ export async function addClozeCard(
       modelName: "Cloze",
       fields: {
         Text: `${clozeText}<br><br><small>Translation: ${translation}</small>`,
-        Extra: `<b>${targetWord}</b> = ${wordMeaning}`,
+        Extra: `<b>${cleanTarget}</b> = ${wordMeaning}`,
       },
       options: {
         allowDuplicate: true, // Allow duplicates - user may want the same word from different sentences

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -522,7 +522,7 @@ export async function getCollectionCounts(): Promise<Record<ClozeCollection, { t
   return res.json();
 }
 
-export async function getStreak(): Promise<{ streak: number; practicedToday: boolean }> {
+export async function getStreak(): Promise<{ streak: number; longest: number; practicedToday: boolean }> {
   const res = await fetch(`/api/stats/streak${langParam()}`);
   return res.json();
 }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,34 @@
+// Pure date helpers shared by client and server code.
+// Mirrored for the Bun API in api/src/lib/dates.ts (the two servers share the
+// SQLite file but not source — same pattern as the crypto module).
+//
+// All "day" boundaries in Lector (daily stats, streaks) are calendar dates in
+// the user's configured time zone — never raw UTC (issue #108).
+
+export function isValidTimeZone(timeZone: string): boolean {
+  if (!timeZone) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Format a Date as YYYY-MM-DD in the given IANA time zone. */
+export function dateStringInTimeZone(date: Date, timeZone: string): string {
+  // The en-CA locale formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+/** Add days to a YYYY-MM-DD string. Calendar math only — time-zone independent. */
+export function addDaysToDateString(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00Z'); // noon UTC avoids DST edge cases
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().split('T')[0];
+}

--- a/src/lib/server/dates.ts
+++ b/src/lib/server/dates.ts
@@ -1,0 +1,31 @@
+import { db } from './database';
+import { dateStringInTimeZone, isValidTimeZone } from '@/lib/dates';
+
+// Day-rollover time zone for daily stats and streaks. Configurable via the
+// `timezone` setting (Settings → Time Zone); falls back to the server's local
+// zone. Mirrored in api/src/lib/dates.ts.
+
+export function getConfiguredTimeZone(): string {
+  try {
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('timezone') as
+      | { value: string }
+      | undefined;
+    if (row) {
+      let value: unknown = row.value;
+      try {
+        value = JSON.parse(row.value);
+      } catch {
+        // legacy raw-string value
+      }
+      if (typeof value === 'string' && isValidTimeZone(value)) return value;
+    }
+  } catch {
+    // fall through to the server zone
+  }
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/** Today's date (YYYY-MM-DD) in the configured time zone. */
+export function getTodayDate(): string {
+  return dateStringInTimeZone(new Date(), getConfiguredTimeZone());
+}

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,0 +1,67 @@
+// Single source of truth for streak math (issue #108 — the app previously had
+// three conflicting streak definitions). Mirrored in api/src/lib/streak.ts.
+//
+// A day counts toward the streak when any study activity happened: a
+// dictionary lookup, cloze practice, or reading time.
+
+import { addDaysToDateString } from './dates';
+
+export interface DailyActivityRow {
+  date: string;
+  dictionaryLookups?: number | null;
+  clozePracticed?: number | null;
+  minutesRead?: number | null;
+}
+
+export function isActiveDay(row: DailyActivityRow): boolean {
+  return (
+    (row.dictionaryLookups ?? 0) > 0 ||
+    (row.clozePracticed ?? 0) > 0 ||
+    (row.minutesRead ?? 0) > 0
+  );
+}
+
+export function activeDateSet(rows: DailyActivityRow[]): Set<string> {
+  const set = new Set<string>();
+  for (const row of rows) {
+    if (isActiveDay(row)) set.add(row.date);
+  }
+  return set;
+}
+
+export interface StreakResult {
+  current: number;
+  longest: number;
+  activeToday: boolean;
+}
+
+/**
+ * Compute current and longest streaks from a set of active YYYY-MM-DD dates.
+ * `today` must already be expressed in the user's configured time zone.
+ * A current streak survives until a full configured-TZ day passes with no
+ * activity: if today is inactive, counting starts from yesterday.
+ */
+export function computeStreaks(activeDates: Set<string>, today: string): StreakResult {
+  const activeToday = activeDates.has(today);
+
+  let current = 0;
+  let cursor = activeToday ? today : addDaysToDateString(today, -1);
+  while (activeDates.has(cursor)) {
+    current++;
+    cursor = addDaysToDateString(cursor, -1);
+  }
+
+  let longest = 0;
+  for (const date of activeDates) {
+    if (activeDates.has(addDaysToDateString(date, -1))) continue; // not a run start
+    let length = 1;
+    let next = addDaysToDateString(date, 1);
+    while (activeDates.has(next)) {
+      length++;
+      next = addDaysToDateString(next, 1);
+    }
+    if (length > longest) longest = length;
+  }
+
+  return { current, longest, activeToday };
+}

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -1,0 +1,11 @@
+// Shared word-token helpers.
+// Part of the cloze sentence bank stores clozeWords with trailing punctuation
+// attached (e.g. "haar."), so anything matching, displaying, or persisting a
+// cloze word must strip it first (issues #68, #108).
+
+/** Strip trailing punctuation from a word, returning [cleanWord, punctuation]. */
+export function splitTrailingPunctuation(word: string): [string, string] {
+  const match = word.match(/^(.+?)([.,!?;:'")\]]+)$/);
+  if (match) return [match[1], match[2]];
+  return [word, ''];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['**/node_modules/**', '**/.claude/worktrees/**', '**/e2e/**'],
+    // api/ tests are written for bun:test and run via `bun test` (#110)
+    exclude: ['**/node_modules/**', '**/.claude/worktrees/**', '**/e2e/**', '**/api/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #108.

Fixes all nine verified learning-loop bugs, with the day-rollover time zone made **user-configurable** (Settings → Time Zone) rather than hardcoded.

## High

- **UTC day-rollover → configured-TZ day-rollover.** One shared helper pair (`src/lib/server/dates.ts` + `api/src/lib/dates.ts`, pure math in `src/lib/dates.ts`) replaces all six `toISOString().split('T')[0]` sites — plus two more the issue didn't list (`/api/stats` days-window, `/api/stats/fluency` weekly windows, both servers). The zone comes from the new `timezone` setting (IANA dropdown in Settings, "Auto — server time zone" default, one-click "use this device's zone"). Stats-page date windows are TZ-aware client-side too.
- **Retry no longer re-promotes failed cards.** The object pushed to `retryQueue` now carries `masteryLevel: 0` (matching what was just written to the DB), and retry-phase answers award **no points** — the answer was revealed on the miss. Applied to both type and MC paths.
- **Anki cloze/highlight punctuation.** `splitTrailingPunctuation` moved to shared `src/lib/words.ts`; `addClozeCard`/`addBasicCard` strip the target before building the `\b…\b` regex, so the ~26% of bank words like `"haar."` now produce a valid `{{c1::…}}` (punctuation stays outside the blank). A guard throws a clear error if no cloze was built instead of letting AnkiConnect reject opaquely. Root cause #68.

## Medium

- **Mastery-100 known-marking normalised** — `updateWordState` now receives the clean token, so reader highlighting matches and fluency stats stop double-counting `haar` / `haar.`.
- **Anki sync only upgrades** — state-rank guard; interval-0/new cards are a no-op; `ignored` is never touched. Export-then-sync no longer wipes known states.
- **Mastery-100 maintenance reviews are served** — removed the `masteryLevel < 100` filter from the review query and due counts; the 14-day maintenance review the scheduler already writes can now actually happen.
- **One streak definition** (`computeStreaks` in `src/lib/streak.ts`, mirrored for the Bun API): a day is active if it has any lookups, practice, or reading minutes; rollover in the configured TZ. `/api/stats/streak` (both servers) returns `{streak, longest, practicedToday}`; home and stats pages render from it and their three divergent local implementations are deleted.
- **CLAUDE.md** now documents the live SRS behaviour (exact-time scheduling, hard reset on miss, no-points retries, TZ-aware rollover). `src/lib/srs.ts` deletion stays in #114.

## Lower

- **MC mode re-queues wrong answers** (parity with type mode, demoted copy).
- **MC feedback timer is cancelled** on Back/unmount/next-question via a ref — a stale closure can no longer record a review and force the feedback screen after navigation. Relates #72.

## Test-infra (pulled from #110 — the two lines needed to verify this PR safely)

- `vitest.config.ts` excludes `api/**` (bun:test files), so `npm test` passes for the first time.
- `playwright.config.ts` runs both servers with `DATA_DIR=tmp/e2e-data` and `reuseExistingServer: false` — the suite can never touch the real `data/lector.db` again, including via an already-running dev server. The data dir is wiped and the dictionary re-copied each run (several specs assert empty-DB state, e.g. fluency's `totalKnownWords === 0` — they only ever passed against the live DB by coincidence). The rest of #110 (CI jobs, `bun test` script) is untouched.
- The Anki-export spec seeded a vocab entry whose sentence didn't contain the word — the old code shipped that broken (cloze-less) note to the mock, which accepted it; real AnkiConnect rejects it, which is the #108 bug. The fixture now embeds the word sentence-finally with a full stop, and the spec asserts the note contains `{{c1::word}}` with the punctuation outside — a direct regression test for the cloze fix.

## Verification

- `npx tsc --noEmit` clean; `npm run lint` 0 errors (24 pre-existing warnings in untouched files).
- `npm test`: 51 passed — includes new unit suites for the date helpers (UTC+10 rollover cases from the issue), streak math (Mon/Tue/Wed scenario, longest-run, month boundaries), and cloze building (`"gelees."` → `{{c1::gelees}}.`).
- Bun API smoke-tested against a `sqlite3 .backup` copy of the real DB with `timezone = Australia/Brisbane`: `/api/stats/today` returned `date: 2026-06-11` while UTC was still June 10 — the exact failure mode from the issue, fixed.
- E2E (isolated data dir): **140 passed, 0 failed** (1 pre-existing translation-drawer flake passed on retry, 1 skipped, 5.8m). Along the way the suite caught two latent infra issues, both fixed here: the Anki-export fixture shipped an invalid cloze-less note that only the mock accepted (details below), and specs asserting empty-DB state only ever passed against the live dev DB by coincidence (hence the per-run reset). Manually tested end-to-end by @heuwels.

**Observed while testing (pre-existing, not fixed here):** on a completely fresh `DATA_DIR`, the Bun API 500s until the Next server has created the schema (`migrateAddLanguageColumn` assumes `journal_entries` exists) — more evidence for #112's bootstrap-ordering problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
