### PR TITLE
ci(test): run unit suites in CI + e2e against the production image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,27 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  api-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+        working-directory: api
+      - run: bun test
+        working-directory: api
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -71,5 +92,59 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+  # The dev-mode e2e job above exercises `next dev` + Bun from source. This one
+  # runs the same suite against the production artifact — the standalone Next
+  # build + docker-entrypoint.sh — so INTERNAL_API_URL proxying and standalone
+  # packaging are covered before a release image is ever cut (#110).
+  e2e-docker:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - uses: docker/setup-buildx-action@v3
+      - name: Build production image
+        # Same cache scope as docker.yml's amd64 build, so PR builds reuse
+        # master's layer cache (the dictionary is baked in by the Dockerfile).
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          push: false
+          tags: lector:e2e
+          platforms: linux/amd64
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
+      - name: Start container
+        # No volume mount: /app/data starts empty, matching the fresh DB the
+        # dev-mode webServer guarantees. Container :3000 maps to host :3456,
+        # the origin the e2e specs hardcode.
+        run: docker run -d --name lector-e2e -p 3456:3000 lector:e2e
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Wait for app
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3456 > /dev/null; then exit 0; fi
+            sleep 2
+          done
+          echo "App did not become ready in 60s" >&2
+          docker logs lector-e2e
+          exit 1
+      - name: Run e2e suite against the image
+        run: E2E_EXTERNAL_SERVER=1 npm run test:e2e
+      - name: Dump container logs
+        if: failure()
+        run: docker logs lector-e2e
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-docker
           path: playwright-report/
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [master]
 
+# Dictionary release pinned to the same version the Dockerfile uses. Bump
+# together when a new dict release is published via scripts/release-dict.sh.
+env:
+  DICT_VERSION: dict-2026-06-06
+  DICT_SHA256: 652df8d15e0678ead3b25ce0a021776d428256673df15b16e3e04cfe9b284a78
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -36,6 +42,15 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Fetch on-device dictionary
+        # dictionary-db.test.ts is an integration test over the real (gitignored)
+        # dictionary — without this the whole vitest run fails in beforeAll.
+        run: |
+          mkdir -p data
+          curl -fL --retry 3 \
+            "https://github.com/heuwels/lector/releases/download/${DICT_VERSION}/dictionary-af.db" \
+            -o data/dictionary-af.db
+          echo "${DICT_SHA256}  data/dictionary-af.db" | sha256sum -c -
       - run: npm test
 
   api-tests:
@@ -45,7 +60,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
         working-directory: api
-      - run: bun test
+      # bun run test, not bare bun test — the script isolates DATA_DIR
+      - run: bun run test
         working-directory: api
 
   build:
@@ -62,11 +78,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     needs: [build]
-    # Pinned to the same release the Dockerfile uses. Bump together when a new
-    # dict release is published via scripts/release-dict.sh.
-    env:
-      DICT_VERSION: dict-2026-06-06
-      DICT_SHA256: 652df8d15e0678ead3b25ce0a021776d428256673df15b16e3e04cfe9b284a78
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,11 @@ jobs:
       - name: Start container
         # No volume mount: /app/data starts empty, matching the fresh DB the
         # dev-mode webServer guarantees. Container :3000 maps to host :3456,
-        # the origin the e2e specs hardcode.
-        run: docker run -d --name lector-e2e -p 3456:3000 lector:e2e
+        # the origin the e2e specs hardcode. host-gateway lets the in-container
+        # Bun API reach test stubs on the runner (lmstudio-chat.spec.ts).
+        run: |
+          docker run -d --name lector-e2e -p 3456:3000 \
+            --add-host=host.docker.internal:host-gateway lector:e2e
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: Wait for app

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ next-env.d.ts
 # Hono API (Bun)
 /api/node_modules
 /api/bun.lock
+/api/.test-data/

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ next-env.d.ts
 /data/
 .env
 
+# Isolated e2e data dir (playwright.config.ts webServer)
+/tmp/
+
 # Hono API (Bun)
 /api/node_modules
 /api/bun.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,11 @@ Every new feature MUST be accompanied by:
   - Edge cases (empty states, error handling, boundary conditions)
 
 Tests live in:
-- `e2e/` - Playwright end-to-end tests
-- Run with: `npm run test:e2e`
+- `src/**/*.test.ts` - vitest unit tests — run with `npm test`
+- `api/src/**/*.test.ts` - bun:test unit tests — run with `cd api && bun test` (vitest excludes `api/**`; don't mix the two runners)
+- `e2e/` - Playwright end-to-end tests — run with `npm run test:e2e` (boots both servers against an isolated `tmp/e2e-data`, never the real `data/`)
+
+CI runs all of these, plus the e2e suite a second time against the production Docker image (`E2E_EXTERNAL_SERVER=1` with the container mapped to :3456) to cover the standalone build and `docker-entrypoint.sh`.
 
 ## Tech Stack
 

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
-    "test": "bun test"
+    "test": "rm -rf .test-data && DATA_DIR=.test-data bun test"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.114",

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "bun run --watch src/index.ts",
-    "start": "bun run src/index.ts"
+    "start": "bun run src/index.ts",
+    "test": "bun test"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.114",

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -179,6 +179,9 @@ function migrateAddLanguageColumn(database: Database) {
 
   for (const table of tablesToMigrate) {
     const cols = database.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+    // Empty = table doesn't exist in this server's schema (journal_entries is
+    // created by the Next side only) — nothing to migrate, and ALTER would throw.
+    if (cols.length === 0) continue;
     if (!cols.some(c => c.name === 'language')) {
       database.exec(`ALTER TABLE ${table} ADD COLUMN language TEXT NOT NULL DEFAULT 'af'`);
     }

--- a/e2e/lmstudio-chat.spec.ts
+++ b/e2e/lmstudio-chat.spec.ts
@@ -8,6 +8,15 @@ interface CapturedRequest {
   body: unknown;
 }
 
+// The Bun API fetches lmstudioUrl server-side. Under E2E_EXTERNAL_SERVER the
+// API runs inside the Docker container, where 127.0.0.1 is the container — the
+// stub must bind all interfaces and advertise host.docker.internal instead
+// (resolved natively by Docker Desktop; Linux CI passes
+// --add-host=host.docker.internal:host-gateway on the docker run).
+const EXTERNAL = !!process.env.E2E_EXTERNAL_SERVER;
+const STUB_BIND_HOST = EXTERNAL ? "0.0.0.0" : "127.0.0.1";
+const STUB_ADVERTISED_HOST = EXTERNAL ? "host.docker.internal" : "127.0.0.1";
+
 /**
  * Spin up an in-process stub that pretends to be LM Studio. Captures incoming
  * requests so the test can assert on what lector sent (previous_response_id,
@@ -37,10 +46,10 @@ function startStub(handler: (req: CapturedRequest) => { status: number; body: un
         res.end(JSON.stringify(out.body));
       });
     });
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, STUB_BIND_HOST, () => {
       const port = (server.address() as AddressInfo).port;
       resolve({
-        url: `http://127.0.0.1:${port}`,
+        url: `http://${STUB_ADVERTISED_HOST}:${port}`,
         captured,
         close: () => new Promise<void>((r) => server.close(() => r())),
       });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// E2E_EXTERNAL_SERVER=1 — the app is already running at localhost:3456 (e.g.
+// the production Docker image with `-p 3456:3000`) and Playwright must not
+// spawn the dev servers. The server must be FRESH: several specs assert
+// empty-DB state, which `webServer` otherwise guarantees by wiping
+// tmp/e2e-data. Specs hardcode the localhost:3456 origin, so the external
+// server has to be mapped there — a different origin is not supported.
+const externalServer = !!process.env.E2E_EXTERNAL_SERVER;
+
 export default defineConfig({
   testDir: "./e2e",
   globalSetup: "./e2e/global-setup.ts",
@@ -31,7 +39,7 @@ export default defineConfig({
   // Both servers run against an isolated DATA_DIR so the suite never touches
   // the real data/lector.db (#110). reuseExistingServer is off for the same
   // reason: an already-running dev server would be using the real data dir.
-  webServer: [
+  webServer: externalServer ? undefined : [
     {
       // Fresh DB every run — several specs assert empty-DB state (e.g.
       // fluency expects totalKnownWords 0). The dictionary is re-copied since


### PR DESCRIPTION
Closes #110.

Two of the three checkboxes were partially landed with #132 (vitest excludes `api/**`; e2e runs against an isolated `DATA_DIR=tmp/e2e-data`). This PR finishes the issue:

## `api/` tests get a runner
- `api/package.json` gains `"test": "bun test"` — the four `bun:test` files (~440 lines of LLM-provider tests, 48 tests) previously ran nowhere.

## CI runs the unit suites
- **`unit-tests`** job: `npm test` (vitest, 51 tests) — was never run in CI.
- **`api-tests`** job: `bun test` in `api/` — ditto.

## CI tests the production artifact
- **`e2e-docker`** job: builds the production image (same GHA cache scope as `docker.yml`'s amd64 build), starts it with container `:3000` mapped to host `:3456`, and runs the full Playwright suite against it. This covers the standalone Next build, `docker-entrypoint.sh`, and `INTERNAL_API_URL` proxying — none of which the dev-mode e2e job exercises.
- `playwright.config.ts` gains an `E2E_EXTERNAL_SERVER=1` mode that skips the `webServer` spawn when the app is already running at `localhost:3456` (the origin the specs hardcode). A fresh container has an empty `/app/data`, matching the fresh-DB guarantee the dev-mode `webServer` provides by wiping `tmp/e2e-data`.

## First catch by the new job
Running the suite against the image locally immediately failed `lmstudio-chat.spec.ts` (both tests): the spec stubs LM Studio on `127.0.0.1` and the Bun API fetches that URL **server-side** — from inside the container, `127.0.0.1` is the container. Under `E2E_EXTERNAL_SERVER` the stub now binds `0.0.0.0` and advertises `host.docker.internal` (native on Docker Desktop; the CI `docker run` adds `--add-host=host.docker.internal:host-gateway` for Linux runners). Dev mode is unchanged — both hosts stay `127.0.0.1` there.

## Housekeeping
- `/tmp/` added to `.gitignore` — the isolated e2e data dir was committable.
- `CLAUDE.md` testing section now lists all three suites and their runners.

## Verification (local)
- `npm test` — 51 passed
- `cd api && bun test` — 48 passed
- `npx playwright test` (dev mode) — **141 passed, 1 skipped, 0 failed**
- `E2E_EXTERNAL_SERVER=1 npx playwright test` against the locally-built production image (fresh container) — **141 passed, 1 skipped, 0 failed** (2.5m)

Not done here (possible follow-up): `release.yml` duplicates the CI jobs and could grow the same three; `tsc` still excludes `api/` (deliberate since `0f707af`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
