### PR TITLE
feat(stats): Words Read card, composite activity heatmap, growth range selector

### DIFF
--- a/e2e/activity-heatmap.spec.ts
+++ b/e2e/activity-heatmap.spec.ts
@@ -5,7 +5,7 @@ test.describe("Activity Heatmap", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
   });
 
-  test("renders on stats page with lookup-based total", async ({ page }) => {
+  test("renders on stats page with an activity total", async ({ page }) => {
     await page.goto("/stats");
     await page.waitForLoadState("networkidle");
 
@@ -14,7 +14,7 @@ test.describe("Activity Heatmap", () => {
 
     const total = page.locator('[data-testid="activity-heatmap-total"]');
     await expect(total).toBeVisible();
-    await expect(total).toHaveText(/^\d[\d,]*\s+lookups in the last year$/);
+    await expect(total).toHaveText(/^\d[\d,]*\s+actions in the last year$/);
   });
 
   test("reflects new dictionary lookups after a reload", async ({ page }) => {
@@ -29,6 +29,34 @@ test.describe("Activity Heatmap", () => {
     for (let i = 0; i < bump; i++) {
       const res = await page.request.put("/api/stats/today", {
         data: { field: "dictionaryLookups", amount: 1 },
+      });
+      expect(res.ok()).toBeTruthy();
+    }
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const updatedText = (await total.textContent()) ?? "";
+    const updatedCount = parseInt(updatedText.replace(/[^\d]/g, ""), 10) || 0;
+    expect(updatedCount).toBe(initialCount + bump);
+  });
+
+  test("counts cloze reviews toward activity (matches the streak definition)", async ({
+    page,
+  }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const total = page.locator('[data-testid="activity-heatmap-total"]');
+    const initialText = (await total.textContent()) ?? "";
+    const initialCount = parseInt(initialText.replace(/[^\d]/g, ""), 10) || 0;
+
+    // A cloze-only day keeps a streak alive, so it must register on the heatmap
+    // too. Previously the heatmap counted dictionary lookups only.
+    const bump = 4;
+    for (let i = 0; i < bump; i++) {
+      const res = await page.request.put("/api/stats/today", {
+        data: { field: "clozePracticed", amount: 1 },
       });
       expect(res.ok()).toBeTruthy();
     }

--- a/e2e/stats.spec.ts
+++ b/e2e/stats.spec.ts
@@ -89,21 +89,62 @@ test.describe("Stats Page", () => {
   test("should render skeleton placeholders before stats load, then swap to real content", async ({
     page,
   }) => {
-    // Slow the fluency request so the skeleton has time to appear.
-    await page.route("**/api/stats/fluency", async (route) => {
-      await new Promise((r) => setTimeout(r, 800));
+    // Hold the fluency response open until the skeleton has been asserted, so
+    // the check is deterministic instead of racing a fixed delay.
+    let releaseFluency: () => void = () => {};
+    const fluencyGate = new Promise<void>((resolve) => {
+      releaseFluency = resolve;
+    });
+    // Match the query string too: the request is /api/stats/fluency?language=af,
+    // so a bare "**/api/stats/fluency" glob never intercepts it.
+    await page.route("**/api/stats/fluency*", async (route) => {
+      await fluencyGate;
       await route.continue();
     });
 
-    await page.goto("/stats");
+    await page.goto("/stats", { waitUntil: "commit" });
 
-    // Skeleton should be visible during load
+    // Skeleton is shown while stats are still loading.
     const skeleton = page.locator('[data-testid="stats-skeleton"]');
-    await expect(skeleton).toBeVisible({ timeout: 5000 });
+    await expect(skeleton).toBeVisible({ timeout: 10000 });
 
-    // Eventually the real content takes over and the skeleton goes away
+    // Release the data; the real content takes over and the skeleton goes away.
+    releaseFluency();
     await page.waitForLoadState("networkidle");
     await expect(skeleton).toHaveCount(0, { timeout: 10000 });
     await expect(page.locator('[data-testid="stats-top-cards"]')).toBeVisible();
+  });
+
+  test("shows an estimated Words Read card in the top row", async ({ page }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const topCards = page.locator('[data-testid="stats-top-cards"]');
+    await expect(topCards).toBeVisible({ timeout: 10000 });
+
+    await expect(topCards.getByText("Words Read", { exact: true })).toBeVisible();
+    // The caveat must be visible so the estimate isn't read as a precise count.
+    await expect(topCards.getByText("Estimated from reading position")).toBeVisible();
+  });
+
+  test("vocab growth range selector defaults to 1y and toggles", async ({
+    page,
+  }) => {
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const selector = page.locator('[data-testid="stats-range-selector"]');
+    await expect(selector).toBeVisible({ timeout: 10000 });
+
+    const oneYear = selector.getByRole("button", { name: "1y" });
+    const all = selector.getByRole("button", { name: "All" });
+
+    await expect(oneYear).toHaveAttribute("aria-pressed", "true");
+    await expect(all).toHaveAttribute("aria-pressed", "false");
+
+    await all.click();
+
+    await expect(all).toHaveAttribute("aria-pressed", "true");
+    await expect(oneYear).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/src/app/api/stats/reading/route.ts
+++ b/src/app/api/stats/reading/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+import { deriveReadingStats } from '@/lib/stats-derive';
+
+// GET /api/stats/reading - Estimated reading volume derived from per-lesson
+// scroll progress. This is an estimate, not a tracked count — see
+// deriveReadingStats for why. Not language-scoped: lessons carry no language
+// column, so this reflects the whole library.
+export async function GET() {
+  const rows = db
+    .prepare('SELECT wordCount, progress_percentComplete AS percentComplete FROM lessons')
+    .all() as { wordCount: number; percentComplete: number }[];
+
+  return NextResponse.json(deriveReadingStats(rows));
+}

--- a/src/app/stats/components.tsx
+++ b/src/app/stats/components.tsx
@@ -1,5 +1,48 @@
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { ClozeCollection, FluencyStats, WordState } from '@/lib/data-layer';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+// Time-range options for the stats page. `days: null` means "all time".
+export const RANGE_OPTIONS: { label: string; days: number | null }[] = [
+  { label: '30d', days: 30 },
+  { label: '90d', days: 90 },
+  { label: '1y', days: 365 },
+  { label: 'All', days: null },
+];
+
+// Segmented time-range control. Built from the ui/Button primitive rather than
+// hand-rolled buttons, per the design-system guidance.
+export function RangeSelector({
+  value,
+  onChange,
+}: {
+  value: number | null;
+  onChange: (days: number | null) => void;
+}) {
+  return (
+    <div
+      data-testid="stats-range-selector"
+      className="inline-flex gap-0.5 rounded-lg bg-zinc-100 p-0.5 dark:bg-zinc-800/60"
+    >
+      {RANGE_OPTIONS.map((opt) => {
+        const active = value === opt.days;
+        return (
+          <Button
+            key={opt.label}
+            size="xs"
+            variant={active ? 'secondary' : 'ghost'}
+            aria-pressed={active}
+            className={cn(!active && 'text-zinc-500 dark:text-zinc-400')}
+            onClick={() => onChange(opt.days)}
+          >
+            {opt.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
 
 // Stat card component
 export function StatCard({

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,23 +1,26 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Book, CheckCircle, Flame } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Book, BookOpen, CheckCircle, Flame } from 'lucide-react';
 import Link from 'next/link';
 import {
-  getStatsForDateRange,
+  getAllDailyStats,
   getAllClozeSentences,
   getCollectionCounts,
   getFluencyStats,
+  getReadingStats,
   getStreak,
   getSetting,
 } from '@/lib/data-layer';
-import { addDaysToDateString, dateStringInTimeZone, isValidTimeZone } from '@/lib/dates';
+import { dateStringInTimeZone, isValidTimeZone } from '@/lib/dates';
+import { compositeActivityCount, sliceSeriesByDays } from '@/lib/stats-derive';
 import ActivityHeatmap from '@/components/ActivityHeatmap';
 import PageHeader from '@/components/PageHeader';
 import VocabGrowthChart from '@/components/VocabGrowthChart';
 import {
   ClozeStats,
   FluencyBadge,
+  RangeSelector,
   SentenceMastery,
   StatCard,
   StatsSkeleton,
@@ -28,32 +31,36 @@ import { StatsData } from './types';
 export default function StatsPage() {
   const [stats, setStats] = useState<StatsData | null>(null);
   const [loading, setLoading] = useState(true);
+  // Time window for the vocabulary-growth chart. Defaults to one year.
+  const [range, setRange] = useState<number | null>(365);
 
   useEffect(() => {
     async function loadStats() {
       try {
-        const [collectionCounts, fluency, streakData, tzSetting] = await Promise.all([
+        const [collectionCounts, fluency, reading, streakData, tzSetting] = await Promise.all([
           getCollectionCounts(),
           getFluencyStats(),
+          getReadingStats(),
           getStreak(),
           getSetting<string>('timezone'),
         ]);
 
-        // Get all daily stats for the past year. "Today" is a calendar date
-        // in the configured time zone (falling back to this device's zone),
-        // not UTC — otherwise the window misses today's row before 10:00
-        // AEST (issue #108).
+        // "Today" is a calendar date in the configured time zone (falling back
+        // to this device's zone), not UTC — otherwise the window misses today's
+        // row before 10:00 AEST (issue #108).
         const timeZone =
           tzSetting && isValidTimeZone(tzSetting)
             ? tzSetting
             : Intl.DateTimeFormat().resolvedOptions().timeZone;
         const endDate = dateStringInTimeZone(new Date(), timeZone);
-        const startDateStr = addDaysToDateString(endDate, -365);
 
-        const dailyStats = await getStatsForDateRange(startDateStr, endDate);
+        // Fetch all history so the "All" range and the cumulative growth series
+        // have everything; panels that are scoped to "the last year" slice it.
+        const dailyStats = await getAllDailyStats();
+        const last365 = sliceSeriesByDays(dailyStats, 365, endDate);
 
-        const totalClozeAttempts = dailyStats.reduce((sum, d) => sum + d.clozePracticed, 0);
-        const totalPoints = dailyStats.reduce((sum, d) => sum + d.points, 0);
+        const totalClozeAttempts = last365.reduce((sum, d) => sum + d.clozePracticed, 0);
+        const totalPoints = last365.reduce((sum, d) => sum + d.points, 0);
 
         // Get cloze correct count from db
         const clozeSentences = await getAllClozeSentences();
@@ -63,13 +70,15 @@ export default function StatsPage() {
         const currentStreak = streakData.streak;
         const longestStreak = streakData.longest;
 
-        // Build activity heatmap data (dictionary lookups per day)
-        const activityData = dailyStats.map((d) => ({
+        // Activity heatmap: composite study activity (lookups + cloze reviews +
+        // reading minutes) so the heatmap agrees with the streak, not dictionary
+        // lookups alone. Limited to the last year the heatmap renders.
+        const activityData = last365.map((d) => ({
           date: d.date,
-          count: d.dictionaryLookups,
+          count: compositeActivityCount(d),
         }));
 
-        // Build vocab growth data (cumulative over time)
+        // Build vocab growth data (cumulative over all history)
         const sortedDailyStats = [...dailyStats].sort(
           (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
         );
@@ -110,11 +119,13 @@ export default function StatsPage() {
           totalClozeAttempts,
           totalClozeCorrect,
           totalPoints,
+          reading,
           dailyStats,
           vocabGrowth,
           activityData,
           collectionCounts,
           fluency,
+          endDate,
         });
       } catch (error) {
         console.error('Failed to load stats:', error);
@@ -125,6 +136,13 @@ export default function StatsPage() {
 
     loadStats();
   }, []);
+
+  // Window the cumulative growth series for display. Cumulative values are kept
+  // intact — only the x-window narrows.
+  const displayedVocabGrowth = useMemo(
+    () => (stats ? sliceSeriesByDays(stats.vocabGrowth, range, stats.endDate) : []),
+    [stats, range],
+  );
 
   if (loading) {
     return <StatsSkeleton />;
@@ -158,7 +176,10 @@ export default function StatsPage() {
       <FluencyBadge fluency={stats.fluency} />
 
       {/* Top stat cards */}
-      <div data-testid="stats-top-cards" className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+      <div
+        data-testid="stats-top-cards"
+        className="mb-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4"
+      >
         <StatCard
           label="Words Known"
           value={stats.totalKnown}
@@ -173,6 +194,13 @@ export default function StatsPage() {
           icon={<Book size="24" />}
         />
         <StatCard
+          label="Words Read"
+          value={stats.reading.wordsRead}
+          sublabel="Estimated from reading position"
+          color="blue"
+          icon={<BookOpen size="24" />}
+        />
+        <StatCard
           label="Current Streak"
           value={`${stats.currentStreak} days`}
           sublabel={`Longest: ${stats.longestStreak} days`}
@@ -183,12 +211,15 @@ export default function StatsPage() {
 
       {/* Vocabulary Growth Chart */}
       <div className="mb-8">
-        <VocabGrowthChart data={stats.vocabGrowth} />
+        <VocabGrowthChart
+          data={displayedVocabGrowth}
+          controls={<RangeSelector value={range} onChange={setRange} />}
+        />
       </div>
 
       {/* Activity Heatmap */}
       <div className="mb-8">
-        <ActivityHeatmap data={stats.activityData} />
+        <ActivityHeatmap data={stats.activityData} unit="actions" />
       </div>
 
       {/* Detailed breakdowns */}

--- a/src/app/stats/types.ts
+++ b/src/app/stats/types.ts
@@ -1,4 +1,4 @@
-import { FluencyStats } from "@/lib/data-layer";
+import { FluencyStats, ReadingStats } from "@/lib/data-layer";
 import { ClozeCollection, DailyStats, WordState } from "@/types";
 
 export interface StatsData {
@@ -10,9 +10,13 @@ export interface StatsData {
   totalClozeAttempts: number;
   totalClozeCorrect: number;
   totalPoints: number;
+  reading: ReadingStats;
   dailyStats: DailyStats[];
+  // Full-history cumulative series; the page windows it for display via the range selector.
   vocabGrowth: Array<{ date: string; known: number; learning: number; total: number }>;
   activityData: Array<{ date: string; count: number }>;
   collectionCounts: Record<ClozeCollection, { total: number; due: number; mastered: number }>;
   fluency: FluencyStats;
+  // Today's date in the user's time zone — the anchor for windowing the series.
+  endDate: string;
 }

--- a/src/components/ActivityHeatmap/index.tsx
+++ b/src/components/ActivityHeatmap/index.tsx
@@ -9,6 +9,7 @@ import { formatDate, getColor } from './utils';
 
 export default function ActivityHeatmap({
   data,
+  unit = 'lookups',
   colorScheme: colorSchemeProp,
 }: ActivityHeatmapProps) {
   const isDark = useIsDark();
@@ -78,7 +79,7 @@ export default function ActivityHeatmap({
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Activity</h3>
         <div data-testid="activity-heatmap-total" className="text-sm text-zinc-500 dark:text-slate-400">
-          {totalActivity.toLocaleString()} lookups in the last year
+          {totalActivity.toLocaleString()} {unit} in the last year
         </div>
       </div>
 
@@ -123,7 +124,7 @@ export default function ActivityHeatmap({
                   key={day.date}
                   className="w-[12px] h-[12px] rounded-sm transition-colors hover:ring-1 hover:ring-black/20 dark:hover:ring-white/30"
                   style={{ backgroundColor: getColor(day.count, maxCount, colorScheme) }}
-                  title={`${day.date}: ${day.count} lookups`}
+                  title={`${day.date}: ${day.count} ${unit}`}
                 />
               ))}
               {/* Fill empty days for incomplete weeks */}

--- a/src/components/ActivityHeatmap/types.ts
+++ b/src/components/ActivityHeatmap/types.ts
@@ -6,6 +6,8 @@ export interface ActivityDay {
 
 export interface ActivityHeatmapProps {
   data: ActivityDay[];
+  /** Noun for the counted unit, e.g. "actions" or "lookups". Defaults to "lookups". */
+  unit?: string;
   colorScheme?: {
     empty: string;
     level1: string;

--- a/src/components/VocabGrowthChart/index.tsx
+++ b/src/components/VocabGrowthChart/index.tsx
@@ -22,6 +22,7 @@ export default function VocabGrowthChart({
   data,
   showLegend = true,
   height = 300,
+  controls,
 }: VocabGrowthChartProps) {
   const isDark = useIsDark();
   const theme = isDark ? darkChartTheme : lightChartTheme;
@@ -35,9 +36,10 @@ export default function VocabGrowthChart({
 
   return (
     <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h3 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-white">
-        Vocabulary Growth
-      </h3>
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Vocabulary Growth</h3>
+        {controls}
+      </div>
 
       <ResponsiveContainer width="100%" height={height}>
         <AreaChart data={formattedData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>

--- a/src/components/VocabGrowthChart/types.ts
+++ b/src/components/VocabGrowthChart/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 export interface VocabDataPoint {
   date: string;
   known: number;
@@ -9,4 +11,6 @@ export interface VocabGrowthChartProps {
   data: VocabDataPoint[];
   showLegend?: boolean;
   height?: number;
+  /** Optional controls rendered in the card header, e.g. a time-range selector. */
+  controls?: ReactNode;
 }

--- a/src/lib/__tests__/stats-derive.test.ts
+++ b/src/lib/__tests__/stats-derive.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveReadingStats,
+  compositeActivityCount,
+  sliceSeriesByDays,
+} from '../stats-derive';
+
+describe('deriveReadingStats', () => {
+  it('returns zeros for no lessons', () => {
+    expect(deriveReadingStats([])).toEqual({
+      wordsRead: 0,
+      totalWords: 0,
+      lessonsTotal: 0,
+      lessonsStarted: 0,
+      lessonsCompleted: 0,
+    });
+  });
+
+  it('prorates words read by percent complete', () => {
+    const stats = deriveReadingStats([
+      { wordCount: 1000, percentComplete: 50 },
+      { wordCount: 400, percentComplete: 25 },
+    ]);
+    expect(stats.wordsRead).toBe(600); // 500 + 100
+    expect(stats.totalWords).toBe(1400);
+    expect(stats.lessonsTotal).toBe(2);
+    expect(stats.lessonsStarted).toBe(2);
+    expect(stats.lessonsCompleted).toBe(0);
+  });
+
+  it('counts started and completed lessons by progress', () => {
+    const stats = deriveReadingStats([
+      { wordCount: 100, percentComplete: 0 }, // not started
+      { wordCount: 100, percentComplete: 1 }, // started
+      { wordCount: 100, percentComplete: 100 }, // completed (and started)
+    ]);
+    expect(stats.lessonsStarted).toBe(2);
+    expect(stats.lessonsCompleted).toBe(1);
+  });
+
+  it('clamps out-of-range percentages and rounds the estimate', () => {
+    const stats = deriveReadingStats([
+      { wordCount: 100, percentComplete: 150 }, // clamps to 100 -> 100
+      { wordCount: 100, percentComplete: -20 }, // clamps to 0 -> 0
+      { wordCount: 300, percentComplete: 33 }, // 99
+    ]);
+    expect(stats.wordsRead).toBe(199);
+    expect(stats.lessonsCompleted).toBe(1); // the clamped-to-100 one
+  });
+
+  it('treats missing word counts as zero', () => {
+    const stats = deriveReadingStats([
+      { wordCount: undefined as unknown as number, percentComplete: 50 },
+    ]);
+    expect(stats.wordsRead).toBe(0);
+    expect(stats.totalWords).toBe(0);
+  });
+});
+
+describe('compositeActivityCount', () => {
+  it('sums the three streak signals', () => {
+    expect(
+      compositeActivityCount({ dictionaryLookups: 5, clozePracticed: 3, minutesRead: 12 }),
+    ).toBe(20);
+  });
+
+  it('is non-zero whenever any single signal is present (matches the streak)', () => {
+    expect(compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 4, minutesRead: 0 })).toBe(
+      4,
+    );
+    expect(compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0 })).toBe(
+      0,
+    );
+  });
+
+  it('tolerates missing fields', () => {
+    expect(
+      compositeActivityCount({
+        dictionaryLookups: 2,
+      } as Parameters<typeof compositeActivityCount>[0]),
+    ).toBe(2);
+  });
+});
+
+describe('sliceSeriesByDays', () => {
+  const series = [
+    { date: '2026-06-01', v: 1 },
+    { date: '2026-06-08', v: 2 },
+    { date: '2026-06-12', v: 3 },
+    { date: '2026-06-14', v: 4 },
+  ];
+
+  it('returns the whole series for a null window', () => {
+    expect(sliceSeriesByDays(series, null, '2026-06-14')).toEqual(series);
+  });
+
+  it('keeps only entries within the trailing window (inclusive boundary)', () => {
+    // 7-day window ending 2026-06-14 -> cutoff 2026-06-08
+    const out = sliceSeriesByDays(series, 7, '2026-06-14');
+    expect(out.map((d) => d.date)).toEqual(['2026-06-08', '2026-06-12', '2026-06-14']);
+  });
+
+  it('preserves the original point values within the window', () => {
+    const out = sliceSeriesByDays(series, 3, '2026-06-14');
+    expect(out).toEqual([
+      { date: '2026-06-12', v: 3 },
+      { date: '2026-06-14', v: 4 },
+    ]);
+  });
+});

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -35,6 +35,8 @@ export type {
   Settings,
 } from '@/types';
 
+export type { ReadingStats } from './stats-derive';
+
 import type {
   WordState,
   Collection,
@@ -580,6 +582,11 @@ export async function getFluencyStats(): Promise<FluencyStats> {
   return res.json();
 }
 
+export async function getReadingStats(): Promise<import('./stats-derive').ReadingStats> {
+  const res = await fetch('/api/stats/reading');
+  return res.json();
+}
+
 // Migration function - no-op for server storage
 export async function migrateClozeSentences(): Promise<number> {
   return 0;
@@ -692,6 +699,13 @@ export async function getStatsForDateRange(
   endDate: string,
 ): Promise<DailyStats[]> {
   const res = await fetch(`/api/stats?startDate=${startDate}&endDate=${endDate}${langParam('&')}`);
+  return res.json();
+}
+
+// All daily-stats rows, oldest first — used by the stats page so the "All" range
+// and full-history cumulative series have everything to work with.
+export async function getAllDailyStats(): Promise<DailyStats[]> {
+  const res = await fetch(`/api/stats${langParam()}`);
   return res.json();
 }
 

--- a/src/lib/stats-derive.ts
+++ b/src/lib/stats-derive.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure derivation helpers for the statistics page.
+ *
+ * These have no DB or DOM dependencies so they can be unit-tested directly and
+ * reused between the API route and the page. The streak/date helpers they lean
+ * on live in ./streak and ./dates.
+ */
+
+import { addDaysToDateString } from './dates';
+import type { DailyStats } from '@/types';
+
+export interface LessonReadingRow {
+  /** Total words in the lesson (lessons.wordCount). */
+  wordCount: number;
+  /** Furthest/last scroll position as a percentage, 0..100 (lessons.progress_percentComplete). */
+  percentComplete: number;
+}
+
+export interface ReadingStats {
+  /** Estimated words read across all lessons. See caveat below. */
+  wordsRead: number;
+  /** Total words across all lessons (the library size). */
+  totalWords: number;
+  lessonsTotal: number;
+  lessonsStarted: number;
+  lessonsCompleted: number;
+}
+
+/**
+ * Estimate "words read" from per-lesson reading progress.
+ *
+ * This is deliberately approximate. `percentComplete` is the reader's latest
+ * scroll position (see MarkdownReader.handleScroll), not a measure of words
+ * actually read — it over-counts skimming and is reduced by scrolling back up.
+ * It is, however, the only reading-volume signal the app currently captures
+ * (`minutesRead` is never written), so the page surfaces it as an estimate with
+ * a visible caveat rather than a precise figure.
+ */
+export function deriveReadingStats(rows: LessonReadingRow[]): ReadingStats {
+  let wordsRead = 0;
+  let totalWords = 0;
+  let lessonsStarted = 0;
+  let lessonsCompleted = 0;
+
+  for (const row of rows) {
+    const words = Math.max(0, row.wordCount || 0);
+    const pct = Math.min(100, Math.max(0, row.percentComplete || 0));
+    wordsRead += (words * pct) / 100;
+    totalWords += words;
+    if (pct > 0) lessonsStarted++;
+    if (pct >= 100) lessonsCompleted++;
+  }
+
+  return {
+    wordsRead: Math.round(wordsRead),
+    totalWords,
+    lessonsTotal: rows.length,
+    lessonsStarted,
+    lessonsCompleted,
+  };
+}
+
+/**
+ * Composite daily study-activity magnitude. Matches the streak's definition of
+ * an active day (`isActiveDay` in ./streak: a dictionary lookup, cloze review,
+ * or reading minute), so the activity heatmap agrees with the streak. Before
+ * this the heatmap counted dictionary lookups only, leaving cloze-only days
+ * uncoloured even though they keep a streak alive.
+ */
+export function compositeActivityCount(
+  d: Pick<DailyStats, 'dictionaryLookups' | 'clozePracticed' | 'minutesRead'>,
+): number {
+  return (d.dictionaryLookups || 0) + (d.clozePracticed || 0) + (d.minutesRead || 0);
+}
+
+/**
+ * Narrow a date-ascending series to the last `days` ending at `endDate`
+ * (inclusive). `days === null` returns the whole series unchanged. Only the
+ * x-window is narrowed — cumulative values on each point are preserved, so a
+ * windowed cumulative chart keeps its real running totals rather than resetting
+ * to zero at the window start.
+ */
+export function sliceSeriesByDays<T extends { date: string }>(
+  series: T[],
+  days: number | null,
+  endDate: string,
+): T[] {
+  if (days === null) return series;
+  const cutoff = addDaysToDateString(endDate, -(days - 1));
+  return series.filter((d) => d.date >= cutoff);
+}


### PR DESCRIPTION
## Summary

Tier 1 of the stats-page expansion: surface reading volume, make the activity heatmap honest about what counts as activity, and let the vocabulary-growth chart be scoped to a time window.

### What's new
- **Words Read card** (top row) — estimated reading volume across the library, derived from per-lesson reading progress (`Σ wordCount × percentComplete`). Labelled **"Estimated from reading position"** so it isn't read as a precise count. New `GET /api/stats/reading` route + `deriveReadingStats()` helper.
- **Activity heatmap now matches the streak.** It previously coloured days by **dictionary lookups only**, so a day where you *only* practised cloze showed up empty even though it kept your streak alive. It now counts composite study activity (lookups + cloze reviews + reading minutes) — the same signals as `isActiveDay`. Copy reads "actions" instead of "lookups".
- **Vocabulary Growth time-range selector** (30d / 90d / 1y / All). The page now loads full history and windows the cumulative series for display; running totals are preserved — the window narrows the x-axis, it doesn't reset to zero.

### Deferred (by design)
Reading **time** and **WPM** are intentionally not included. `minutesRead` is never written by the app (there's no session timer), so an "Hours Read" card would render `0` and WPM `0/NaN`. This is the same trap that led to #80 removing the old empty *Time Reading* / *Books Read* cards. Adding a reading-session timer is a clean follow-up.

### Why "Words Read" is an estimate
`percentComplete` is the reader's latest scroll position (`MarkdownReader.handleScroll`), not a measure of words actually read — inflated by skimming, reduced by scrolling back. It's the only reading-volume signal currently captured, so it's surfaced as an estimate with a visible caveat rather than a precise figure. It is also not language-scoped (lessons carry no language column).

## Tests
- **Unit** (`src/lib/__tests__/stats-derive.test.ts`): `deriveReadingStats` (proration, clamping, started/completed counts), `compositeActivityCount`, `sliceSeriesByDays`.
- **E2E**: Words Read card + caveat; range selector defaults to 1y and toggles; cloze reviews register on the heatmap.
- **Drive-by fix — flaky skeleton test.** Its fluency route interception used a `**/api/stats/fluency` glob that stopped matching once the request gained a `?language=af` query string (multi-language), so it never delayed the response and just raced load timing (~1/3 pass locally). It now matches `…fluency*` and holds the response open until the skeleton is asserted, then releases it — deterministic (5/5 locally).

Verified locally: `npm run lint`, `npx tsc --noEmit`, `npm test` (new tests green; the only failure is the dictionary integration test, which needs the gitignored dict that CI fetches), `npm run build`, and the touched e2e specs.

## Test Plan
Proof captured locally and posted as a [PR comment](https://github.com/heuwels/lector/pull/148#issuecomment-4701515099):
- [x] Words Read card renders with the "Estimated from reading position" caveat (value `2,000` from seeded progress) — [proof](https://github.com/heuwels/lector/pull/148#issuecomment-4701515099)
- [x] Activity heatmap counts composite study activity — today cell shows `15 actions` from 5 lookups + 10 cloze reviews — [proof](https://github.com/heuwels/lector/pull/148#issuecomment-4701515099)
- [x] Vocabulary-growth range selector toggles (`aria-pressed`) and widens the window from Jun 18 (1y) to Nov 20 (All) — [proof](https://github.com/heuwels/lector/pull/148#issuecomment-4701515099)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
