### PR TITLE
Design: grown-up gamified theme — light + warm dark (skinning) (#147)

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -207,7 +207,7 @@ test.describe("Chat Widget", () => {
 
     // Panel should be visible and functional in dark mode
     const panel = page.getByTestId("chat-panel");
-    await expect(panel).toHaveClass(/dark:bg-gray-800/);
+    await expect(panel).toHaveClass(/bg-card/);
   });
 
   test("should be available on practice page too", async ({ page }) => {

--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -45,7 +45,7 @@ test.describe.serial("Practice - Setup Screen", () => {
     await btn.click();
 
     // Should have selected state (blue background)
-    await expect(btn).toHaveClass(/bg-blue-500/);
+    await expect(btn).toHaveClass(/bg-primary/);
   });
 
   test("should switch round size", async ({ page }) => {
@@ -53,7 +53,7 @@ test.describe.serial("Practice - Setup Screen", () => {
 
     const btn10 = page.getByRole("button", { name: "10", exact: true });
     await btn10.click();
-    await expect(btn10).toHaveClass(/bg-blue-500/);
+    await expect(btn10).toHaveClass(/bg-primary/);
   });
 
   test("should switch between Type and MC modes", async ({ page }) => {
@@ -64,11 +64,11 @@ test.describe.serial("Practice - Setup Screen", () => {
 
     // Select MC mode
     await mcBtn.click();
-    await expect(mcBtn).toHaveClass(/bg-blue-500/);
+    await expect(mcBtn).toHaveClass(/bg-primary/);
 
     // Switch back to Type
     await typeBtn.click();
-    await expect(typeBtn).toHaveClass(/bg-blue-500/);
+    await expect(typeBtn).toHaveClass(/bg-primary/);
   });
 });
 
@@ -318,7 +318,7 @@ test.describe.serial("Practice - Multiple Choice Mode", () => {
     await page.waitForTimeout(500);
 
     // The correct answer button should have green styling
-    const greenBtn = mcGrid.locator("button.border-green-500");
+    const greenBtn = mcGrid.locator("button.border-primary");
     await expect(greenBtn).toBeVisible({ timeout: 2000 });
 
     // Wait for auto-advance
@@ -348,7 +348,7 @@ test.describe.serial("Practice - Multiple Choice Mode", () => {
     await page.waitForTimeout(500);
 
     // No button should have been selected (no green/red border)
-    const selectedBtn = mcGrid.locator("button.border-green-500, button.border-red-500");
+    const selectedBtn = mcGrid.locator("button.border-primary, button.border-destructive");
     await expect(selectedBtn).toHaveCount(0);
 
     // The instruction text should still be visible (not advanced)
@@ -740,7 +740,7 @@ test.describe("Practice - Incorrect Type Answer Feedback", () => {
 });
 
 test.describe("Practice - Fuzzy Input Coloring", () => {
-  test("should show green border only for exact prefix matches", async ({
+  test("should show sage border only for exact prefix matches", async ({
     page,
   }) => {
     await waitForSetup(page);
@@ -763,14 +763,14 @@ test.describe("Practice - Fuzzy Input Coloring", () => {
     expect(firstLetter.length).toBe(1);
 
     // Typing correct prefix should show green (partial match)
-    await expect(input).toHaveClass(/border-green-400/);
+    await expect(input).toHaveClass(/border-primary/);
 
     // Now type a wrong character after the correct prefix
     await input.fill(firstLetter + "zzz");
     await page.waitForTimeout(100);
 
     // Should show red border (wrong)
-    await expect(input).toHaveClass(/border-red-400/);
+    await expect(input).toHaveClass(/border-destructive/);
   });
 
   test("should show red for divergent input even with shared prefix", async ({
@@ -798,7 +798,7 @@ test.describe("Practice - Fuzzy Input Coloring", () => {
     expect(twoLetters.length).toBe(2);
 
     // Correct prefix should be green
-    await expect(input).toHaveClass(/border-green-400/);
+    await expect(input).toHaveClass(/border-primary/);
 
     // Replace last character with wrong one to simulate divergence
     // e.g. correct is "he" from "heel", type "h~" instead
@@ -807,10 +807,10 @@ test.describe("Practice - Fuzzy Input Coloring", () => {
     await page.waitForTimeout(100);
 
     // Should be red since it's not a prefix of the correct word
-    await expect(input).toHaveClass(/border-red-400/);
+    await expect(input).toHaveClass(/border-destructive/);
   });
 
-  test("should show blue border when input is empty", async ({ page }) => {
+  test("should show clay border when input is empty", async ({ page }) => {
     await waitForSetup(page);
 
     await page.getByRole("button", { name: "10", exact: true }).click();
@@ -823,11 +823,11 @@ test.describe("Practice - Fuzzy Input Coloring", () => {
 
     const input = page.locator('input[placeholder="..."]');
 
-    // Empty input should have blue border
-    await expect(input).toHaveClass(/border-blue-400/);
+    // Empty input should have the clay (neutral) border
+    await expect(input).toHaveClass(/var\(--clay\)/);
   });
 
-  test("should show green-500 border and Submit button when answer is correct", async ({
+  test("should show sage border and Submit button when answer is correct", async ({
     page,
   }) => {
     await waitForSetup(page);
@@ -853,8 +853,8 @@ test.describe("Practice - Fuzzy Input Coloring", () => {
       await page.waitForTimeout(100);
     }
 
-    // Full correct answer should show green-500 border (match)
-    await expect(input).toHaveClass(/border-green-500/);
+    // Full correct answer should show sage border (match)
+    await expect(input).toHaveClass(/border-primary/);
 
     // Button should say "Submit" not "Check"
     await expect(

--- a/e2e/stats.spec.ts
+++ b/e2e/stats.spec.ts
@@ -28,7 +28,7 @@ test.describe("Stats Page", () => {
     const topCards = page.locator('[data-testid="stats-top-cards"]');
     await expect(topCards).toBeVisible({ timeout: 10000 });
 
-    const labels = topCards.locator("p.text-zinc-500, p.dark\\:text-zinc-400");
+    const labels = topCards.locator("p.text-muted-foreground");
     // Top row should contain Words Known, Learning (L1-L4), and Current Streak
     await expect(topCards.getByText("Words Known")).toBeVisible();
     await expect(topCards.getByText("Learning (L1-L4)")).toBeVisible();
@@ -69,10 +69,10 @@ test.describe("Stats Page", () => {
 
     const topCards = page.locator('[data-testid="stats-top-cards"]');
     const knownCardValue = topCards
-      .locator("div.rounded-xl", { hasText: "Words Known" })
+      .locator("div.panel", { hasText: "Words Known" })
       .locator("p.text-4xl");
     const learningCardValue = topCards
-      .locator("div.rounded-xl", { hasText: "Learning (L1-L4)" })
+      .locator("div.panel", { hasText: "Learning (L1-L4)" })
       .locator("p.text-4xl");
 
     // Both displays must agree, and reflect at least the seeded words

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -59,7 +59,7 @@ test.describe('Theme Toggle', () => {
     const stored = await page.evaluate((key) => localStorage.getItem(key), SETTINGS_KEYS.THEME);
     expect(stored).toBe('light');
 
-    // Body should have a light background (bg-gray-50)
+    // Body should have a light background (warm sand)
     expect(await getBodyBrightness(page)).toBeGreaterThan(200);
   });
 
@@ -81,7 +81,7 @@ test.describe('Theme Toggle', () => {
     const stored = await page.evaluate((key) => localStorage.getItem(key), SETTINGS_KEYS.THEME);
     expect(stored).toBe('dark');
 
-    // Body should have a dark background (bg-gray-900)
+    // Body should have a dark background (warm espresso)
     expect(await getBodyBrightness(page)).toBeLessThan(60);
   });
 

--- a/src/app/(index)/components/AddCollectionTile.tsx
+++ b/src/app/(index)/components/AddCollectionTile.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui/button';
+
 export default function AddCollectionTile({
   value,
   onChange,
@@ -15,7 +17,7 @@ export default function AddCollectionTile({
         e.preventDefault();
         onSubmit();
       }}
-      className="flex min-h-[14rem] flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-zinc-300 p-4 dark:border-zinc-700"
+      className="flex min-h-[14rem] flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-border p-4"
     >
       <input
         type="text"
@@ -27,23 +29,15 @@ export default function AddCollectionTile({
         placeholder="Collection title"
         autoFocus
         data-testid="new-collection-input"
-        className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+        className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
       />
       <div className="flex gap-2">
-        <button
-          type="submit"
-          data-testid="new-collection-submit"
-          className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-        >
+        <Button type="submit" size="sm" data-testid="new-collection-submit">
           Create
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded-lg px-3 py-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
-        >
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
           Cancel
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/src/app/(index)/components/EmptyState.tsx
+++ b/src/app/(index)/components/EmptyState.tsx
@@ -1,25 +1,21 @@
 import { BookOpen, CloudUpload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 export default function EmptyState({ onImport }: { onImport: () => void }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-zinc-200 bg-white px-6 py-16 text-center dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-zinc-100 dark:bg-zinc-800">
-        <BookOpen className="h-8 w-8 text-zinc-400 dark:text-zinc-500" strokeWidth={1.5} />
+    <div className="flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-border bg-card px-6 py-16 text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <BookOpen className="h-8 w-8 text-muted-foreground" strokeWidth={1.5} />
       </div>
-      <h3 className="mb-2 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-        No books in your library
-      </h3>
-      <p className="mb-6 max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
+      <h3 className="mb-2 text-lg font-bold text-foreground">No books in your library</h3>
+      <p className="mb-6 max-w-sm text-sm text-muted-foreground">
         Import a book (EPUB or Markdown) to start learning. Your vocabulary and progress will be
         tracked as you read.
       </p>
-      <button
-        onClick={onImport}
-        className="inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-      >
+      <Button onClick={onImport} size="lg">
         <CloudUpload className="h-5 w-5" />
         Import Book
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/app/(index)/components/GroupMenu.tsx
+++ b/src/app/(index)/components/GroupMenu.tsx
@@ -1,5 +1,6 @@
 import { MoreVertical } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
 
 export default function GroupMenu({
   onRename,
@@ -24,21 +25,22 @@ export default function GroupMenu({
 
   return (
     <div className="relative" ref={menuRef}>
-      <button
+      <Button
+        variant="ghost"
+        size="icon"
         onClick={() => setIsOpen(!isOpen)}
-        className="rounded-lg p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
         data-testid="group-menu-btn"
       >
         <MoreVertical className="h-4 w-4" />
-      </button>
+      </Button>
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-1 w-36 rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+        <div className="absolute right-0 z-50 mt-1 w-36 rounded-lg border border-border bg-card py-1 shadow-lg">
           <button
             onClick={() => {
               setIsOpen(false);
               onRename();
             }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-700"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-foreground hover:bg-accent"
             data-testid="group-rename-btn"
           >
             Rename
@@ -48,7 +50,7 @@ export default function GroupMenu({
               setIsOpen(false);
               onDelete();
             }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-destructive hover:bg-accent"
             data-testid="group-delete-btn"
           >
             Delete

--- a/src/app/(index)/components/SortableCollectionCard.tsx
+++ b/src/app/(index)/components/SortableCollectionCard.tsx
@@ -34,7 +34,7 @@ export default function SortableCollectionCard({ collection }: { collection: Col
         {...listeners}
         aria-label={`Drag to reorder ${collection.title}`}
         data-testid={`drag-collection-${collection.id}`}
-        className="absolute top-2 left-2 cursor-grab touch-none rounded-md bg-white/90 p-1 text-zinc-400 opacity-70 shadow-sm transition-opacity group-hover:opacity-100 hover:text-zinc-700 focus-visible:opacity-100 active:cursor-grabbing dark:bg-zinc-800/90 dark:hover:text-zinc-200"
+        className="absolute top-2 left-2 cursor-grab touch-none rounded-md bg-card/90 p-1 text-muted-foreground opacity-70 shadow-sm transition-opacity group-hover:opacity-100 hover:text-foreground focus-visible:opacity-100 active:cursor-grabbing"
       >
         <GripVertical className="h-4 w-4" />
       </button>

--- a/src/app/(index)/page.tsx
+++ b/src/app/(index)/page.tsx
@@ -262,7 +262,7 @@ export default function Home() {
                 placeholder="Group name"
                 autoFocus
                 data-testid="new-group-input"
-                className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                className="rounded-lg border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
               />
               <Button type="submit" data-testid="new-group-submit">
                 Add
@@ -302,7 +302,7 @@ export default function Home() {
       </PageHeader>
       {isLoading ? (
         <div className="flex h-64 items-center justify-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100" />
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-foreground" />
         </div>
       ) : (
         <section>
@@ -327,7 +327,7 @@ export default function Home() {
                   <div
                     key={group.id}
                     data-testid={`group-${group.id}`}
-                    className="rounded-2xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+                    className="panel p-5"
                   >
                     <div className="mb-4 flex items-center gap-3">
                       <button
@@ -335,16 +335,16 @@ export default function Home() {
                         aria-expanded={!isCollapsed}
                         aria-label={isCollapsed ? `Expand ${group.name}` : `Collapse ${group.name}`}
                         data-testid={`group-toggle-${group.id}`}
-                        className="-ml-1 flex items-center gap-2 rounded-lg px-1 py-0.5 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        className="-ml-1 flex items-center gap-2 rounded-lg px-1 py-0.5 text-left hover:bg-accent"
                       >
                         <ChevronDown
-                          className={`h-4 w-4 text-zinc-400 transition-transform ${isCollapsed ? '-rotate-90' : ''}`}
+                          className={`h-4 w-4 text-muted-foreground transition-transform ${isCollapsed ? '-rotate-90' : ''}`}
                         />
-                        <h3 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200">
+                        <h3 className="text-lg font-semibold text-foreground">
                           {group.name}
                         </h3>
                       </button>
-                      <span className="text-sm text-zinc-400 dark:text-zinc-500">
+                      <span className="text-sm text-muted-foreground">
                         {items.length} {items.length === 1 ? 'item' : 'items'}
                       </span>
                       <div className="flex-1" />
@@ -386,7 +386,7 @@ export default function Home() {
                                 setNewCollectionTitle('');
                               }}
                               data-testid={`add-collection-${group.id}`}
-                              className="group flex min-h-[14rem] flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-zinc-300 text-zinc-400 transition-all hover:border-zinc-400 hover:bg-white hover:text-zinc-600 dark:border-zinc-700 dark:hover:border-zinc-600 dark:hover:bg-zinc-900 dark:hover:text-zinc-300"
+                              className="group flex min-h-[14rem] flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-border text-muted-foreground transition-all hover:bg-accent hover:text-foreground"
                             >
                               <Plus className="h-8 w-8" strokeWidth={1.5} />
                               <span className="text-sm font-medium">New collection</span>
@@ -403,10 +403,10 @@ export default function Home() {
               {ungrouped.length > 0 && (
                 <div
                   data-testid="ungrouped-section"
-                  className="rounded-2xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+                  className="panel p-5"
                 >
                   {hasGroups && (
-                    <h3 className="mb-4 text-lg font-semibold text-zinc-800 dark:text-zinc-200">
+                    <h3 className="mb-4 text-lg font-semibold text-foreground">
                       Ungrouped
                     </h3>
                   )}

--- a/src/app/collection/[id]/page.tsx
+++ b/src/app/collection/[id]/page.tsx
@@ -158,7 +158,7 @@ export default function CollectionPage({ params }: { params: Promise<{ id: strin
     return (
       <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6">
         <div className="flex h-64 items-center justify-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100" />
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-foreground" />
         </div>
       </main>
     );
@@ -174,7 +174,7 @@ export default function CollectionPage({ params }: { params: Promise<{ id: strin
       {/* Back link */}
       <Link
         href="/"
-        className="mb-6 inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+        className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
       >
         <ArrowLeft className="h-4 w-4" />
         Library
@@ -182,8 +182,8 @@ export default function CollectionPage({ params }: { params: Promise<{ id: strin
 
       {/* Collection header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-zinc-900 dark:text-zinc-50">{collection.title}</h1>
-        <p className="mt-1 text-zinc-500 dark:text-zinc-400">
+        <h1 className="text-3xl font-bold text-foreground">{collection.title}</h1>
+        <p className="mt-1 text-muted-foreground">
           {collection.author} &middot; {lessons.length}{' '}
           {lessons.length === 1 ? 'lesson' : 'lessons'}
           {completedCount > 0 && ` \u00b7 ${completedCount} completed`}
@@ -191,14 +191,14 @@ export default function CollectionPage({ params }: { params: Promise<{ id: strin
 
         {/* Group selector */}
         <div className="mt-3 flex items-center gap-2">
-          <label htmlFor="group-select" className="text-sm text-zinc-500 dark:text-zinc-400">
+          <label htmlFor="group-select" className="text-sm text-muted-foreground">
             Group:
           </label>
           <select
             id="group-select"
             value={collection.groupId || ''}
             onChange={(e) => handleGroupChange(e.target.value)}
-            className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-700 focus:border-zinc-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+            className="rounded-lg border border-input bg-background px-3 py-1.5 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
             data-testid="group-select"
           >
             <option value="">None</option>
@@ -215,14 +215,14 @@ export default function CollectionPage({ params }: { params: Promise<{ id: strin
           {continueLesson && (
             <Link
               href={`/read/${continueLesson.id}`}
-              className="inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
             >
               Continue Reading
             </Link>
           )}
           <button
             onClick={handleDelete}
-            className="rounded-lg px-4 py-2.5 text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+            className="rounded-lg px-4 py-2.5 text-sm text-destructive hover:bg-accent"
           >
             Delete
           </button>
@@ -253,7 +253,7 @@ export default function CollectionPage({ params }: { params: Promise<{ id: strin
         <button
           onClick={() => setIsAddOpen(true)}
           data-testid="add-lesson"
-          className="group flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-300 bg-transparent px-5 py-4 text-sm font-medium text-zinc-500 transition-all hover:border-zinc-400 hover:bg-white hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:bg-zinc-900 dark:hover:text-zinc-200"
+          className="group flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-transparent px-5 py-4 text-sm font-medium text-muted-foreground transition-all hover:bg-accent hover:text-foreground"
         >
           <Plus className="h-4 w-4" />
           Add lesson

--- a/src/app/collection/components/SortableLessonRow.tsx
+++ b/src/app/collection/components/SortableLessonRow.tsx
@@ -36,7 +36,7 @@ export default function SortableLessonRow({
     <div
       ref={setNodeRef}
       style={style}
-      className={`group flex items-center gap-3 rounded-xl border border-zinc-200 bg-white px-3 py-4 transition-all hover:border-zinc-300 hover:shadow-sm sm:px-4 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700 ${isDragging ? 'opacity-60 shadow-md' : ''}`}
+      className={`group flex items-center gap-3 rounded-xl border border-border bg-card px-3 py-4 transition-all hover:border-border hover:shadow-sm sm:px-4 ${isDragging ? 'opacity-60 shadow-md' : ''}`}
     >
       <button
         ref={setActivatorNodeRef}
@@ -44,7 +44,7 @@ export default function SortableLessonRow({
         {...listeners}
         aria-label={`Drag to reorder ${lesson.title}`}
         data-testid={`drag-lesson-${lesson.id}`}
-        className="flex-shrink-0 cursor-grab touch-none rounded-md p-1 text-zinc-300 hover:text-zinc-500 active:cursor-grabbing dark:text-zinc-600 dark:hover:text-zinc-400"
+        className="flex-shrink-0 cursor-grab touch-none rounded-md p-1 text-muted-foreground hover:text-foreground active:cursor-grabbing"
       >
         <GripVertical className="h-5 w-5" />
       </button>
@@ -54,8 +54,8 @@ export default function SortableLessonRow({
         <div
           className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-medium ${
             isComplete
-              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-              : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
+              ? 'bg-[var(--primary-soft)] text-primary'
+              : 'bg-muted text-muted-foreground'
           }`}
         >
           {isComplete ? <Check className="h-4 w-4" /> : index + 1}
@@ -63,10 +63,10 @@ export default function SortableLessonRow({
 
         {/* Lesson info */}
         <div className="min-w-0 flex-1">
-          <h3 className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          <h3 className="truncate text-sm font-medium text-foreground">
             {lesson.title}
           </h3>
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+          <p className="text-xs text-muted-foreground">
             {lesson.wordCount.toLocaleString()} words
             {progress > 0 && !isComplete && ` · ${progress}%`}
           </p>
@@ -74,21 +74,21 @@ export default function SortableLessonRow({
 
         {/* Progress bar */}
         {progress > 0 && !isComplete && (
-          <div className="h-1.5 w-20 rounded-full bg-zinc-100 dark:bg-zinc-800">
+          <div className="h-1.5 w-20 rounded-full bg-muted">
             <div
-              className="h-full rounded-full bg-zinc-400 dark:bg-zinc-500"
+              className="h-full rounded-full bg-primary"
               style={{ width: `${progress}%` }}
             />
           </div>
         )}
 
-        <ChevronRight className="h-4 w-4 flex-shrink-0 text-zinc-400" />
+        <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
       </Link>
 
       {/* Edit button */}
       <button
         onClick={() => onEdit(lesson.id)}
-        className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all group-hover:opacity-100 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+        className="flex-shrink-0 rounded-lg p-2 text-muted-foreground opacity-0 transition-all group-hover:opacity-100 hover:bg-accent hover:text-foreground"
         title="Edit lesson"
         data-testid={`edit-lesson-${lesson.id}`}
       >
@@ -98,7 +98,7 @@ export default function SortableLessonRow({
       {/* Delete button */}
       <button
         onClick={() => onDelete(lesson.id, lesson.title)}
-        className="flex-shrink-0 rounded-lg p-2 text-zinc-400 opacity-0 transition-all group-hover:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+        className="flex-shrink-0 rounded-lg p-2 text-muted-foreground opacity-0 transition-all group-hover:opacity-100 hover:bg-accent hover:text-destructive"
         title="Delete lesson"
       >
         <Trash2 className="h-4 w-4" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,45 +4,95 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/*
+ * "Grown-up gamified" visual language (issue #147).
+ * Token values are lifted from lector-design-demos/08-playful-mature.html (light)
+ * and 09-playful-mature-dark.html (dark). Components should reference these
+ * tokens, never hardcode colours.
+ */
 :root {
   --mobile-topbar-h: 2.5rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.871 0.006 286.286);
-  --chart-2: oklch(0.552 0.016 285.938);
-  --chart-3: oklch(0.442 0.017 285.786);
-  --chart-4: oklch(0.37 0.013 285.805);
-  --chart-5: oklch(0.274 0.006 286.033);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
+
+  /* shadcn semantic tokens — warm sand / sage (light) */
+  --background: #f3eee3; /* warm sand */
+  --foreground: #2c2a23; /* warm near-black */
+  --card: #fffdf7;
+  --card-foreground: #2c2a23;
+  --popover: #fffdf7; /* translation drawer / sheet surface */
+  --popover-foreground: #2c2a23;
+  --primary: #2f8a76; /* sage / teal */
+  --primary-foreground: #ffffff;
+  --secondary: #f1ebda; /* warm chip/pill bg */
+  --secondary-foreground: #6b6356;
+  --muted: #f4efe2; /* example box, subtle fills */
+  --muted-foreground: #6b6356;
+  --accent: #efe9dc; /* subtle hover surface ONLY */
+  --accent-foreground: #2c2a23;
+  --destructive: #b8442f;
+  --destructive-foreground: #ffffff;
+  --border: #e9e1d0;
+  --input: #e9e1d0;
+  --ring: #2f8a76;
+
+  /* charts — retinted into the sage/clay/gold/sand family */
+  --chart-1: #2f8a76;
+  --chart-2: #c0744f;
+  --chart-3: #cf9a3d;
+  --chart-4: #8a9a5b;
+  --chart-5: #6b6356;
+
+  --radius: 0.75rem; /* was 0.625rem */
+
+  /* sidebar (shadcn primitive) — kept in family */
+  --sidebar: #fffdf7;
+  --sidebar-foreground: #2c2a23;
+  --sidebar-primary: #2f8a76;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #efe9dc;
+  --sidebar-accent-foreground: #2c2a23;
+  --sidebar-border: #e9e1d0;
+  --sidebar-ring: #2f8a76;
+
+  /* custom: elevation + brand accents */
+  --lip: #dbceb8; /* shallow 3D bottom edge on cards/buttons */
+  --primary-lip: #226a5a; /* darker sage = button bottom edge */
+  --destructive-lip: #8f3422;
+  --primary-soft: #e2efe9; /* sage-tinted fill (active nav, "known") */
+  --primary-text: #226a5a; /* sage text on light surfaces */
+  --clay: #c0744f;
+  --clay-foreground: #ffffff;
+  --clay-lip: #a35a37;
+  --clay-soft: #f6e7dd;
+  --gold: #cf9a3d;
+  --gold-strong: #a87a22;
+  --gold-soft: #f3e9cf;
+  --gold-lip: #e0d2a8;
+  --glow-1: #e4ecd9;
+  --glow-2: #f3e2d2; /* optional ambient bg radials */
+
+  /* custom: word-state ramp (single warm ochre ramp + calm slate for "new") */
+  --w-new-bg: #e6ecef;
+  --w-new-fg: #4a6678;
+  --w-new-bd: #d3dde2;
+  --w-l1-bg: #eed7a4;
+  --w-l1-fg: #8a5c14;
+  --w-l1-bd: #e2c587; /* least known -> deepest */
+  --w-l2-bg: #efdfb4;
+  --w-l2-fg: #896020;
+  --w-l2-bd: #e4d099;
+  --w-l3-bg: #efe6c6;
+  --w-l3-fg: #897328;
+  --w-l3-bd: #e6d8ac;
+  --w-l4-bg: #eee9d6;
+  --w-l4-fg: #847644;
+  --w-l4-bd: #e2dbc1; /* nearly known -> faint */
+  /* known -> no chip (plain text). ignored -> --muted bg, --muted-foreground, .6 opacity */
 }
 
 @theme inline {
-  --font-sans: var(--font-inter);
-  --font-heading: var(--font-inter);
+  --font-sans: var(--font-nunito);
+  --font-heading: var(--font-nunito);
+  --font-reading: var(--font-literata); /* MarkdownReader body */
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -60,6 +110,7 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -74,6 +125,11 @@
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  /* custom brand-accent utilities */
+  --color-clay: var(--clay);
+  --color-clay-foreground: var(--clay-foreground);
+  --color-gold: var(--gold);
+  --color-gold-soft: var(--gold-soft);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -84,37 +140,81 @@
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.871 0.006 286.286);
-  --chart-2: oklch(0.552 0.016 285.938);
-  --chart-3: oklch(0.442 0.017 285.786);
-  --chart-4: oklch(0.37 0.013 285.805);
-  --chart-5: oklch(0.274 0.006 286.033);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
+  --background: #17140f; /* warm espresso, NOT cool charcoal */
+  --foreground: #ece5d6;
+  --card: #211d16;
+  --card-foreground: #ece5d6;
+  --popover: #211d16;
+  --popover-foreground: #ece5d6;
+  --primary: #54ab92; /* brighter sage for dark */
+  --primary-foreground: #10221c; /* dark text on the bright sage CTA */
+  --secondary: #2a251c;
+  --secondary-foreground: #ece5d6;
+  --muted: #2a251c;
+  --muted-foreground: #a99e8a;
+  --accent: #2a251c;
+  --accent-foreground: #ece5d6;
+  --destructive: #e0795f;
+  --destructive-foreground: #2a0f08;
+  --border: #352f24;
+  --input: #352f24;
+  --ring: #54ab92;
+
+  --chart-1: #54ab92;
+  --chart-2: #d18c63;
+  --chart-3: #d7a64c;
+  --chart-4: #9aa86a;
+  --chart-5: #a99e8a;
+
+  --sidebar: #211d16;
+  --sidebar-foreground: #ece5d6;
+  --sidebar-primary: #54ab92;
+  --sidebar-primary-foreground: #10221c;
+  --sidebar-accent: #2a251c;
+  --sidebar-accent-foreground: #ece5d6;
+  --sidebar-border: #352f24;
+  --sidebar-ring: #54ab92;
+
+  --lip: #0e0c08;
+  --primary-lip: #1f4438;
+  --destructive-lip: #7a3322;
+  --primary-soft: #1c2e28; /* sage-tinted fill (active nav, "known") */
+  --primary-text: #7fc9b3; /* brighter sage for text on dark surfaces */
+  --clay: #d18c63;
+  --clay-foreground: #241009;
+  --clay-lip: #6a3d27;
+  --clay-soft: #33231a;
+  --gold: #d7a64c;
+  --gold-strong: #d7a64c;
+  --gold-soft: #322712;
+  --gold-lip: #2a2010;
+  --glow-1: #23301f;
+  --glow-2: #33271c;
+
+  /* word states — translucent so they read on the warm dark card */
+  --w-new-bg: rgba(126, 156, 176, 0.16);
+  --w-new-fg: #a6bdcb;
+  --w-new-bd: rgba(126, 156, 176, 0.34);
+  --w-l1-bg: rgba(217, 162, 78, 0.22);
+  --w-l1-fg: #e7bd72;
+  --w-l1-bd: rgba(217, 162, 78, 0.46);
+  --w-l2-bg: rgba(217, 162, 78, 0.155);
+  --w-l2-fg: #dab47d;
+  --w-l2-bd: rgba(217, 162, 78, 0.34);
+  --w-l3-bg: rgba(214, 168, 92, 0.105);
+  --w-l3-fg: #ccb389;
+  --w-l3-bd: rgba(214, 168, 92, 0.26);
+  --w-l4-bg: rgba(206, 180, 128, 0.07);
+  --w-l4-fg: #b3a991;
+  --w-l4-bd: rgba(206, 180, 128, 0.2);
+}
+
+@layer components {
+  /* Card/panel: 1px border + a shallow 3D bottom "lip" instead of a drop shadow (#147 §4.2). */
+  .panel {
+    @apply rounded-xl border border-border border-b-4 bg-card;
+    border-bottom-color: var(--lip);
+  }
 }
 
 html {

--- a/src/app/journal/components/CorrectionBadge.tsx
+++ b/src/app/journal/components/CorrectionBadge.tsx
@@ -3,7 +3,7 @@ import { correctionTypeLabels } from '../constants';
 export default function CorrectionBadge({ type }: { type: string }) {
   const info = correctionTypeLabels[type] || {
     label: type,
-    className: 'bg-zinc-100 text-zinc-600',
+    className: 'bg-muted text-muted-foreground',
   };
   return (
     <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${info.className}`}>

--- a/src/app/journal/components/CorrectionView.tsx
+++ b/src/app/journal/components/CorrectionView.tsx
@@ -9,12 +9,12 @@ export default function CorrectionView({ entry }: { entry: JournalEntry }) {
     <div className="space-y-6">
       {/* Original with inline highlights */}
       <div>
-        <h3 className="mb-2 text-sm font-medium text-zinc-500 dark:text-zinc-400">Your text</h3>
-        <div className="rounded-lg bg-zinc-50 p-4 text-sm leading-relaxed whitespace-pre-wrap dark:bg-zinc-900">
+        <h3 className="mb-2 text-sm font-medium text-muted-foreground">Your text</h3>
+        <div className="rounded-lg bg-muted p-4 text-sm leading-relaxed whitespace-pre-wrap">
           <HighlightedText body={entry.body} corrections={corrections} />
         </div>
         {corrections.length > 0 && (
-          <p className="mt-1 text-xs text-zinc-400 dark:text-zinc-500">
+          <p className="mt-1 text-xs text-muted-foreground">
             Click highlighted words to see corrections
           </p>
         )}
@@ -23,8 +23,8 @@ export default function CorrectionView({ entry }: { entry: JournalEntry }) {
       {/* Corrected version */}
       {entry.correctedBody && entry.correctedBody !== entry.body && (
         <div>
-          <h3 className="mb-2 text-sm font-medium text-zinc-500 dark:text-zinc-400">Corrected</h3>
-          <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-sm leading-relaxed whitespace-pre-wrap dark:border-green-900 dark:bg-green-950/30">
+          <h3 className="mb-2 text-sm font-medium text-muted-foreground">Corrected</h3>
+          <div className="rounded-lg border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] p-4 text-sm leading-relaxed whitespace-pre-wrap">
             {entry.correctedBody}
           </div>
         </div>
@@ -33,7 +33,7 @@ export default function CorrectionView({ entry }: { entry: JournalEntry }) {
       {/* Summary */}
       {corrections.length > 0 ? (
         <div className="flex flex-wrap gap-2">
-          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          <span className="text-xs text-muted-foreground">
             {corrections.length} correction{corrections.length !== 1 ? 's' : ''}:
           </span>
           {corrections.map((c, i) => (
@@ -41,8 +41,8 @@ export default function CorrectionView({ entry }: { entry: JournalEntry }) {
           ))}
         </div>
       ) : (
-        <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-center dark:border-green-900 dark:bg-green-950/30">
-          <p className="font-medium text-green-800 dark:text-green-300">
+        <div className="rounded-lg border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] p-4 text-center">
+          <p className="font-medium text-primary">
             Perfek! No corrections needed.
           </p>
         </div>

--- a/src/app/journal/components/EntryModal.tsx
+++ b/src/app/journal/components/EntryModal.tsx
@@ -16,16 +16,16 @@ export default function EntryModal({
       onClick={onClose}
     >
       <div
-        className="max-h-[80vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900"
+        className="max-h-[80vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-card p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          <h2 className="text-lg font-semibold text-foreground">
             {formatDateTime(entry.createdAt)}
           </h2>
           <button
             onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+            className="text-muted-foreground hover:text-foreground"
           >
             <X className="h-5 w-5" />
           </button>
@@ -33,7 +33,7 @@ export default function EntryModal({
         {entry.status === 'submitted' ? (
           <CorrectionView entry={entry} />
         ) : (
-          <div className="rounded-lg bg-zinc-50 p-4 text-sm leading-relaxed whitespace-pre-wrap dark:bg-zinc-800">
+          <div className="rounded-lg bg-muted p-4 text-sm leading-relaxed whitespace-pre-wrap">
             {entry.body}
           </div>
         )}

--- a/src/app/journal/components/HighlightedText.tsx
+++ b/src/app/journal/components/HighlightedText.tsx
@@ -47,21 +47,21 @@ export default function HighlightedText({
             e.stopPropagation();
             setActiveIdx(isActive ? null : span.correctionIdx);
           }}
-          className="-mx-0.5 cursor-pointer rounded px-0.5 text-red-700 underline decoration-red-400 decoration-wavy underline-offset-4 transition-colors hover:bg-red-50 dark:text-red-400 dark:decoration-red-500 dark:hover:bg-red-950/30"
+          className="-mx-0.5 cursor-pointer rounded px-0.5 text-destructive underline decoration-destructive decoration-wavy underline-offset-4 transition-colors hover:bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))]"
         >
           {body.slice(span.start, span.end)}
         </button>
         {isActive && (
-          <span className="absolute top-full left-0 z-10 mt-1 w-64 rounded-lg border border-zinc-200 bg-white p-3 text-left shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+          <span className="absolute top-full left-0 z-10 mt-1 w-64 rounded-lg border border-border bg-popover p-3 text-left shadow-lg">
             <span className="mb-1 flex items-center gap-2">
               <CorrectionBadge type={c.type} />
             </span>
             <span className="mb-1 block text-sm">
-              <span className="text-red-600 line-through dark:text-red-400">{c.original}</span>
+              <span className="text-destructive line-through">{c.original}</span>
               {' → '}
-              <span className="font-medium text-green-700 dark:text-green-400">{c.corrected}</span>
+              <span className="font-medium text-primary">{c.corrected}</span>
             </span>
-            <span className="block text-xs text-zinc-500 dark:text-zinc-400">{c.explanation}</span>
+            <span className="block text-xs text-muted-foreground">{c.explanation}</span>
           </span>
         )}
       </span>,

--- a/src/app/journal/components/HistoryCard.tsx
+++ b/src/app/journal/components/HistoryCard.tsx
@@ -17,21 +17,21 @@ export default function HistoryCard({
   return (
     <div
       onClick={() => onSelect(entry)}
-      className="cursor-pointer rounded-lg border border-zinc-200 p-4 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+      className="cursor-pointer rounded-lg border border-border p-4 transition-colors hover:bg-accent"
     >
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+        <span className="text-sm font-medium text-foreground">
           {formatDateTime(entry.createdAt)}
         </span>
         <div className="flex items-center gap-2">
           {entry.status === 'submitted' ? (
-            <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">
+            <span className="rounded-full bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] px-2 py-0.5 text-xs font-medium text-primary">
               {correctionCount > 0
                 ? `${correctionCount} correction${correctionCount !== 1 ? 's' : ''}`
                 : 'Perfect'}
             </span>
           ) : (
-            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+            <span className="rounded-full bg-[var(--gold-soft)] px-2 py-0.5 text-xs font-medium text-[var(--gold-strong)]">
               Draft
             </span>
           )}
@@ -40,15 +40,15 @@ export default function HistoryCard({
               e.stopPropagation();
               onDelete(entry.id);
             }}
-            className="text-zinc-400 transition-colors hover:text-red-500"
+            className="text-muted-foreground transition-colors hover:text-destructive"
             title="Delete entry"
           >
             <Trash2 className="h-4 w-4" />
           </button>
         </div>
       </div>
-      <p className="line-clamp-2 text-sm text-zinc-600 dark:text-zinc-400">{preview}</p>
-      <p className="mt-1 text-xs text-zinc-400 dark:text-zinc-500">
+      <p className="line-clamp-2 text-sm text-muted-foreground">{preview}</p>
+      <p className="mt-1 text-xs text-muted-foreground">
         {entry.wordCount} word{entry.wordCount > 1 ? 's' : ''}
       </p>
     </div>

--- a/src/app/journal/constants.ts
+++ b/src/app/journal/constants.ts
@@ -1,8 +1,18 @@
 export const correctionTypeLabels: Record<string, { label: string; className: string }> = {
-  grammar: { label: 'Grammar', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300' },
-  spelling: { label: 'Spelling', className: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300' },
-  word_choice: { label: 'Word choice', className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300' },
-  word_order: { label: 'Word order', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300' },
-  missing_word: { label: 'Missing word', className: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300' },
-  extra_word: { label: 'Extra word', className: 'bg-zinc-100 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300' },
+  grammar: { label: 'Grammar', className: 'bg-[var(--clay-soft)] text-clay ' },
+  spelling: {
+    label: 'Spelling',
+    className:
+      'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive',
+  },
+  word_choice: {
+    label: 'Word choice',
+    className: 'bg-[var(--gold-soft)] text-[var(--gold-strong)]',
+  },
+  word_order: {
+    label: 'Word order',
+    className: 'bg-[var(--primary-soft)] text-primary',
+  },
+  missing_word: { label: 'Missing word', className: 'bg-[var(--gold-soft)] text-[var(--gold-strong)] ' },
+  extra_word: { label: 'Extra word', className: 'bg-muted text-muted-foreground' },
 };

--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -140,7 +140,7 @@ export default function JournalPage() {
       {showEditor && (
         <section className="mb-10">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+            <h2 className="text-sm font-medium text-muted-foreground">
               {formatDate(new Date().toISOString())}
             </h2>
             <Button
@@ -161,43 +161,42 @@ export default function JournalPage() {
               value={bodyText}
               onChange={(e) => handleBodyChange(e.target.value)}
               placeholder="Skryf vandag se joernaal inskrywing in Afrikaans..."
-              className="min-h-[160px] w-full resize-y rounded-lg border border-zinc-300 bg-white p-4 text-sm leading-relaxed text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder-zinc-500"
+              className="min-h-[160px] w-full resize-y rounded-lg border border-input bg-background p-4 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
               disabled={isSubmitting}
               autoFocus
             />
 
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
+              <div className="flex items-center gap-3 text-xs text-muted-foreground">
                 <span>
                   {wordCount} word{wordCount > 1 ? 's' : ''}
                 </span>
                 {saveStatus && (
-                  <span className="text-green-600 dark:text-green-400">{saveStatus}</span>
+                  <span className="text-primary">{saveStatus}</span>
                 )}
               </div>
 
               <div className="flex items-center gap-2">
-                <button
+                <Button
                   onClick={handleSaveDraft}
                   disabled={isSaving || isSubmitting || !bodyText.trim()}
-                  className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  variant="secondary"
                 >
                   {isSaving ? 'Saving...' : 'Save Draft'}
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={handleSubmit}
                   disabled={isSubmitting || !bodyText.trim()}
-                  className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
                 >
                   {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
                   {isSubmitting ? 'Correcting...' : 'Submit for Correction'}
-                </button>
+                </Button>
               </div>
             </div>
           </div>
 
           {error && (
-            <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+            <div className="mt-3 rounded-lg border border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] p-3 text-sm text-destructive">
               {error}
             </div>
           )}
@@ -205,7 +204,7 @@ export default function JournalPage() {
       )}
       {entries.length > 0 ? (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
             {entries.length} entr{entries.length !== 1 ? 'ies' : 'y'}
           </h2>
           <div className="space-y-2">
@@ -227,7 +226,7 @@ export default function JournalPage() {
         </section>
       ) : !showEditor ? (
         <div className="py-16 text-center">
-          <p className="mb-4 text-zinc-500 dark:text-zinc-400">No journal entries yet</p>
+          <p className="mb-4 text-muted-foreground">No journal entries yet</p>
           <Button onClick={handleNewEntry}>Write your first entry</Button>
         </div>
       ) : null}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Inter, Literata } from 'next/font/google';
+import { Nunito, Literata } from 'next/font/google';
 import Script from 'next/script';
 import { Toaster } from 'sonner';
 import ChatWidget from '@/components/ChatWidget';
@@ -7,9 +7,11 @@ import SetupGuard from '@/components/SetupGuard';
 import './globals.css';
 import NavHeader from '@/components/NavHeader';
 
-const inter = Inter({
-  variable: '--font-inter',
+// Nunito is the UI/chrome font; Literata stays the reading body (issue #147 §2.1).
+const nunito = Nunito({
+  variable: '--font-nunito',
   subsets: ['latin'],
+  weight: ['400', '600', '700', '800'],
 });
 
 const literata = Literata({
@@ -40,7 +42,7 @@ export default function RootLayout({
       </head>
 
       <body
-        className={`${inter.variable} ${literata.variable} flex min-h-screen flex-col bg-gray-50 font-sans text-gray-900 antialiased sm:flex-row dark:bg-gray-900 dark:text-gray-100`}
+        className={`${nunito.variable} ${literata.variable} flex min-h-screen flex-col bg-background font-sans text-foreground antialiased sm:flex-row`}
       >
         <NavHeader />
 

--- a/src/app/practice/components/EmptyState/index.tsx
+++ b/src/app/practice/components/EmptyState/index.tsx
@@ -9,13 +9,13 @@ export default function EmptyState({
 }: IEmptyStateProps) {
   return (
     <div className="py-8 text-center">
-      <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-900/50 dark:text-amber-400">
+      <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-[var(--gold-soft)] text-[var(--gold-strong)]">
         <Clock className="h-8 w-8" />
       </div>
-      <h2 className="mb-2 text-xl font-bold text-zinc-900 dark:text-zinc-50">
+      <h2 className="mb-2 text-xl font-bold text-foreground">
         {roundType === 'review' ? 'Nothing to Review' : 'No New Sentences'}
       </h2>
-      <p className="mx-auto mb-6 max-w-xs text-sm text-zinc-500 dark:text-zinc-400">
+      <p className="mx-auto mb-6 max-w-xs text-sm text-muted-foreground">
         {roundType === 'review'
           ? 'No sentences are due for review right now. Try learning new ones or check back later.'
           : "You've seen all the sentences in this collection. Try a different collection or review existing ones."}

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -691,8 +691,8 @@ export default function PracticePage() {
               );
               if (totalDue === 0) return null;
               return (
-                <div className="mb-8 rounded-2xl border border-amber-200 bg-amber-50 p-5 dark:border-amber-800/50 dark:bg-amber-950/20">
-                  <h2 className="mb-3 text-base font-semibold text-amber-800 dark:text-amber-300">
+                <div className="mb-8 rounded-2xl border border-[var(--gold-lip)] bg-[var(--gold-soft)] p-5">
+                  <h2 className="mb-3 text-base font-semibold text-[var(--gold-strong)]">
                     Review Due ({totalDue})
                   </h2>
                   <div className="space-y-2">
@@ -708,12 +708,12 @@ export default function PracticePage() {
                             setRoundSize(Math.min(due, 20) as RoundSize);
                             startRoundWith(coll, 'review', Math.min(due, 20));
                           }}
-                          className="flex w-full items-center justify-between rounded-xl border border-zinc-200 bg-white px-4 py-3 transition-all hover:border-amber-400 active:scale-[0.98] dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-amber-600"
+                          className="flex w-full items-center justify-between rounded-xl border border-border bg-card px-4 py-3 transition-all hover:border-[var(--gold-strong)] active:scale-[0.98]"
                         >
-                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                          <span className="font-medium text-foreground">
                             {COLLECTION_LABELS[coll]}
                           </span>
-                          <span className="text-sm font-semibold text-amber-600 dark:text-amber-400">
+                          <span className="text-sm font-semibold text-[var(--gold-strong)]">
                             {due} due
                           </span>
                         </button>
@@ -725,8 +725,8 @@ export default function PracticePage() {
             })()}
 
             {/* Learn New section */}
-            <div className="rounded-2xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
-              <h2 className="mb-4 text-base font-semibold text-zinc-900 dark:text-zinc-100">
+            <div className="rounded-2xl border border-border bg-card p-5">
+              <h2 className="mb-4 text-base font-semibold text-foreground">
                 Learn New
               </h2>
 
@@ -757,7 +757,7 @@ export default function PracticePage() {
               {/* Round size + Mode in a row */}
               <div className="mb-4 flex gap-4">
                 <div className="flex-1">
-                  <label className="mb-2 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                  <label className="mb-2 block text-xs font-medium text-muted-foreground">
                     Sentences
                   </label>
                   <div className="flex gap-1.5">
@@ -777,7 +777,7 @@ export default function PracticePage() {
                   </div>
                 </div>
                 <div className="">
-                  <label className="mb-2 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                  <label className="mb-2 block text-xs font-medium text-muted-foreground">
                     Mode
                   </label>
                   <div className="flex gap-1.5">
@@ -824,7 +824,7 @@ export default function PracticePage() {
               >
                 &larr; Back
               </button>
-              <span className="flex items-center gap-1.5 text-sm font-medium text-amber-600 dark:text-amber-400">
+              <span className="flex items-center gap-1.5 text-sm font-medium text-[var(--gold-strong)]">
                 <Star className="h-4 w-4" fill="currentColor" />
                 {points.toLocaleString()}
               </span>
@@ -832,7 +832,7 @@ export default function PracticePage() {
 
             {/* Round progress bar */}
             <div>
-              <div className="flex items-center justify-between text-sm text-zinc-500 dark:text-zinc-400">
+              <div className="flex items-center justify-between text-sm text-muted-foreground">
                 <span>{COLLECTION_LABELS[selectedCollection]}</span>
                 <span className="font-medium">
                   {roundProgress}/{roundSize}
@@ -850,12 +850,12 @@ export default function PracticePage() {
 
         {/* Main content area */}
         {state !== 'setup' && (
-          <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
             {/* Loading state */}
             {state === 'loading' && (
               <div className="flex flex-col items-center justify-center py-12">
-                <div className="mb-4 h-10 w-10 animate-spin rounded-full border-4 border-zinc-200 border-t-blue-500 dark:border-zinc-700 dark:border-t-blue-400" />
-                <p className="text-zinc-500 dark:text-zinc-400">Loading sentences...</p>
+                <div className="mb-4 h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-primary" />
+                <p className="text-muted-foreground">Loading sentences...</p>
               </div>
             )}
 
@@ -865,10 +865,10 @@ export default function PracticePage() {
               (() => {
                 const fuzzyStatus = getFuzzyStatus(userAnswer, current.sentence.clozeWord);
                 const inputColorClass = {
-                  empty: 'border-blue-400 bg-blue-50 dark:bg-blue-950/50',
-                  match: 'border-green-500 bg-green-50 dark:bg-green-950/50',
-                  partial: 'border-green-400 bg-green-50/50 dark:bg-green-950/30',
-                  wrong: 'border-red-400 bg-red-50 dark:bg-red-950/50',
+                  empty: 'border-[var(--clay)] bg-[color-mix(in_srgb,var(--clay)_14%,var(--card))]',
+                  match: 'border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))]',
+                  partial: 'border-primary bg-[color-mix(in_srgb,var(--primary)_8%,var(--card))]',
+                  wrong: 'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))]',
                 }[fuzzyStatus];
 
                 const words = current.sentence.sentence.split(/\s+/);
@@ -883,7 +883,7 @@ export default function PracticePage() {
                     {/* Sentence with inline input or blank */}
                     <div className="mb-6">
                       <div className="mb-4 flex items-center justify-between">
-                        <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+                        <span className="text-sm font-medium text-muted-foreground">
                           {practiceMode === 'mc' || mcFallback
                             ? 'Choose the correct word'
                             : 'Fill in the blank'}
@@ -893,7 +893,7 @@ export default function PracticePage() {
                           onSentenceBlacklisted={handleSentenceBlacklisted}
                         />
                       </div>
-                      <p className="text-xl leading-loose font-medium text-zinc-900 dark:text-zinc-50">
+                      <p className="text-xl leading-loose font-medium text-foreground">
                         {words.map((word, i) => (
                           <span key={i}>
                             {i > 0 && ' '}
@@ -916,12 +916,12 @@ export default function PracticePage() {
                                     autoCorrect="off"
                                     spellCheck={false}
                                     placeholder="..."
-                                    className={`inline-block w-32 rounded-lg border-2 px-2 py-1 text-center text-xl font-medium transition-all outline-none focus:ring-2 focus:ring-offset-1 ${inputColorClass} ${fuzzyStatus === 'match' ? 'text-green-700 focus:ring-green-400 dark:text-green-300' : ''} ${fuzzyStatus === 'partial' ? 'text-green-600 focus:ring-green-400 dark:text-green-400' : ''} ${fuzzyStatus === 'wrong' ? 'text-red-600 focus:ring-red-400 dark:text-red-400' : ''} ${fuzzyStatus === 'empty' ? 'text-zinc-900 focus:ring-blue-400 dark:text-zinc-100' : ''} `}
+                                    className={`inline-block w-32 rounded-lg border-2 px-2 py-1 text-center text-xl font-medium transition-all outline-none focus:ring-2 focus:ring-offset-1 ${inputColorClass} ${fuzzyStatus === 'match' ? 'text-primary focus:ring-ring' : ''} ${fuzzyStatus === 'partial' ? 'text-primary focus:ring-ring' : ''} ${fuzzyStatus === 'wrong' ? 'text-destructive focus:ring-destructive' : ''} ${fuzzyStatus === 'empty' ? 'text-foreground focus:ring-ring' : ''} `}
                                     style={{ minWidth: `${Math.max(clozeBase.length * 0.7, 4)}ch` }}
                                   />
                                 ) : (
                                   <span
-                                    className="inline-block rounded-lg border-2 border-blue-400 bg-blue-50 px-3 py-1 text-center text-xl font-bold text-blue-600 dark:bg-blue-950/50 dark:text-blue-300"
+                                    className="inline-block rounded-lg border-2 border-[var(--clay)] bg-[color-mix(in_srgb,var(--clay)_14%,var(--card))] px-3 py-1 text-center text-xl font-bold text-foreground"
                                     style={{ minWidth: `${Math.max(clozeBase.length * 0.7, 4)}ch` }}
                                   >
                                     _____
@@ -933,7 +933,7 @@ export default function PracticePage() {
                               <span
                                 data-testid="cloze-word"
                                 onClick={() => handleWordClick(word)}
-                                className="cursor-pointer rounded px-0.5 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:hover:bg-blue-900/40 dark:hover:text-blue-300"
+                                className="cursor-pointer rounded px-0.5 transition-colors hover:bg-accent hover:text-foreground"
                               >
                                 {word}
                               </span>
@@ -942,7 +942,7 @@ export default function PracticePage() {
                         ))}
                       </p>
                       {/* English translation */}
-                      <p className="mt-3 text-base text-zinc-500 italic dark:text-zinc-400">
+                      <p className="mt-3 text-base text-muted-foreground italic">
                         {current.sentence.translation}
                       </p>
                     </div>
@@ -1023,7 +1023,7 @@ export default function PracticePage() {
                       </div>
                     )}
                     {/* Mastery indicator */}
-                    <div className="mt-6 flex items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
+                    <div className="mt-6 flex items-center justify-center gap-2 text-sm text-muted-foreground">
                       <span>Mastery:</span>
                       <div className="flex h-2 w-24 overflow-hidden rounded-full bg-muted">
                         <div
@@ -1042,7 +1042,7 @@ export default function PracticePage() {
               <div>
                 <div className="mb-4">
                   <div className="mb-2 flex items-center justify-between">
-                    <span className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+                    <span className="text-sm font-medium text-muted-foreground">
                       {feedbackData.isCorrect ? 'Correct!' : 'Incorrect'}
                     </span>
                     {ttsSupported && feedbackData.isCorrect && (
@@ -1052,7 +1052,7 @@ export default function PracticePage() {
                       </Button>
                     )}
                   </div>
-                  <p className="text-xl leading-relaxed font-medium text-zinc-900 dark:text-zinc-50">
+                  <p className="text-xl leading-relaxed font-medium text-foreground">
                     {current.sentence.sentence.split(/\s+/).map((word, i) => (
                       <span key={i}>
                         {i > 0 && ' '}
@@ -1062,8 +1062,8 @@ export default function PracticePage() {
                             onClick={() => handleWordClick(word)}
                             className={`cursor-pointer rounded px-1 font-bold ${
                               feedbackData.isCorrect
-                                ? 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/50 dark:text-green-300 dark:hover:bg-green-900/70'
-                                : 'bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/50 dark:text-red-300 dark:hover:bg-red-900/70'
+                                ? 'border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
+                                : 'border border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
                             }`}
                           >
                             {word}
@@ -1072,7 +1072,7 @@ export default function PracticePage() {
                           <span
                             data-testid="cloze-word"
                             onClick={() => handleWordClick(word)}
-                            className="cursor-pointer rounded px-0.5 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:hover:bg-blue-900/40 dark:hover:text-blue-300"
+                            className="cursor-pointer rounded px-0.5 transition-colors hover:bg-accent hover:text-foreground"
                           >
                             {word}
                           </span>
@@ -1080,7 +1080,7 @@ export default function PracticePage() {
                       </span>
                     ))}
                   </p>
-                  <p className="mt-2 text-base text-zinc-500 italic dark:text-zinc-400">
+                  <p className="mt-2 text-base text-muted-foreground italic">
                     {current.sentence.translation}
                   </p>
                 </div>
@@ -1105,16 +1105,16 @@ export default function PracticePage() {
 
             {state === 'complete' && (
               <div className="py-8 text-center">
-                <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400">
+                <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary">
                   <CheckCircle className="h-8 w-8" />
                 </div>
-                <h2 className="mb-2 text-xl font-bold text-zinc-900 dark:text-zinc-50">
+                <h2 className="mb-2 text-xl font-bold text-foreground">
                   Round Complete!
                 </h2>
-                <p className="mb-1 text-zinc-500 dark:text-zinc-400">
+                <p className="mb-1 text-muted-foreground">
                   {roundCorrect}/{roundProgress} correct
                 </p>
-                <p className="mb-6 text-sm text-zinc-400 dark:text-zinc-500">
+                <p className="mb-6 text-sm text-muted-foreground">
                   {points.toLocaleString()} total points
                 </p>
                 <div className="flex justify-center gap-3">

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -732,18 +732,15 @@ export default function PracticePage() {
 
               {/* Collection */}
               <div className="mb-4">
-                <div className="flex gap-2">
+                <div className="grid grid-cols-3 gap-2">
                   {VISIBLE_COLLECTIONS.map((coll) => {
                     const count = collectionCounts?.[coll];
                     return (
-                      <button
+                      <Button
                         key={coll}
                         onClick={() => setSelectedCollection(coll)}
-                        className={`flex-1 rounded-xl py-2.5 text-sm font-semibold transition-all ${
-                          selectedCollection === coll
-                            ? 'bg-blue-500 text-white shadow-md'
-                            : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
-                        }`}
+                        variant={selectedCollection === coll ? 'default' : 'secondary'}
+                        className="flex h-14 flex-col justify-center gap-0"
                       >
                         <div>{COLLECTION_LABELS[coll]}</div>
                         {count && count.total > 0 && (
@@ -751,7 +748,7 @@ export default function PracticePage() {
                             {count.mastered}/{count.total} mastered
                           </div>
                         )}
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>
@@ -765,60 +762,49 @@ export default function PracticePage() {
                   </label>
                   <div className="flex gap-1.5">
                     {ROUND_SIZES.map((size) => (
-                      <button
+                      <Button
                         key={size}
+                        size="sm"
+                        variant={roundSize === size ? 'default' : 'secondary'}
                         onClick={() => {
                           setOriginalRoundSize(size);
                           setRoundSize(size);
                         }}
-                        className={`flex-1 rounded-lg py-2 text-sm font-semibold transition-all ${
-                          roundSize === size
-                            ? 'bg-blue-500 text-white'
-                            : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
-                        }`}
                       >
                         {size}
-                      </button>
+                      </Button>
                     ))}
                   </div>
                 </div>
-                <div className="w-40">
+                <div className="">
                   <label className="mb-2 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
                     Mode
                   </label>
                   <div className="flex gap-1.5">
-                    <button
+                    <Button
                       onClick={() => handleSetPracticeMode('type')}
-                      className={`flex-1 rounded-lg py-2 text-sm font-semibold transition-all ${
-                        practiceMode === 'type'
-                          ? 'bg-blue-500 text-white'
-                          : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
-                      }`}
+                      variant={practiceMode === 'type' ? 'default' : 'secondary'}
                     >
                       Type
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() => handleSetPracticeMode('mc')}
-                      className={`flex-1 rounded-lg py-2 text-sm font-semibold transition-all ${
-                        practiceMode === 'mc'
-                          ? 'bg-blue-500 text-white'
-                          : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700'
-                      }`}
+                      variant={practiceMode === 'mc' ? 'default' : 'secondary'}
                     >
                       MC
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </div>
 
               {/* Start button */}
-              <button
+              <Button
                 onClick={() => startRoundWith(selectedCollection, 'new', roundSize)}
                 disabled={!seeded}
-                className="w-full rounded-xl bg-blue-600 py-3.5 text-lg font-bold text-white transition-all hover:bg-blue-700 active:scale-[0.98] disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                className="w-full"
               >
                 {seeded ? 'Start' : 'Loading...'}
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -820,7 +820,7 @@ export default function PracticePage() {
                   const counts = await getCollectionCounts();
                   setCollectionCounts(counts);
                 }}
-                className="text-sm text-zinc-500 transition-colors hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                className="text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 &larr; Back
               </button>
@@ -838,9 +838,9 @@ export default function PracticePage() {
                   {roundProgress}/{roundSize}
                 </span>
               </div>
-              <div className="mt-1 h-3 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+              <div className="mt-1 h-3 w-full overflow-hidden rounded-full bg-muted">
                 <div
-                  className="h-full rounded-full bg-gradient-to-r from-blue-500 to-indigo-500 transition-all duration-500"
+                  className="h-full rounded-full bg-gradient-to-r from-[color-mix(in_srgb,var(--primary)_55%,#fff)] to-primary transition-all duration-500"
                   style={{ width: `${progressPercent}%` }}
                 />
               </div>
@@ -952,18 +952,18 @@ export default function PracticePage() {
                       <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
                         {mcOptions.map((option, idx) => {
                           let btnClass =
-                            'border-zinc-200 bg-zinc-50 text-zinc-900 hover:bg-zinc-100 hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700';
+                            'border-border bg-card text-foreground hover:bg-accent';
 
                           if (mcSelected !== null) {
                             if (idx === mcCorrectIdx) {
                               btnClass =
-                                'border-green-500 bg-green-50 text-green-800 dark:border-green-400 dark:bg-green-950/50 dark:text-green-200';
+                                'border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary';
                             } else if (idx === mcSelected) {
                               btnClass =
-                                'border-red-500 bg-red-50 text-red-800 dark:border-red-400 dark:bg-red-950/50 dark:text-red-200';
+                                'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive';
                             } else {
                               btnClass =
-                                'border-zinc-200 bg-zinc-50 text-zinc-400 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-500';
+                                'border-border bg-card text-muted-foreground opacity-60';
                             }
                           }
 
@@ -975,7 +975,7 @@ export default function PracticePage() {
                               disabled={mcLocked}
                               className={`flex items-center gap-3 rounded-xl border-2 px-4 py-4 text-left text-lg font-medium transition-all active:scale-[0.98] ${btnClass}`}
                             >
-                              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-sm font-bold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+                              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-secondary text-sm font-bold text-secondary-foreground">
                                 {idx + 1}
                               </span>
                               {option}
@@ -988,22 +988,22 @@ export default function PracticePage() {
                     {/* Type mode buttons */}
                     {practiceMode === 'type' && !mcFallback && (
                       <div className="flex justify-center gap-2">
-                        <button
+                        <Button
                           type="button"
+                          variant="secondary"
                           onClick={() => {
                             if (!current) return;
                             generateMcOptionsForSentence(current.sentence, queue);
                             setMcFallback(true);
                           }}
-                          className="rounded-xl bg-purple-50 px-4 py-3 text-sm font-medium text-purple-600 transition-all hover:bg-purple-100 dark:bg-purple-950/30 dark:text-purple-400 dark:hover:bg-purple-950/50"
                           title="Switch to multiple choice for this question"
                         >
                           Multiple Choice
-                        </button>
-                        <button
+                        </Button>
+                        <Button
                           type="button"
+                          variant="secondary"
                           onClick={handleHint}
-                          className="rounded-xl bg-zinc-100 px-4 py-3 text-sm font-medium text-zinc-600 transition-all hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
                           title="Reveal next letter"
                         >
                           Hint (
@@ -1011,27 +1011,23 @@ export default function PracticePage() {
                             ? `${hintLetters} letter${hintLetters > 1 ? 's' : ''}`
                             : '?'}
                           )
-                        </button>
-                        <button
+                        </Button>
+                        <Button
                           type="button"
+                          size="lg"
                           onClick={handleSubmit}
                           disabled={!userAnswer.trim()}
-                          className={`rounded-xl px-6 py-3 text-lg font-semibold transition-all ${
-                            fuzzyStatus === 'match'
-                              ? 'bg-green-600 text-white hover:bg-green-700 active:scale-95 dark:bg-green-500 dark:hover:bg-green-600'
-                              : 'bg-blue-600 text-white hover:bg-blue-700 active:scale-95 dark:bg-blue-500 dark:hover:bg-blue-600'
-                          } disabled:opacity-40`}
                         >
                           {fuzzyStatus === 'match' ? 'Submit' : 'Check'}
-                        </button>
+                        </Button>
                       </div>
                     )}
                     {/* Mastery indicator */}
                     <div className="mt-6 flex items-center justify-center gap-2 text-sm text-zinc-500 dark:text-zinc-400">
                       <span>Mastery:</span>
-                      <div className="flex h-2 w-24 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+                      <div className="flex h-2 w-24 overflow-hidden rounded-full bg-muted">
                         <div
-                          className="bg-blue-500 transition-all"
+                          className="bg-primary transition-all"
                           style={{ width: `${current.sentence.masteryLevel}%` }}
                         />
                       </div>

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, use, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import MarkdownReader from '@/components/MarkdownReader';
 import TranslationDrawer from '@/components/TranslationDrawer';
+import { Button } from '@/components/ui/button';
 import {
   type Lesson,
   type LessonSummary,
@@ -555,10 +556,10 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-zinc-900">
+      <div className="flex min-h-screen items-center justify-center bg-card">
         <div className="flex flex-col items-center gap-4">
-          <div className="h-10 w-10 animate-spin rounded-full border-3 border-blue-500 border-t-transparent" />
-          <p className="text-zinc-600 dark:text-zinc-400">Loading lesson...</p>
+          <div className="h-10 w-10 animate-spin rounded-full border-3 border-primary border-t-transparent" />
+          <p className="text-muted-foreground">Loading lesson...</p>
         </div>
       </div>
     );
@@ -566,22 +567,19 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
 
   if (error || !lesson) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-white p-8 dark:bg-zinc-900">
-        <div className="mb-4 text-xl text-red-500 dark:text-red-400">
+      <div className="flex min-h-screen flex-col items-center justify-center bg-card p-8">
+        <div className="mb-4 text-xl text-destructive">
           {error || 'Lesson not found'}
         </div>
-        <button
-          onClick={() => router.push('/')}
-          className="rounded-lg bg-zinc-200 px-4 py-2 text-zinc-900 transition-colors hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
-        >
+        <Button variant="secondary" onClick={() => router.push('/')}>
           Go to Library
-        </button>
+        </Button>
       </div>
     );
   }
 
   return (
-    <div className="flex h-dvh flex-col overflow-x-hidden bg-white dark:bg-zinc-900">
+    <div className="flex h-dvh flex-col overflow-x-hidden bg-card">
       <div className="relative flex-1 overflow-hidden">
         <MarkdownReader
           lesson={lesson}

--- a/src/app/settings/components/APITokens/index.tsx
+++ b/src/app/settings/components/APITokens/index.tsx
@@ -29,9 +29,9 @@ export default function APITokens() {
   };
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <section className="panel p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">API Tokens</h2>
+        <h2 className="text-lg font-semibold text-foreground">API Tokens</h2>
         {!showTokenForm && !createdToken && (
           <Button
             onClick={() => {
@@ -75,7 +75,7 @@ export default function APITokens() {
 
       {/* Create token form */}
       {showTokenForm && (
-        <div className="mb-4 rounded-md border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+        <div className="mb-4 rounded-md border border-border bg-muted p-4">
           <div className="mb-3">
             <label className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
               Token Name
@@ -85,7 +85,7 @@ export default function APITokens() {
               value={newTokenName}
               onChange={(e) => setNewTokenName(e.target.value)}
               placeholder="e.g. CLI, Automation, Backup script"
-              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
           </div>
 
@@ -111,8 +111,8 @@ export default function APITokens() {
                   key={value}
                   className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
                     newTokenScopes.includes(value)
-                      ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                      : 'border-zinc-300 bg-white text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300'
+                      ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                      : 'border-input bg-background text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300'
                   } ${
                     newTokenScopes.includes('*') && value !== '*'
                       ? 'cursor-not-allowed opacity-50'
@@ -170,7 +170,7 @@ export default function APITokens() {
                 }
               }}
               disabled={!newTokenName.trim() || newTokenScopes.length === 0}
-              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Create Token
             </button>
@@ -181,7 +181,7 @@ export default function APITokens() {
                 setNewTokenScopes(['*']);
                 setTokenError(null);
               }}
-              className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+              className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent"
             >
               Cancel
             </button>
@@ -206,7 +206,7 @@ export default function APITokens() {
                     {(token.scopes.includes('*') ? ['Full Access'] : token.scopes).map((scope) => (
                       <span
                         key={scope}
-                        className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                        className="rounded-full bg-[var(--primary-soft)] px-2 py-0.5 text-xs font-medium text-primary"
                       >
                         {scope}
                       </span>

--- a/src/app/settings/components/APITokens/index.tsx
+++ b/src/app/settings/components/APITokens/index.tsx
@@ -44,25 +44,25 @@ export default function APITokens() {
         )}
       </div>
 
-      <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      <p className="mb-4 text-sm text-muted-foreground">
         Create personal access tokens for CLI or API access. Tokens are scoped to specific
         permissions.
       </p>
 
       {tokenError && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div className="mb-4 rounded-md bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] p-3 text-sm text-destructive ">
           {tokenError}
         </div>
       )}
 
       {/* One-time token display */}
       {createdToken && (
-        <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-900/20">
-          <p className="mb-2 text-sm font-medium text-amber-800 dark:text-amber-300">
+        <div className="mb-4 rounded-md border border-[var(--gold-lip)] bg-[var(--gold-soft)] p-4 ">
+          <p className="mb-2 text-sm font-medium text-[var(--gold-strong)] ">
             Copy this token now &mdash; it won&apos;t be shown again.
           </p>
           <div className="mb-2 flex items-center gap-2">
-            <code className="flex-1 rounded border border-amber-200 bg-white px-3 py-2 font-mono text-sm break-all text-zinc-900 select-all dark:border-amber-800 dark:bg-zinc-800 dark:text-zinc-100">
+            <code className="flex-1 rounded border border-[var(--gold-lip)] bg-muted px-3 py-2 font-mono text-sm break-all text-foreground select-all   ">
               {createdToken}
             </code>
             <Button onClick={handleCopyTokenButtonPressed}>Copy</Button>
@@ -77,7 +77,7 @@ export default function APITokens() {
       {showTokenForm && (
         <div className="mb-4 rounded-md border border-border bg-muted p-4">
           <div className="mb-3">
-            <label className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-1 block text-sm font-medium text-foreground">
               Token Name
             </label>
             <input
@@ -90,7 +90,7 @@ export default function APITokens() {
           </div>
 
           <div className="mb-3">
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               Scopes
             </label>
             <div className="grid grid-cols-2 gap-2">
@@ -112,11 +112,11 @@ export default function APITokens() {
                   className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
                     newTokenScopes.includes(value)
                       ? 'border-primary bg-[var(--primary-soft)] text-primary'
-                      : 'border-input bg-background text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300'
+                      : 'border-input bg-background text-foreground   '
                   } ${
                     newTokenScopes.includes('*') && value !== '*'
                       ? 'cursor-not-allowed opacity-50'
-                      : 'cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-700'
+                      : 'cursor-pointer hover:bg-accent'
                   }`}
                 >
                   <input
@@ -195,11 +195,11 @@ export default function APITokens() {
           {apiTokens.map((token) => (
             <div
               key={token.id}
-              className="flex items-center justify-between rounded-md border border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-700 dark:bg-zinc-800/50"
+              className="flex items-center justify-between rounded-md border border-border bg-muted px-4 py-3  "
             >
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  <span className="text-sm font-medium text-foreground">
                     {token.name}
                   </span>
                   <div className="flex flex-wrap gap-1">
@@ -213,7 +213,7 @@ export default function APITokens() {
                     ))}
                   </div>
                 </div>
-                <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                <div className="mt-1 text-xs text-muted-foreground">
                   Created {new Date(token.createdAt).toLocaleDateString()}
                   {token.lastUsedAt
                     ? ` · Last used ${new Date(token.lastUsedAt).toLocaleDateString()}`
@@ -236,7 +236,7 @@ export default function APITokens() {
         </div>
       ) : (
         !showTokenForm && (
-          <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          <p className="text-sm text-muted-foreground">
             No tokens created yet. Generate one to use the CLI or access the API remotely.
           </p>
         )

--- a/src/app/settings/components/AnkiSettings/index.tsx
+++ b/src/app/settings/components/AnkiSettings/index.tsx
@@ -48,8 +48,8 @@ export default function AnkiSettings() {
   }, [checkAnkiConnection]);
 
   return (
-    <section className="panel p-6">
-      <div className="mb-4 flex items-center justify-between">
+    <section className="panel space-y-4 p-6">
+      <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Anki Integration</h2>
         <div className="flex items-center gap-2">
           <span
@@ -67,15 +67,18 @@ export default function AnkiSettings() {
       </div>
 
       {ankiError && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
           {ankiError}
         </div>
       )}
 
-      <div className="mb-4">
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           AnkiConnect URL
         </label>
+        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+          Hint: Use Tailscale IP for remote Anki (e.g., http://100.x.x.x:8765)
+        </p>
         <input
           type="text"
           value={ankiConnectUrl}
@@ -87,22 +90,22 @@ export default function AnkiSettings() {
             refreshAnkiUrl();
           }}
           placeholder="http://localhost:8765"
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
         />
-        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
-          Hint: Use Tailscale IP for remote Anki (e.g., http://100.x.x.x:8765)
-        </p>
       </div>
 
-      <div className="mb-4">
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Vocab Deck
         </label>
+        <p className="mb-1 text-xs text-zinc-500 dark:text-zinc-500">
+          Deck for basic cards from reader vocabulary
+        </p>
         {ankiConnected && ankiDecks.length > 0 ? (
           <select
             value={ankiDeckName}
             onChange={(e) => localStorage.setItem(SETTINGS_KEYS.ANKI_DECK_NAME, e.target.value)}
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
           >
             {ankiDecks.map((deck) => (
               <option key={deck} value={deck}>
@@ -116,25 +119,24 @@ export default function AnkiSettings() {
             value={ankiDeckName}
             onChange={(e) => localStorage.setItem(SETTINGS_KEYS.ANKI_DECK_NAME, e.target.value)}
             placeholder="Deck name"
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
           />
         )}
-        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
-          Deck for basic cards from reader vocabulary
-        </p>
       </div>
-
       <div>
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Cloze Practice Deck
         </label>
+        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+          Deck for cloze cards from practice mode
+        </p>
         {ankiConnected && ankiDecks.length > 0 ? (
           <select
             value={ankiClozeDeckName}
             onChange={(e) =>
               localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, e.target.value)
             }
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
           >
             {ankiDecks.map((deck) => (
               <option key={deck} value={deck}>
@@ -146,47 +148,44 @@ export default function AnkiSettings() {
           <input
             type="text"
             value={ankiClozeDeckName}
-            onChange={(e) =>
-              localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, e.target.value)
-            }
+            onChange={(e) => {
+              const newVal = e.target.value;
+
+              localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, newVal);
+              setAnkiClozeDeckName(newVal);
+            }}
             placeholder="Cloze deck name"
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
           />
         )}
-        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
-          Deck for cloze cards from practice mode
-        </p>
       </div>
-
       <div>
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Default Card Type
         </label>
-        <div className="flex gap-2">
-          <button
-            onClick={() => localStorage.setItem(SETTINGS_KEYS.DEFAULT_CARD_TYPE, 'basic')}
-            className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
-              defaultCardType === 'basic'
-                ? 'border-primary bg-[var(--primary-soft)] text-primary'
-                : 'border-border bg-card text-foreground hover:bg-accent'
-            }`}
-          >
-            Basic
-          </button>
-          <button
-            onClick={() => localStorage.setItem(SETTINGS_KEYS.DEFAULT_CARD_TYPE, 'cloze')}
-            className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
-              defaultCardType === 'cloze'
-                ? 'border-primary bg-[var(--primary-soft)] text-primary'
-                : 'border-border bg-card text-foreground hover:bg-accent'
-            }`}
-          >
-            Cloze
-          </button>
-        </div>
-        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
           Basic shows front/back, Cloze creates fill-in-the-blank cards
         </p>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            onClick={(e) => {
+              localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, 'basic');
+              setDefaultCardType('basic');
+            }}
+            variant={defaultCardType === 'basic' ? 'default' : 'secondary'}
+          >
+            Basic
+          </Button>
+          <Button
+            onClick={(e) => {
+              localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, 'cloze');
+              setDefaultCardType('cloze');
+            }}
+            variant={defaultCardType === 'cloze' ? 'default' : 'secondary'}
+          >
+            Cloze
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/src/app/settings/components/AnkiSettings/index.tsx
+++ b/src/app/settings/components/AnkiSettings/index.tsx
@@ -48,9 +48,9 @@ export default function AnkiSettings() {
   }, [checkAnkiConnection]);
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <section className="panel p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Anki Integration</h2>
+        <h2 className="text-lg font-semibold text-foreground">Anki Integration</h2>
         <div className="flex items-center gap-2">
           <span
             className={`inline-block h-2 w-2 rounded-full ${
@@ -87,7 +87,7 @@ export default function AnkiSettings() {
             refreshAnkiUrl();
           }}
           placeholder="http://localhost:8765"
-          className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
         />
         <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
           Hint: Use Tailscale IP for remote Anki (e.g., http://100.x.x.x:8765)
@@ -102,7 +102,7 @@ export default function AnkiSettings() {
           <select
             value={ankiDeckName}
             onChange={(e) => localStorage.setItem(SETTINGS_KEYS.ANKI_DECK_NAME, e.target.value)}
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
           >
             {ankiDecks.map((deck) => (
               <option key={deck} value={deck}>
@@ -116,7 +116,7 @@ export default function AnkiSettings() {
             value={ankiDeckName}
             onChange={(e) => localStorage.setItem(SETTINGS_KEYS.ANKI_DECK_NAME, e.target.value)}
             placeholder="Deck name"
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
           />
         )}
         <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
@@ -134,7 +134,7 @@ export default function AnkiSettings() {
             onChange={(e) =>
               localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, e.target.value)
             }
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
           >
             {ankiDecks.map((deck) => (
               <option key={deck} value={deck}>
@@ -150,7 +150,7 @@ export default function AnkiSettings() {
               localStorage.setItem(SETTINGS_KEYS.ANKI_CLOZE_DECK_NAME, e.target.value)
             }
             placeholder="Cloze deck name"
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
           />
         )}
         <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
@@ -167,8 +167,8 @@ export default function AnkiSettings() {
             onClick={() => localStorage.setItem(SETTINGS_KEYS.DEFAULT_CARD_TYPE, 'basic')}
             className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
               defaultCardType === 'basic'
-                ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                : 'border-border bg-card text-foreground hover:bg-accent'
             }`}
           >
             Basic
@@ -177,8 +177,8 @@ export default function AnkiSettings() {
             onClick={() => localStorage.setItem(SETTINGS_KEYS.DEFAULT_CARD_TYPE, 'cloze')}
             className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
               defaultCardType === 'cloze'
-                ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                : 'border-border bg-card text-foreground hover:bg-accent'
             }`}
           >
             Cloze

--- a/src/app/settings/components/AnkiSettings/index.tsx
+++ b/src/app/settings/components/AnkiSettings/index.tsx
@@ -54,10 +54,10 @@ export default function AnkiSettings() {
         <div className="flex items-center gap-2">
           <span
             className={`inline-block h-2 w-2 rounded-full ${
-              ankiConnected ? 'bg-green-500' : 'bg-red-500'
+              ankiConnected ? 'bg-primary' : 'bg-destructive'
             }`}
           />
-          <span className="text-sm text-zinc-600 dark:text-zinc-400">
+          <span className="text-sm text-muted-foreground">
             {ankiConnected ? 'Connected' : 'Not connected'}
           </span>
           <Button variant="link" onClick={checkAnkiConnection} disabled={ankiLoading}>
@@ -67,16 +67,16 @@ export default function AnkiSettings() {
       </div>
 
       {ankiError && (
-        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+        <div className="rounded-md bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] p-3 text-sm text-destructive ">
           {ankiError}
         </div>
       )}
 
       <div>
-        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-foreground">
           AnkiConnect URL
         </label>
-        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+        <p className="mb-2 text-xs text-muted-foreground">
           Hint: Use Tailscale IP for remote Anki (e.g., http://100.x.x.x:8765)
         </p>
         <input
@@ -95,10 +95,10 @@ export default function AnkiSettings() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-foreground">
           Vocab Deck
         </label>
-        <p className="mb-1 text-xs text-zinc-500 dark:text-zinc-500">
+        <p className="mb-1 text-xs text-muted-foreground">
           Deck for basic cards from reader vocabulary
         </p>
         {ankiConnected && ankiDecks.length > 0 ? (
@@ -124,10 +124,10 @@ export default function AnkiSettings() {
         )}
       </div>
       <div>
-        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-foreground">
           Cloze Practice Deck
         </label>
-        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+        <p className="mb-2 text-xs text-muted-foreground">
           Deck for cloze cards from practice mode
         </p>
         {ankiConnected && ankiDecks.length > 0 ? (
@@ -160,10 +160,10 @@ export default function AnkiSettings() {
         )}
       </div>
       <div>
-        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-foreground">
           Default Card Type
         </label>
-        <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+        <p className="mb-2 text-xs text-muted-foreground">
           Basic shows front/back, Cloze creates fill-in-the-blank cards
         </p>
         <div className="grid grid-cols-2 gap-2">

--- a/src/app/settings/components/DataManagement/index.tsx
+++ b/src/app/settings/components/DataManagement/index.tsx
@@ -54,7 +54,7 @@ export default function DataManagement() {
   };
 
   return (
-    <section className="rounded-lg border border-red-200 bg-white p-6 dark:border-red-900/50 dark:bg-zinc-900">
+    <section className="rounded-lg border border-destructive/30 bg-card p-6 ">
       <h2 className="mb-4 text-lg font-semibold text-foreground">
         Data Management
       </h2>

--- a/src/app/settings/components/DataManagement/index.tsx
+++ b/src/app/settings/components/DataManagement/index.tsx
@@ -55,7 +55,7 @@ export default function DataManagement() {
 
   return (
     <section className="rounded-lg border border-red-200 bg-white p-6 dark:border-red-900/50 dark:bg-zinc-900">
-      <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">
         Data Management
       </h2>
 
@@ -63,11 +63,11 @@ export default function DataManagement() {
         <Button
           variant="secondary"
           onClick={exportFullBackup}
-          className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent"
         >
           Export Full Backup
         </Button>
-        <label className="cursor-pointer rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700">
+        <label className="cursor-pointer rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent">
           Import Backup
           <input type="file" accept=".json" onChange={handleBackupImport} className="hidden" />
         </label>

--- a/src/app/settings/components/Export/index.tsx
+++ b/src/app/settings/components/Export/index.tsx
@@ -50,8 +50,8 @@ export default function Export() {
   };
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">Export Data</h2>
+    <section className="panel p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">Export Data</h2>
       <div className="flex flex-wrap gap-3">
         <Button onClick={exportVocabCSV}>Export Vocab (CSV)</Button>
         <Button onClick={exportVocabJSON}>Export Vocab (JSON)</Button>

--- a/src/app/settings/components/KnownWordsImport/index.tsx
+++ b/src/app/settings/components/KnownWordsImport/index.tsx
@@ -167,8 +167,8 @@ export default function KnownWordsImport() {
   };
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+    <section className="panel p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">
         Import Known Words
       </h2>
       <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
@@ -206,7 +206,7 @@ export default function KnownWordsImport() {
           onChange={(e) => setImportText(e.target.value)}
           placeholder="die&#10;en&#10;is&#10;van&#10;..."
           rows={6}
-          className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
         />
       </div>
 

--- a/src/app/settings/components/KnownWordsImport/index.tsx
+++ b/src/app/settings/components/KnownWordsImport/index.tsx
@@ -171,17 +171,17 @@ export default function KnownWordsImport() {
       <h2 className="mb-4 text-lg font-semibold text-foreground">
         Import Known Words
       </h2>
-      <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      <p className="mb-4 text-sm text-muted-foreground">
         Import words you already know. Supports <strong>LingQ exports</strong> (with status levels
         and translations) or simple word lists.
       </p>
-      <p className="mb-4 text-xs text-zinc-500 dark:text-zinc-500">
+      <p className="mb-4 text-xs text-muted-foreground">
         LingQ: Vocabulary → Settings gear → Export LingQs → Upload the CSV here
       </p>
 
       {/* CSV Upload */}
       <div className="mb-4">
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="mb-2 block text-sm font-medium text-foreground">
           Upload CSV File
         </label>
         <input
@@ -189,16 +189,16 @@ export default function KnownWordsImport() {
           type="file"
           accept=".csv,.txt"
           onChange={handleFileUpload}
-          className="block w-full text-sm text-zinc-600 file:mr-4 file:rounded-md file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 dark:text-zinc-400 dark:file:bg-blue-900/20 dark:file:text-blue-400"
+          className="block w-full text-sm text-muted-foreground file:mr-4 file:rounded-md file:border-0 file:bg-[var(--primary-soft)] file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary hover:file:bg-[var(--primary-soft)] dark:text-muted-foreground  "
         />
-        <p className="mt-1 text-xs text-zinc-500">
+        <p className="mt-1 text-xs text-muted-foreground">
           CSV with words in the first column, or a plain text file
         </p>
       </div>
 
       {/* Text Area Import */}
       <div className="mb-4">
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="mb-2 block text-sm font-medium text-foreground">
           Or Paste Words (one per line)
         </label>
         <textarea

--- a/src/app/settings/components/LLMSettings/index.tsx
+++ b/src/app/settings/components/LLMSettings/index.tsx
@@ -310,9 +310,9 @@ export default function LLMSettings() {
   };
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <section className="panel p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">AI Provider</h2>
+        <h2 className="text-lg font-semibold text-foreground">AI Provider</h2>
         <div className="flex items-center gap-2">
           <span
             className={clsx(`inline-block h-2 w-2 rounded-full`, {
@@ -342,7 +342,7 @@ export default function LLMSettings() {
         <select
           value={llmProvider}
           onChange={(e) => saveLLMProvider(e.target.value as LLMProvider)}
-          className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
         >
           <option value="ollama">Ollama (local)</option>
           <option value="anthropic">Anthropic (cloud)</option>
@@ -360,7 +360,7 @@ export default function LLMSettings() {
           <select
             value={ollamaModel}
             onChange={(e) => saveOllamaModel(e.target.value)}
-            className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
           >
             {OLLAMA_MODELS.map((m) => (
               <option key={m.value} value={m.value}>
@@ -389,8 +389,8 @@ export default function LLMSettings() {
                   disabled={isFetchingLlmStatus}
                   className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
                     anthropicAuthMode === 'api_key'
-                      ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                      : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                      ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                      : 'border-border bg-card text-foreground hover:bg-accent'
                   }`}
                 >
                   API Key
@@ -400,8 +400,8 @@ export default function LLMSettings() {
                   disabled={isFetchingLlmStatus}
                   className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
                     anthropicAuthMode === 'oauth'
-                      ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                      : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                      ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                      : 'border-border bg-card text-foreground hover:bg-accent'
                   }`}
                 >
                   OAuth Token
@@ -425,7 +425,7 @@ export default function LLMSettings() {
                 href="https://console.anthropic.com/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-primary hover:underline"
               >
                 console.anthropic.com
               </a>
@@ -438,13 +438,13 @@ export default function LLMSettings() {
                 </span>
                 <button
                   onClick={() => setEditingApiKey(true)}
-                  className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                  className="rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-accent"
                 >
                   Replace
                 </button>
                 <button
                   onClick={clearAnthropicApiKey}
-                  className="rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                  className="rounded-md border border-destructive/40 bg-background px-3 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
                 >
                   Clear
                 </button>
@@ -456,12 +456,12 @@ export default function LLMSettings() {
                   value={newApiKey}
                   onChange={(e) => setNewApiKey(e.target.value)}
                   placeholder="sk-ant-api..."
-                  className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
                 />
                 <button
                   onClick={() => saveAnthropicApiKey(newApiKey)}
                   disabled={!newApiKey.trim()}
-                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Save
                 </button>
@@ -471,7 +471,7 @@ export default function LLMSettings() {
                       setEditingApiKey(false);
                       setNewApiKey('');
                     }}
-                    className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    className="rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-accent"
                   >
                     Cancel
                   </button>
@@ -493,7 +493,7 @@ export default function LLMSettings() {
             </label>
             <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
               Uses your Claude Pro or Team subscription credits. Run{' '}
-              <code className="rounded bg-zinc-100 px-1 dark:bg-zinc-800">claude setup-token</code>{' '}
+              <code className="rounded bg-muted px-1">claude setup-token</code>{' '}
               to obtain a token. Note: slower initial startup than API keys.
             </p>
             {hasOauthToken && !editingOauthToken ? (
@@ -504,13 +504,13 @@ export default function LLMSettings() {
                 </span>
                 <button
                   onClick={() => setEditingOauthToken(true)}
-                  className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                  className="rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-accent"
                 >
                   Replace
                 </button>
                 <button
                   onClick={clearClaudeOauthToken}
-                  className="rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                  className="rounded-md border border-destructive/40 bg-background px-3 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
                 >
                   Clear
                 </button>
@@ -522,12 +522,12 @@ export default function LLMSettings() {
                   value={newOauthToken}
                   onChange={(e) => setNewOauthToken(e.target.value)}
                   placeholder="sk-ant-oat01-..."
-                  className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
                 />
                 <button
                   onClick={() => saveClaudeOauthToken(newOauthToken)}
                   disabled={!newOauthToken.trim()}
-                  className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-md bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Save
                 </button>
@@ -537,7 +537,7 @@ export default function LLMSettings() {
                       setEditingOauthToken(false);
                       setNewOauthToken('');
                     }}
-                    className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    className="rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-accent"
                   >
                     Cancel
                   </button>
@@ -561,7 +561,7 @@ export default function LLMSettings() {
               onChange={(e) => saveLmstudioUrl(e.target.value)}
               placeholder="http://localhost:1234"
               data-testid="lmstudio-endpoint"
-              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
             <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
               The URL of your LM Studio server (default port 1234). The app talks to it server-side,
@@ -585,7 +585,7 @@ export default function LLMSettings() {
                 <button
                   type="button"
                   onClick={() => setEditingLmstudioApiKey(true)}
-                  className="rounded-md border border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                  className="rounded-md border border-input bg-background px-3 py-1 text-xs font-medium text-foreground hover:bg-accent"
                   data-testid="lmstudio-api-key-replace"
                 >
                   Replace
@@ -593,7 +593,7 @@ export default function LLMSettings() {
                 <button
                   type="button"
                   onClick={clearLmstudioApiKey}
-                  className="rounded-md border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 dark:border-red-700 dark:bg-zinc-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                  className="rounded-md border border-destructive/40 bg-background px-3 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
                   data-testid="lmstudio-api-key-clear"
                 >
                   Clear
@@ -607,13 +607,13 @@ export default function LLMSettings() {
                   onChange={(e) => setNewLmstudioApiKey(e.target.value)}
                   placeholder="leave empty unless your LM Studio is behind auth"
                   data-testid="lmstudio-api-key"
-                  className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                  className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
                 />
                 <button
                   type="button"
                   onClick={() => saveLmstudioApiKey(newLmstudioApiKey)}
                   disabled={!newLmstudioApiKey.trim()}
-                  className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                  className="rounded-md bg-primary px-3 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                   data-testid="lmstudio-api-key-save"
                 >
                   Save
@@ -625,7 +625,7 @@ export default function LLMSettings() {
                       setEditingLmstudioApiKey(false);
                       setNewLmstudioApiKey('');
                     }}
-                    className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                    className="rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-accent"
                   >
                     Cancel
                   </button>
@@ -647,7 +647,7 @@ export default function LLMSettings() {
                 value={lmstudioModel}
                 onChange={(e) => saveLmstudioModel(e.target.value)}
                 data-testid="lmstudio-model"
-                className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50 "
               >
                 {/* Always include an empty placeholder so a freshly-fetched
                           dropdown doesn't visually show a "selected" model that
@@ -673,7 +673,7 @@ export default function LLMSettings() {
                 onClick={fetchLmstudioModels}
                 disabled={lmstudioFetchingModels || !lmstudioUrl}
                 data-testid="lmstudio-fetch-models"
-                className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent disabled:opacity-50"
               >
                 {lmstudioFetchingModels ? 'Fetching...' : 'Fetch models'}
               </button>
@@ -698,7 +698,7 @@ export default function LLMSettings() {
                 onClick={loadLmstudioModel}
                 disabled={!lmstudioModel || lmstudioLoadStatus === 'loading'}
                 data-testid="lmstudio-load"
-                className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent disabled:opacity-50"
               >
                 {lmstudioLoadStatus === 'loading' ? 'Loading...' : 'Load'}
               </button>
@@ -709,10 +709,10 @@ export default function LLMSettings() {
                   lmstudioLoadStatus === 'loaded'
                     ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
                     : lmstudioLoadStatus === 'loading'
-                      ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400'
+                      ? 'bg-[var(--primary-soft)] text-primary'
                       : lmstudioLoadStatus === 'errored'
                         ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
-                        : 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400'
+                        : 'bg-secondary text-secondary-foreground'
                 }`}
               >
                 {lmstudioLoadStatus === 'idle'
@@ -752,7 +752,7 @@ export default function LLMSettings() {
               value={apfelUrl}
               onChange={(e) => saveApfelUrl(e.target.value)}
               placeholder="http://localhost:11434"
-              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
             <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
               The URL of your Apfel instance (OpenAI-compatible API)
@@ -767,7 +767,7 @@ export default function LLMSettings() {
               value={apfelModel}
               onChange={(e) => saveApfelModel(e.target.value)}
               placeholder="default"
-              className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
             <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
               The model name configured on your Apfel server

--- a/src/app/settings/components/LLMSettings/index.tsx
+++ b/src/app/settings/components/LLMSettings/index.tsx
@@ -316,12 +316,12 @@ export default function LLMSettings() {
         <div className="flex items-center gap-2">
           <span
             className={clsx(`inline-block h-2 w-2 rounded-full`, {
-              'bg-green-500': llmStatus?.ok,
-              'bg-red-500': !llmStatus?.ok,
+              'bg-primary': llmStatus?.ok,
+              'bg-destructive': !llmStatus?.ok,
               'bg-yellow-500': isFetchingLlmStatus,
             })}
           />
-          <span className="text-sm text-zinc-600 dark:text-zinc-400">
+          <span className="text-sm text-muted-foreground">
             {llmStatus?.ok ? 'Connected' : llmStatus?.error || 'Not connected'}
             <Button variant="link" onClick={testLLMConnection} disabled={isFetchingLlmStatus}>
               {isFetchingLlmStatus ? 'Checking...' : 'Refresh'}
@@ -329,14 +329,14 @@ export default function LLMSettings() {
           </span>
         </div>
       </div>
-      <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      <p className="mb-4 text-sm text-muted-foreground">
         Choose how translations are powered. Ollama runs locally (no API key needed). Anthropic uses
         cloud AI for higher quality. Apfel is an OpenAI-compatible API you can self-host.
       </p>
 
       {/* Provider selector */}
       <div className="mb-4">
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="mb-2 block text-sm font-medium text-foreground">
           Provider
         </label>
         <select
@@ -354,7 +354,7 @@ export default function LLMSettings() {
       {/* Ollama settings */}
       {llmProvider === 'ollama' && (
         <div className="mb-4">
-          <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+          <label className="mb-2 block text-sm font-medium text-foreground">
             Model
           </label>
           <select
@@ -368,7 +368,7 @@ export default function LLMSettings() {
               </option>
             ))}
           </select>
-          <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+          <p className="mt-1 text-xs text-muted-foreground">
             The model will be downloaded automatically on first use.
           </p>
         </div>
@@ -380,7 +380,7 @@ export default function LLMSettings() {
           {/* Auth mode toggle — only when both credentials are configured */}
           {hasApiKey && hasOauthToken && (
             <div>
-              <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              <label className="mb-2 block text-sm font-medium text-foreground">
                 Authentication Method
               </label>
               <div className="flex gap-2">
@@ -407,7 +407,7 @@ export default function LLMSettings() {
                   OAuth Token
                 </button>
               </div>
-              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+              <p className="mt-1 text-xs text-muted-foreground">
                 Both credentials are configured. Choose which to use — connection will be tested
                 automatically.
               </p>
@@ -416,10 +416,10 @@ export default function LLMSettings() {
 
           {/* API Key */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               API Key
             </label>
-            <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mb-2 text-xs text-muted-foreground">
               Get your API key from{' '}
               <a
                 href="https://console.anthropic.com/"
@@ -432,8 +432,8 @@ export default function LLMSettings() {
             </p>
             {hasApiKey && !editingApiKey ? (
               <div className="flex items-center gap-2">
-                <span className="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-2 text-sm font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
-                  <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                <span className="inline-flex items-center gap-1.5 rounded-md bg-[var(--primary-soft)] px-3 py-2 text-sm font-medium text-primary ">
+                  <span className="inline-block h-2 w-2 rounded-full bg-primary" />
                   Configured
                 </span>
                 <button
@@ -481,25 +481,25 @@ export default function LLMSettings() {
           </div>
 
           <div className="relative flex items-center py-2">
-            <div className="flex-grow border-t border-zinc-200 dark:border-zinc-700" />
-            <span className="mx-3 flex-shrink text-xs text-zinc-400 dark:text-zinc-500">or</span>
-            <div className="flex-grow border-t border-zinc-200 dark:border-zinc-700" />
+            <div className="flex-grow border-t border-border" />
+            <span className="mx-3 flex-shrink text-xs text-muted-foreground">or</span>
+            <div className="flex-grow border-t border-border" />
           </div>
 
           {/* OAuth Token */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
-              OAuth Token <span className="font-normal text-zinc-400">(Pro/Team plan)</span>
+            <label className="mb-2 block text-sm font-medium text-foreground">
+              OAuth Token <span className="font-normal text-muted-foreground">(Pro/Team plan)</span>
             </label>
-            <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mb-2 text-xs text-muted-foreground">
               Uses your Claude Pro or Team subscription credits. Run{' '}
               <code className="rounded bg-muted px-1">claude setup-token</code>{' '}
               to obtain a token. Note: slower initial startup than API keys.
             </p>
             {hasOauthToken && !editingOauthToken ? (
               <div className="flex items-center gap-2">
-                <span className="inline-flex items-center gap-1.5 rounded-md bg-green-50 px-3 py-2 text-sm font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
-                  <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                <span className="inline-flex items-center gap-1.5 rounded-md bg-[var(--primary-soft)] px-3 py-2 text-sm font-medium text-primary ">
+                  <span className="inline-block h-2 w-2 rounded-full bg-primary" />
                   Configured
                 </span>
                 <button
@@ -552,7 +552,7 @@ export default function LLMSettings() {
       {llmProvider === 'lmstudio' && (
         <div className="mb-4 space-y-4" data-testid="lmstudio-settings">
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               Endpoint
             </label>
             <input
@@ -563,7 +563,7 @@ export default function LLMSettings() {
               data-testid="lmstudio-endpoint"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
-            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mt-1 text-xs text-muted-foreground">
               The URL of your LM Studio server (default port 1234). The app talks to it server-side,
               so localhost works even when lector is hosted elsewhere — set this to a reachable
               address.
@@ -571,13 +571,13 @@ export default function LLMSettings() {
           </div>
 
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               API Key (optional)
             </label>
             {hasLmstudioApiKey && !editingLmstudioApiKey ? (
               <div className="flex items-center gap-2">
                 <span
-                  className="inline-flex items-center rounded-md bg-green-100 px-2 py-1 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                  className="inline-flex items-center rounded-md bg-[var(--primary-soft)] px-2 py-1 text-xs font-medium text-primary "
                   data-testid="lmstudio-api-key-status"
                 >
                   Configured
@@ -632,14 +632,14 @@ export default function LLMSettings() {
                 )}
               </div>
             )}
-            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mt-1 text-xs text-muted-foreground">
               Sent as a Bearer token from the server (never exposed to the browser after save). Only
               needed for reverse-proxied or LM Studio Cloud setups.
             </p>
           </div>
 
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               Model
             </label>
             <div className="flex gap-2">
@@ -680,7 +680,7 @@ export default function LLMSettings() {
             </div>
             {lmstudioFetchError && (
               <p
-                className="mt-1 text-xs text-red-600 dark:text-red-400"
+                className="mt-1 text-xs text-destructive"
                 data-testid="lmstudio-fetch-error"
               >
                 {lmstudioFetchError}
@@ -689,7 +689,7 @@ export default function LLMSettings() {
           </div>
 
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               Load model
             </label>
             <div className="flex items-center gap-3">
@@ -707,11 +707,11 @@ export default function LLMSettings() {
                 data-status={lmstudioLoadStatus}
                 className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
                   lmstudioLoadStatus === 'loaded'
-                    ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                    ? 'bg-[var(--primary-soft)] text-primary '
                     : lmstudioLoadStatus === 'loading'
                       ? 'bg-[var(--primary-soft)] text-primary'
                       : lmstudioLoadStatus === 'errored'
-                        ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+                        ? 'bg-[color-mix(in_srgb,var(--destructive)_15%,var(--card))] text-destructive '
                         : 'bg-secondary text-secondary-foreground'
                 }`}
               >
@@ -726,13 +726,13 @@ export default function LLMSettings() {
             </div>
             {lmstudioLoadError && (
               <p
-                className="mt-1 text-xs text-red-600 dark:text-red-400"
+                className="mt-1 text-xs text-destructive"
                 data-testid="lmstudio-load-error"
               >
                 {lmstudioLoadError}
               </p>
             )}
-            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mt-1 text-xs text-muted-foreground">
               Loads the selected model on the LM Studio server. Make sure LM Studio&apos;s
               &ldquo;auto-load&rdquo; is enabled if you want JIT loading on chat too.
             </p>
@@ -744,7 +744,7 @@ export default function LLMSettings() {
       {llmProvider === 'apfel' && (
         <div className="mb-4 space-y-4">
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               Server URL
             </label>
             <input
@@ -754,12 +754,12 @@ export default function LLMSettings() {
               placeholder="http://localhost:11434"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
-            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mt-1 text-xs text-muted-foreground">
               The URL of your Apfel instance (OpenAI-compatible API)
             </p>
           </div>
           <div>
-            <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label className="mb-2 block text-sm font-medium text-foreground">
               Model
             </label>
             <input
@@ -769,7 +769,7 @@ export default function LLMSettings() {
               placeholder="default"
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none  "
             />
-            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-500">
+            <p className="mt-1 text-xs text-muted-foreground">
               The model name configured on your Apfel server
             </p>
           </div>

--- a/src/app/settings/components/TTSSettings/index.tsx
+++ b/src/app/settings/components/TTSSettings/index.tsx
@@ -59,10 +59,10 @@ export default function TTSSettings() {
           <div className="flex items-center gap-2">
             <span
               className={`inline-block h-2 w-2 rounded-full ${
-                googleTTSAvailable ? 'bg-green-500' : 'bg-yellow-500'
+                googleTTSAvailable ? 'bg-primary' : 'bg-yellow-500'
               }`}
             />
-            <span className="text-sm text-zinc-600 dark:text-zinc-400">
+            <span className="text-sm text-muted-foreground">
               {googleTTSAvailable ? 'Google TTS Active' : 'Using Browser TTS'}
             </span>
           </div>
@@ -70,10 +70,10 @@ export default function TTSSettings() {
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="block text-sm font-medium text-foreground">
           Voice Engine
         </label>
-        <p className="mb-2 text-xs text-zinc-500">
+        <p className="mb-2 text-xs text-muted-foreground">
           Google Cloud has better pronunciation, browser is free
         </p>
         <div className="flex gap-2">
@@ -98,9 +98,9 @@ export default function TTSSettings() {
       </div>
 
       <div>
-        <label className="mb-2 flex items-center justify-between text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="mb-2 flex items-center justify-between text-sm font-medium text-foreground">
           <span>Speech Speed</span>
-          <span className="font-mono text-zinc-500">{ttsSpeed.toFixed(1)}x</span>
+          <span className="font-mono text-muted-foreground">{ttsSpeed.toFixed(1)}x</span>
         </label>
         <input
           type="range"
@@ -111,7 +111,7 @@ export default function TTSSettings() {
           onChange={handleTTSSpeedChanged}
           className="w-full accent-blue-500"
         />
-        <div className="mt-1 flex justify-between text-xs text-zinc-500">
+        <div className="mt-1 flex justify-between text-xs text-muted-foreground">
           <span>0.5x (Slow)</span>
           <span>1.0x</span>
           <span>1.5x (Fast)</span>

--- a/src/app/settings/components/TTSSettings/index.tsx
+++ b/src/app/settings/components/TTSSettings/index.tsx
@@ -52,8 +52,8 @@ export default function TTSSettings() {
   }, [activeLang, ttsSpeed]);
 
   return (
-    <section className="panel p-6">
-      <div className="mb-4 flex items-center justify-between">
+    <section className="panel space-y-4 p-6">
+      <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">Text-to-Speech</h2>
         {googleTTSAvailable !== null && (
           <div className="flex items-center gap-2">
@@ -69,46 +69,32 @@ export default function TTSSettings() {
         )}
       </div>
 
-      {/* TTS Mode Toggle */}
-      <div className="mb-4">
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Voice Engine
         </label>
-        <div className="flex gap-2">
-          <button
-            disabled={!googleTTSAvailable}
-            onClick={() => handleTTSModeChanged('google')}
-            className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
-              currentTTSMode === 'google'
-                ? 'border-primary bg-[var(--primary-soft)] text-primary'
-                : 'border-border bg-card text-foreground hover:bg-accent'
-            }`}
-          >
-            Google Cloud
-          </button>
-          <button
-            onClick={() => handleTTSModeChanged('browser')}
-            className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
-              currentTTSMode === 'browser'
-                ? 'border-primary bg-[var(--primary-soft)] text-primary'
-                : 'border-border bg-card text-foreground hover:bg-accent'
-            }`}
-          >
-            Browser Built-in
-          </button>
-        </div>
-        <p className="mt-1 text-xs text-zinc-500">
+        <p className="mb-2 text-xs text-zinc-500">
           Google Cloud has better pronunciation, browser is free
         </p>
+        <div className="flex gap-2">
+          <Button
+            disabled={!googleTTSAvailable}
+            onClick={() => handleTTSModeChanged('google')}
+            variant={currentTTSMode === 'google' ? 'default' : 'secondary'}
+          >
+            Google Cloud
+          </Button>
+          <Button
+            onClick={() => handleTTSModeChanged('browser')}
+            variant={currentTTSMode === 'browser' ? 'default' : 'secondary'}
+          >
+            Browser Built-in
+          </Button>
+        </div>
       </div>
 
-      <div className="mb-4">
-        <Button
-          onClick={testSpeaking}
-          className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent"
-        >
-          Test Voice
-        </Button>
+      <div>
+        <Button onClick={testSpeaking}>Test Voice</Button>
       </div>
 
       <div>

--- a/src/app/settings/components/TTSSettings/index.tsx
+++ b/src/app/settings/components/TTSSettings/index.tsx
@@ -52,9 +52,9 @@ export default function TTSSettings() {
   }, [activeLang, ttsSpeed]);
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <section className="panel p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Text-to-Speech</h2>
+        <h2 className="text-lg font-semibold text-foreground">Text-to-Speech</h2>
         {googleTTSAvailable !== null && (
           <div className="flex items-center gap-2">
             <span
@@ -80,8 +80,8 @@ export default function TTSSettings() {
             onClick={() => handleTTSModeChanged('google')}
             className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
               currentTTSMode === 'google'
-                ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                : 'border-border bg-card text-foreground hover:bg-accent'
             }`}
           >
             Google Cloud
@@ -90,8 +90,8 @@ export default function TTSSettings() {
             onClick={() => handleTTSModeChanged('browser')}
             className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
               currentTTSMode === 'browser'
-                ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                : 'border-border bg-card text-foreground hover:bg-accent'
             }`}
           >
             Browser Built-in
@@ -105,7 +105,7 @@ export default function TTSSettings() {
       <div className="mb-4">
         <Button
           onClick={testSpeaking}
-          className="rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent"
         >
           Test Voice
         </Button>

--- a/src/app/settings/components/ThemeSettings/index.tsx
+++ b/src/app/settings/components/ThemeSettings/index.tsx
@@ -9,8 +9,8 @@ export default function ThemeSettings() {
   };
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">Appearance</h2>
+    <section className="panel p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">Appearance</h2>
       <div>
         <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Theme
@@ -23,8 +23,8 @@ export default function ThemeSettings() {
               onClick={() => handleThemeChanged(themeOpt)}
               className={`flex-1 rounded-md border px-4 py-2 text-sm font-medium capitalize transition-colors ${
                 theme === themeOpt
-                  ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400'
-                  : 'border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700'
+                  ? 'border-primary bg-[var(--primary-soft)] text-primary'
+                  : 'border-border bg-card text-foreground hover:bg-accent'
               }`}
             >
               {themeOpt}

--- a/src/app/settings/components/ThemeSettings/index.tsx
+++ b/src/app/settings/components/ThemeSettings/index.tsx
@@ -12,7 +12,7 @@ export default function ThemeSettings() {
     <section className="panel p-6">
       <h2 className="mb-4 text-lg font-semibold text-foreground">Appearance</h2>
       <div>
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="mb-2 block text-sm font-medium text-foreground">
           Theme
         </label>
         <div className="flex gap-2">

--- a/src/app/settings/components/Timezone/index.tsx
+++ b/src/app/settings/components/Timezone/index.tsx
@@ -42,15 +42,15 @@ export default function Timezone() {
   };
 
   return (
-    <section className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">Time Zone</h2>
+    <section className="panel p-6">
+      <h2 className="mb-1 text-lg font-semibold text-foreground">Time Zone</h2>
       <p className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
         Daily stats, streaks and review days roll over at midnight in this time zone.
       </p>
       <select
         value={timezone}
         onChange={(e) => saveTimezone(e.target.value)}
-        className="w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none "
       >
         <option value="">Auto — server time zone</option>
         {timezones.map((tz) => (

--- a/src/app/settings/components/Timezone/index.tsx
+++ b/src/app/settings/components/Timezone/index.tsx
@@ -44,7 +44,7 @@ export default function Timezone() {
   return (
     <section className="panel p-6">
       <h2 className="mb-1 text-lg font-semibold text-foreground">Time Zone</h2>
-      <p className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+      <p className="mb-4 text-sm text-muted-foreground">
         Daily stats, streaks and review days roll over at midnight in this time zone.
       </p>
       <select

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -28,12 +28,12 @@ export default function SetupPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 dark:bg-zinc-950">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
       <div className="mb-12 text-center">
-        <h1 className="mb-3 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+        <h1 className="mb-3 text-3xl font-bold tracking-tight text-foreground">
           Welcome to Lector
         </h1>
-        <p className="text-lg text-zinc-500 dark:text-zinc-400">
+        <p className="text-lg text-muted-foreground">
           Choose a language to start learning
         </p>
       </div>
@@ -47,21 +47,21 @@ export default function SetupPage() {
             data-testid={`setup-language-${lang.code}`}
             className={`group flex flex-col items-center gap-3 rounded-2xl border-2 px-6 py-8 transition-all ${
               pending === lang.code
-                ? 'border-zinc-400 bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800'
+                ? 'border-primary bg-[var(--primary-soft)]'
                 : pending !== null
-                  ? 'cursor-not-allowed opacity-50 border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900'
-                  : 'border-zinc-200 bg-white hover:border-zinc-400 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-600'
+                  ? 'cursor-not-allowed border-border bg-card opacity-50'
+                  : 'border-border bg-card hover:border-primary hover:shadow-lg'
             }`}
           >
             {pending === lang.code ? (
-              <div className="h-12 w-12 animate-spin rounded-full border-4 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100" />
+              <div className="h-12 w-12 animate-spin rounded-full border-4 border-border border-t-primary" />
             ) : (
               <span className="text-5xl">{lang.flag}</span>
             )}
-            <span className="text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+            <span className="text-xl font-semibold text-foreground">
               {lang.native}
             </span>
-            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+            <span className="text-sm text-muted-foreground">
               {lang.name}
             </span>
           </button>

--- a/src/app/stats/components.tsx
+++ b/src/app/stats/components.tsx
@@ -16,23 +16,23 @@ export function StatCard({
   color?: 'blue' | 'green' | 'yellow' | 'purple' | 'orange' | 'pink';
 }) {
   const textColors = {
-    blue: 'text-blue-600 dark:text-blue-400',
-    green: 'text-green-600 dark:text-green-400',
-    yellow: 'text-yellow-600 dark:text-yellow-400',
-    purple: 'text-purple-600 dark:text-purple-400',
-    orange: 'text-orange-600 dark:text-orange-400',
-    pink: 'text-pink-600 dark:text-pink-400',
+    blue: 'text-primary',
+    green: 'text-primary',
+    yellow: 'text-[var(--gold-strong)]',
+    purple: 'text-[var(--chart-3)]',
+    orange: 'text-clay',
+    pink: 'text-clay',
   };
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-6 transition-transform hover:scale-[1.02] dark:border-zinc-800 dark:bg-zinc-900">
+    <div className="panel p-6 transition-transform hover:scale-[1.02]">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</p>
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
           <p className={`mt-1 text-4xl font-bold ${textColors[color]}`}>
             {typeof value === 'number' ? value.toLocaleString() : value}
           </p>
-          {sublabel && <p className="mt-1 text-sm text-zinc-400 dark:text-zinc-500">{sublabel}</p>}
+          {sublabel && <p className="mt-1 text-sm text-muted-foreground">{sublabel}</p>}
         </div>
         {icon && <div className={`${textColors[color]} opacity-60`}>{icon}</div>}
       </div>
@@ -46,47 +46,47 @@ export function WordStateBreakdown({ byState }: { byState: Record<WordState, num
     {
       key: 'known',
       label: 'Known',
-      color: 'text-green-600 dark:text-green-400',
-      bgColor: 'bg-green-500',
+      color: 'text-primary',
+      bgColor: 'bg-primary',
     },
     {
       key: 'level4',
       label: 'Level 4',
-      color: 'text-green-500 dark:text-green-300',
-      bgColor: 'bg-green-400',
+      color: 'text-primary',
+      bgColor: 'bg-[color-mix(in_srgb,var(--primary)_70%,#fff)]',
     },
     {
       key: 'level3',
       label: 'Level 3',
-      color: 'text-yellow-500 dark:text-yellow-300',
-      bgColor: 'bg-yellow-400',
+      color: 'text-[var(--gold-strong)]',
+      bgColor: 'bg-[var(--gold)]',
     },
     {
       key: 'level2',
       label: 'Level 2',
-      color: 'text-yellow-600 dark:text-yellow-400',
-      bgColor: 'bg-yellow-500',
+      color: 'text-[var(--gold-strong)]',
+      bgColor: 'bg-[color-mix(in_srgb,var(--gold)_80%,var(--clay))]',
     },
     {
       key: 'level1',
       label: 'Level 1',
-      color: 'text-orange-600 dark:text-orange-400',
-      bgColor: 'bg-orange-500',
+      color: 'text-clay',
+      bgColor: 'bg-clay',
     },
-    { key: 'new', label: 'New', color: 'text-blue-600 dark:text-blue-400', bgColor: 'bg-blue-500' },
+    { key: 'new', label: 'New', color: 'text-[var(--w-new-fg)]', bgColor: 'bg-[var(--chart-5)]' },
     {
       key: 'ignored',
       label: 'Ignored',
-      color: 'text-zinc-500 dark:text-zinc-400',
-      bgColor: 'bg-zinc-400 dark:bg-zinc-500',
+      color: 'text-muted-foreground',
+      bgColor: 'bg-muted-foreground',
     },
   ];
 
   const total = Object.values(byState).reduce((a, b) => a + b, 0);
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h3 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+    <div className="panel p-6">
+      <h3 className="mb-4 text-lg font-semibold text-foreground">
         Words by State
       </h3>
       <div className="space-y-3">
@@ -97,11 +97,11 @@ export function WordStateBreakdown({ byState }: { byState: Record<WordState, num
             <div key={key}>
               <div className="mb-1 flex justify-between text-sm">
                 <span className={color}>{label}</span>
-                <span className="text-zinc-500 dark:text-zinc-400">
+                <span className="text-muted-foreground">
                   {count.toLocaleString()} ({percentage.toFixed(1)}%)
                 </span>
               </div>
-              <div className="h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+              <div className="h-2 overflow-hidden rounded-full bg-muted">
                 <div
                   className={`h-full ${bgColor} rounded-full transition-all duration-500`}
                   style={{ width: `${percentage}%` }}
@@ -128,28 +128,28 @@ export function ClozeStats({
   const accuracy = attempts > 0 ? (correct / attempts) * 100 : 0;
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h3 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+    <div className="panel p-6">
+      <h3 className="mb-4 text-lg font-semibold text-foreground">
         Cloze Practice
       </h3>
       <div className="grid grid-cols-2 gap-4">
-        <div className="rounded-lg bg-zinc-100 p-4 text-center dark:bg-zinc-800/50">
-          <div className="text-3xl font-bold text-purple-600 dark:text-purple-400">
+        <div className="rounded-lg bg-muted p-4 text-center">
+          <div className="text-3xl font-bold text-[var(--chart-3)]">
             {attempts.toLocaleString()}
           </div>
-          <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Sentences Practiced</div>
+          <div className="mt-1 text-sm text-muted-foreground">Sentences Practiced</div>
         </div>
-        <div className="rounded-lg bg-zinc-100 p-4 text-center dark:bg-zinc-800/50">
-          <div className="text-3xl font-bold text-green-600 dark:text-green-400">
+        <div className="rounded-lg bg-muted p-4 text-center">
+          <div className="text-3xl font-bold text-primary">
             {accuracy.toFixed(1)}%
           </div>
-          <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Accuracy</div>
+          <div className="mt-1 text-sm text-muted-foreground">Accuracy</div>
         </div>
-        <div className="col-span-2 rounded-lg bg-zinc-100 p-4 text-center dark:bg-zinc-800/50">
-          <div className="text-3xl font-bold text-yellow-600 dark:text-yellow-400">
+        <div className="col-span-2 rounded-lg bg-muted p-4 text-center">
+          <div className="text-3xl font-bold text-[var(--gold-strong)]">
             {points.toLocaleString()}
           </div>
-          <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Total Points</div>
+          <div className="mt-1 text-sm text-muted-foreground">Total Points</div>
         </div>
       </div>
     </div>
@@ -177,10 +177,10 @@ export function SentenceMastery({
   const overallPercentage = overallTotal > 0 ? (overallMastered / overallTotal) * 100 : 0;
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+    <div className="panel p-6">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Sentence Mastery</h3>
-        <span className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+        <h3 className="text-lg font-semibold text-foreground">Sentence Mastery</h3>
+        <span className="text-sm font-medium text-primary">
           {overallPercentage.toFixed(1)}% overall
         </span>
       </div>
@@ -188,13 +188,13 @@ export function SentenceMastery({
       {/* Overall progress bar */}
       <div className="mb-6">
         <div className="mb-1 flex justify-between text-sm">
-          <span className="text-zinc-500 dark:text-zinc-400">
+          <span className="text-muted-foreground">
             {overallMastered.toLocaleString()} / {overallTotal.toLocaleString()} mastered
           </span>
         </div>
-        <div className="h-3 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+        <div className="h-3 overflow-hidden rounded-full bg-muted">
           <div
-            className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+            className="h-full rounded-full bg-gradient-to-r from-[color-mix(in_srgb,var(--primary)_55%,#fff)] to-primary transition-all duration-500"
             style={{ width: `${overallPercentage}%` }}
           />
         </div>
@@ -207,21 +207,21 @@ export function SentenceMastery({
           return (
             <div key={collection}>
               <div className="mb-1 flex justify-between text-sm">
-                <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                <span className="font-medium text-foreground">
                   {collectionLabels[collection] || collection}
                 </span>
-                <span className="text-zinc-500 dark:text-zinc-400">
+                <span className="text-muted-foreground">
                   {counts.mastered} / {counts.total} ({pct.toFixed(0)}%)
                 </span>
               </div>
-              <div className="h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+              <div className="h-2 overflow-hidden rounded-full bg-muted">
                 <div
-                  className="h-full rounded-full bg-emerald-500/80 transition-all duration-500"
+                  className="h-full rounded-full bg-gradient-to-r from-[color-mix(in_srgb,var(--primary)_55%,#fff)] to-primary transition-all duration-500"
                   style={{ width: `${pct}%` }}
                 />
               </div>
               {counts.due > 0 && (
-                <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
+                <p className="mt-0.5 text-xs text-[var(--gold-strong)]">
                   {counts.due} due for review
                 </p>
               )}
@@ -242,21 +242,21 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
   return (
     <div
       data-testid="fluency-section"
-      className="mb-8 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900"
+      className="mb-8 panel p-6"
     >
       <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
           <span
             data-testid="fluency-level-badge"
-            className="inline-flex items-center rounded-lg bg-blue-100 px-4 py-2 text-lg font-bold text-blue-800 dark:bg-blue-900/40 dark:text-blue-300"
+            className="inline-flex items-center rounded-lg bg-[var(--primary-soft)] px-4 py-2 text-lg font-bold text-[var(--primary-text)]"
           >
             {estimatedLevel.code}
           </span>
           <div>
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            <h3 className="text-lg font-semibold text-foreground">
               {estimatedLevel.code} &mdash; {estimatedLevel.label}
             </h3>
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">Estimated CEFR Level</p>
+            <p className="text-sm text-muted-foreground">Estimated CEFR Level</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -265,8 +265,8 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
               data-testid="fluency-weekly-growth"
               className={`inline-flex items-center gap-1 text-sm font-medium ${
                 growthDelta > 0
-                  ? 'text-green-600 dark:text-green-400'
-                  : 'text-red-500 dark:text-red-400'
+                  ? 'text-primary'
+                  : 'text-destructive'
               }`}
             >
               {growthDelta > 0 ? (
@@ -278,7 +278,7 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
             </span>
           )}
           {growthDelta === 0 && weeklyGrowth.thisWeek > 0 && (
-            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+            <span className="text-sm text-muted-foreground">
               {weeklyGrowth.thisWeek} this week (same as last)
             </span>
           )}
@@ -288,15 +288,15 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
       {/* Progress bar toward next level */}
       <div className="mb-4">
         <div className="mb-1 flex justify-between text-sm">
-          <span className="text-zinc-500 dark:text-zinc-400">Progress to next level</span>
-          <span className="text-zinc-500 dark:text-zinc-400">{progressToNextLevel}%</span>
+          <span className="text-muted-foreground">Progress to next level</span>
+          <span className="text-muted-foreground">{progressToNextLevel}%</span>
         </div>
         <div
           data-testid="fluency-progress-bar"
-          className="h-3 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800"
+          className="h-3 overflow-hidden rounded-full bg-muted"
         >
           <div
-            className="h-full rounded-full bg-blue-500 transition-all duration-500"
+            className="h-full rounded-full bg-gradient-to-r from-[color-mix(in_srgb,var(--primary)_55%,#fff)] to-primary transition-all duration-500"
             style={{ width: `${progressToNextLevel}%` }}
           />
         </div>
@@ -304,23 +304,23 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
 
       {/* Known / Learning counts */}
       <div className="grid grid-cols-2 gap-4">
-        <div className="rounded-lg bg-zinc-100 p-3 text-center dark:bg-zinc-800/50">
+        <div className="rounded-lg bg-muted p-3 text-center">
           <div
             data-testid="fluency-known-count"
-            className="text-2xl font-bold text-green-600 dark:text-green-400"
+            className="text-2xl font-bold text-primary"
           >
             {totalKnownWords.toLocaleString()}
           </div>
-          <div className="text-sm text-zinc-500 dark:text-zinc-400">Known</div>
+          <div className="text-sm text-muted-foreground">Known</div>
         </div>
-        <div className="rounded-lg bg-zinc-100 p-3 text-center dark:bg-zinc-800/50">
+        <div className="rounded-lg bg-muted p-3 text-center">
           <div
             data-testid="fluency-learning-count"
-            className="text-2xl font-bold text-yellow-600 dark:text-yellow-400"
+            className="text-2xl font-bold text-[var(--gold-strong)]"
           >
             {totalLearning.toLocaleString()}
           </div>
-          <div className="text-sm text-zinc-500 dark:text-zinc-400">Learning</div>
+          <div className="text-sm text-muted-foreground">Learning</div>
         </div>
       </div>
     </div>
@@ -328,13 +328,13 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
 }
 
 export function SkeletonBlock({ className = '' }: { className?: string }) {
-  return <div className={`animate-pulse rounded bg-zinc-200 dark:bg-zinc-800 ${className}`} />;
+  return <div className={`animate-pulse rounded bg-muted ${className}`} />;
 }
 
 export function SkeletonCard({ className = '' }: { className?: string }) {
   return (
     <div
-      className={`rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900 ${className}`}
+      className={`panel p-6 ${className}`}
     >
       <SkeletonBlock className="mb-3 h-4 w-24" />
       <SkeletonBlock className="mb-2 h-10 w-32" />
@@ -349,7 +349,7 @@ export function StatsSkeleton() {
       <SkeletonBlock className="mb-6 h-4 w-56" />
 
       {/* Fluency badge skeleton */}
-      <div className="mb-8 rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="mb-8 panel p-6">
         <div className="mb-4 flex items-center gap-4">
           <SkeletonBlock className="h-10 w-16" />
           <div className="flex-1">

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -132,10 +132,10 @@ export default function StatsPage() {
 
   if (!stats) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
+      <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center">
-          <p className="mb-4 text-red-500 dark:text-red-400">Failed to load statistics</p>
-          <Link href="/" className="text-blue-600 hover:underline dark:text-blue-400">
+          <p className="mb-4 text-destructive">Failed to load statistics</p>
+          <Link href="/" className="text-primary hover:underline">
             Return home
           </Link>
         </div>
@@ -146,7 +146,7 @@ export default function StatsPage() {
   return (
     <main className="mx-auto max-w-7xl px-6 py-8">
       <PageHeader title="Statistics">
-        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+        <p className="text-sm text-muted-foreground">
           {new Date().toLocaleDateString('en-US', {
             weekday: 'long',
             year: 'numeric',

--- a/src/app/vocab/components/VocabDetailModal.tsx
+++ b/src/app/vocab/components/VocabDetailModal.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react';
 import { useState } from 'react';
 import { VocabEntry, WordState } from "@/types";
+import { Button } from '@/components/ui/button';
 
 export default function VocabDetailModal({
     entry,
@@ -44,13 +45,13 @@ export default function VocabDetailModal({
 
     // State color classes for dropdown
     const stateOptions: { value: WordState; label: string; color: string }[] = [
-        { value: 'new', label: 'New', color: 'bg-gray-200' },
-        { value: 'level1', label: 'Level 1', color: 'bg-blue-800' },
-        { value: 'level2', label: 'Level 2', color: 'bg-blue-600' },
-        { value: 'level3', label: 'Level 3', color: 'bg-blue-400' },
-        { value: 'level4', label: 'Level 4', color: 'bg-blue-200' },
-        { value: 'known', label: 'Known', color: 'bg-green-500' },
-        { value: 'ignored', label: 'Ignored', color: 'bg-gray-400' },
+        { value: 'new', label: 'New', color: 'bg-[var(--w-new-bd)]' },
+        { value: 'level1', label: 'Level 1', color: 'bg-[var(--w-l1-bd)]' },
+        { value: 'level2', label: 'Level 2', color: 'bg-[var(--w-l2-bd)]' },
+        { value: 'level3', label: 'Level 3', color: 'bg-[var(--w-l3-bd)]' },
+        { value: 'level4', label: 'Level 4', color: 'bg-[var(--w-l4-bd)]' },
+        { value: 'known', label: 'Known', color: 'bg-primary' },
+        { value: 'ignored', label: 'Ignored', color: 'bg-muted-foreground' },
     ];
 
     return (
@@ -59,20 +60,20 @@ export default function VocabDetailModal({
             onClick={onClose}
         >
             <div
-                className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900"
+                className="w-full max-w-lg rounded-lg bg-card p-6 shadow-xl"
                 onClick={(e) => e.stopPropagation()}
             >
                 {/* Header */}
                 <div className="mb-4 flex items-start justify-between">
                     <div>
-                        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">{entry.text}</h2>
-                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                        <h2 className="text-xl font-bold text-foreground">{entry.text}</h2>
+                        <span className="text-sm text-muted-foreground">
                             {entry.type === 'phrase' ? 'Phrase' : 'Word'}
                         </span>
                     </div>
                     <button
                         onClick={onClose}
-                        className="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+                        className="rounded-full p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
                     >
                         <X className="h-6 w-6" />
                     </button>
@@ -82,41 +83,41 @@ export default function VocabDetailModal({
                 <div className="space-y-4">
                     {/* Translation */}
                     <div>
-                        <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <label className="mb-1 block text-sm font-medium text-foreground">
                             Translation
                         </label>
                         {isEditing ? (
                             <textarea
                                 value={translation}
                                 onChange={(e) => setTranslation(e.target.value)}
-                                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
                                 rows={2}
                             />
                         ) : (
-                            <p className="text-gray-900 dark:text-gray-100">{entry.translation}</p>
+                            <p className="text-foreground">{entry.translation}</p>
                         )}
                     </div>
 
                     {/* Context Sentence */}
                     <div>
-                        <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <label className="mb-1 block text-sm font-medium text-foreground">
                             Context Sentence
                         </label>
-                        <p className="rounded-lg bg-gray-50 p-3 text-sm text-gray-700 italic dark:bg-gray-800 dark:text-gray-300">
+                        <p className="rounded-lg bg-muted p-3 text-sm text-muted-foreground italic">
                             {entry.sentence}
                         </p>
                     </div>
 
                     {/* State */}
                     <div>
-                        <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        <label className="mb-1 block text-sm font-medium text-foreground">
                             Learning State
                         </label>
                         {isEditing ? (
                             <select
                                 value={state}
                                 onChange={(e) => setState(e.target.value as WordState)}
-                                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
                             >
                                 {stateOptions.map((opt) => (
                                     <option key={opt.value} value={opt.value}>
@@ -130,7 +131,7 @@ export default function VocabDetailModal({
                                     className={`h-3 w-3 rounded-full ${stateOptions.find((o) => o.value === entry.state)?.color
                                         }`}
                                 />
-                                <span className="text-gray-900 dark:text-gray-100">
+                                <span className="text-foreground">
                                     {stateOptions.find((o) => o.value === entry.state)?.label}
                                 </span>
                             </div>
@@ -140,8 +141,8 @@ export default function VocabDetailModal({
                     {/* Metadata */}
                     <div className="grid grid-cols-2 gap-4 text-sm">
                         <div>
-                            <span className="text-gray-500 dark:text-gray-400">Added: </span>
-                            <span className="text-gray-900 dark:text-gray-100">
+                            <span className="text-muted-foreground">Added: </span>
+                            <span className="text-foreground">
                                 {new Date(entry.createdAt).toLocaleDateString('en-AU', {
                                     day: '2-digit',
                                     month: 'short',
@@ -150,12 +151,12 @@ export default function VocabDetailModal({
                             </span>
                         </div>
                         <div>
-                            <span className="text-gray-500 dark:text-gray-400">Review Count: </span>
-                            <span className="text-gray-900 dark:text-gray-100">{entry.reviewCount}</span>
+                            <span className="text-muted-foreground">Review Count: </span>
+                            <span className="text-foreground">{entry.reviewCount}</span>
                         </div>
                         {entry.pushedToAnki && (
                             <div className="col-span-2">
-                                <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
+                                <span className="inline-flex items-center rounded-full bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] px-2 py-0.5 text-xs font-medium text-primary">
                                     Synced to Anki
                                     {entry.ankiNoteId && ` (Note #${entry.ankiNoteId})`}
                                 </span>
@@ -165,43 +166,39 @@ export default function VocabDetailModal({
                 </div>
 
                 {/* Actions */}
-                <div className="mt-6 flex items-center justify-between border-t border-gray-200 pt-4 dark:border-gray-700">
-                    <button
+                <div className="mt-6 flex items-center justify-between border-t border-border pt-4">
+                    <Button
+                        variant="destructive"
                         onClick={handleDelete}
                         disabled={isDeleting}
-                        className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
                     >
                         {isDeleting ? 'Deleting...' : 'Delete'}
-                    </button>
+                    </Button>
 
                     <div className="flex gap-2">
                         {isEditing ? (
                             <>
-                                <button
+                                <Button
+                                    variant="outline"
                                     onClick={() => {
                                         setIsEditing(false);
                                         setTranslation(entry.translation);
                                         setState(entry.state);
                                     }}
-                                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
                                 >
                                     Cancel
-                                </button>
-                                <button
+                                </Button>
+                                <Button
                                     onClick={handleSave}
                                     disabled={isSaving}
-                                    className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
                                 >
                                     {isSaving ? 'Saving...' : 'Save'}
-                                </button>
+                                </Button>
                             </>
                         ) : (
-                            <button
-                                onClick={() => setIsEditing(true)}
-                                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-                            >
+                            <Button onClick={() => setIsEditing(true)}>
                                 Edit
-                            </button>
+                            </Button>
                         )}
                     </div>
                 </div>

--- a/src/app/vocab/components/VocabStats.tsx
+++ b/src/app/vocab/components/VocabStats.tsx
@@ -14,25 +14,25 @@ export default function VocabStats({
 
     return (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div className="rounded-lg bg-gray-100 p-3 dark:bg-gray-800">
-                <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{stats.total}</div>
-                <div className="text-sm text-gray-600 dark:text-gray-400">Total Words</div>
+            <div className="rounded-lg bg-muted p-3">
+                <div className="text-2xl font-bold text-foreground">{stats.total}</div>
+                <div className="text-sm text-muted-foreground">Total Words</div>
             </div>
-            <div className="rounded-lg bg-blue-100 p-3 dark:bg-blue-900/30">
-                <div className="text-2xl font-bold text-blue-700 dark:text-blue-400">{learningCount}</div>
-                <div className="text-sm text-blue-600 dark:text-blue-400">Learning</div>
+            <div className="rounded-lg bg-[var(--gold-soft)] p-3">
+                <div className="text-2xl font-bold text-[var(--gold-strong)]">{learningCount}</div>
+                <div className="text-sm text-[var(--gold-strong)]">Learning</div>
             </div>
-            <div className="rounded-lg bg-green-100 p-3 dark:bg-green-900/30">
-                <div className="text-2xl font-bold text-green-700 dark:text-green-400">
+            <div className="rounded-lg bg-[var(--primary-soft)] p-3">
+                <div className="text-2xl font-bold text-primary">
                     {stats.byState.known}
                 </div>
-                <div className="text-sm text-green-600 dark:text-green-400">Known</div>
+                <div className="text-sm text-primary">Known</div>
             </div>
-            <div className="rounded-lg bg-gray-100 p-3 dark:bg-gray-800">
-                <div className="text-2xl font-bold text-gray-500 dark:text-gray-500">
+            <div className="rounded-lg bg-muted p-3">
+                <div className="text-2xl font-bold text-muted-foreground">
                     {stats.byState.ignored}
                 </div>
-                <div className="text-sm text-gray-500 dark:text-gray-500">Ignored</div>
+                <div className="text-sm text-muted-foreground">Ignored</div>
             </div>
         </div>
     );

--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -306,15 +306,15 @@ export default function VocabPage() {
       <PageHeader title="Vocabulary">
         <div className="flex items-center gap-2">
           {ankiConnected === null ? (
-            <span className="text-sm text-gray-500">Checking Anki connection...</span>
+            <span className="text-sm text-muted-foreground">Checking Anki connection...</span>
           ) : ankiConnected ? (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-3 py-1 text-sm font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
-              <span className="h-2 w-2 rounded-full bg-green-500" />
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] px-3 py-1 text-sm font-medium text-primary">
+              <span className="h-2 w-2 rounded-full bg-primary" />
               Anki Connected
             </span>
           ) : (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-red-100 px-3 py-1 text-sm font-medium text-red-800 dark:bg-red-900 dark:text-red-200">
-              <span className="h-2 w-2 rounded-full bg-red-500" />
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] px-3 py-1 text-sm font-medium text-destructive">
+              <span className="h-2 w-2 rounded-full bg-destructive" />
               Anki Disconnected
             </span>
           )}

--- a/src/components/ActivityHeatmap/index.tsx
+++ b/src/components/ActivityHeatmap/index.tsx
@@ -74,10 +74,10 @@ export default function ActivityHeatmap({
   }, [data]);
 
   return (
-    <div data-testid="activity-heatmap" className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6">
+    <div data-testid="activity-heatmap" className="panel p-6">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Activity</h3>
-        <div data-testid="activity-heatmap-total" className="text-sm text-zinc-500 dark:text-slate-400">
+        <h3 className="text-lg font-semibold text-foreground">Activity</h3>
+        <div data-testid="activity-heatmap-total" className="text-sm text-muted-foreground">
           {totalActivity.toLocaleString()} lookups in the last year
         </div>
       </div>
@@ -87,7 +87,7 @@ export default function ActivityHeatmap({
         {monthLabels.map((month, i) => (
           <div
             key={i}
-            className="text-xs text-zinc-400 dark:text-slate-500"
+            className="text-xs text-muted-foreground"
             style={{
               position: 'relative',
               left: `${month.weekIndex * 14}px`,
@@ -102,7 +102,7 @@ export default function ActivityHeatmap({
       {/* Heatmap grid */}
       <div className="flex">
         {/* Day of week labels */}
-        <div className="flex flex-col mr-2 text-xs text-zinc-400 dark:text-slate-500">
+        <div className="flex flex-col mr-2 text-xs text-muted-foreground">
           {DAYS_OF_WEEK.map((day, i) => (
             <div
               key={day}
@@ -121,7 +121,7 @@ export default function ActivityHeatmap({
               {week.map((day) => (
                 <div
                   key={day.date}
-                  className="w-[12px] h-[12px] rounded-sm transition-colors hover:ring-1 hover:ring-black/20 dark:hover:ring-white/30"
+                  className="w-[12px] h-[12px] rounded-sm transition-colors hover:ring-1 hover:ring-foreground/20"
                   style={{ backgroundColor: getColor(day.count, maxCount, colorScheme) }}
                   title={`${day.date}: ${day.count} lookups`}
                 />
@@ -136,7 +136,7 @@ export default function ActivityHeatmap({
       </div>
 
       {/* Legend */}
-      <div className="flex items-center justify-end mt-4 gap-2 text-xs text-zinc-400 dark:text-slate-500">
+      <div className="flex items-center justify-end mt-4 gap-2 text-xs text-muted-foreground">
         <span>Less</span>
         <div className="flex gap-[2px]">
           <div
@@ -164,14 +164,14 @@ export default function ActivityHeatmap({
       </div>
 
       {/* Stats row */}
-      <div className="flex gap-6 mt-4 pt-4 border-t border-zinc-200 dark:border-slate-800">
+      <div className="flex gap-6 mt-4 pt-4 border-t border-border">
         <div className="text-sm">
-          <span className="text-zinc-500 dark:text-slate-400">Active days: </span>
-          <span className="text-zinc-900 dark:text-white font-medium">{activeDays}</span>
+          <span className="text-muted-foreground">Active days: </span>
+          <span className="text-foreground font-medium">{activeDays}</span>
         </div>
         <div className="text-sm">
-          <span className="text-zinc-500 dark:text-slate-400">Avg per active day: </span>
-          <span className="text-zinc-900 dark:text-white font-medium">
+          <span className="text-muted-foreground">Avg per active day: </span>
+          <span className="text-foreground font-medium">
             {activeDays > 0 ? Math.round(totalActivity / activeDays).toLocaleString() : 0}
           </span>
         </div>

--- a/src/components/ActivityHeatmap/theme.ts
+++ b/src/components/ActivityHeatmap/theme.ts
@@ -1,15 +1,19 @@
+// Sage scale (issue #147) — retinted from green toward --primary (#54ab92 dark),
+// faint to strong. Empty cell tracks the warm dark border.
 export const darkColorScheme = {
-  empty: '#1e293b',    // slate-800
-  level1: '#166534',   // green-800
-  level2: '#22c55e',   // green-500
-  level3: '#4ade80',   // green-400
-  level4: '#86efac',   // green-300
+  empty: '#352f24',    // --border (dark)
+  level1: '#2c5a4d',   // deep muted sage
+  level2: '#3a8270',
+  level3: '#54ab92',   // --primary (dark)
+  level4: '#7fc9b3',   // --primary-text (dark)
 };
 
+// Sage scale (issue #147) — retinted from green toward --primary (#2f8a76 light),
+// faint to strong. Empty cell tracks the warm sand border.
 export const lightColorScheme = {
-  empty: '#e2e8f0',    // slate-200
-  level1: '#bbf7d0',   // green-200
-  level2: '#4ade80',   // green-400
-  level3: '#22c55e',   // green-500
-  level4: '#16a34a',   // green-600
+  empty: '#e9e1d0',    // --border (light)
+  level1: '#bfe0d6',   // faint sage
+  level2: '#6fb6a3',
+  level3: '#2f8a76',   // --primary (light)
+  level4: '#226a5a',   // --primary-lip (deepest)
 };

--- a/src/components/AnkiStatus/index.tsx
+++ b/src/components/AnkiStatus/index.tsx
@@ -8,7 +8,7 @@ export default function AnkiStatus({
     if (pushedToAnki) {
         return (
             <span
-                className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200"
+                className="inline-flex items-center rounded-full bg-[var(--primary-soft)] px-2 py-0.5 text-xs font-medium text-primary"
                 title={ankiNoteId ? `Anki Note ID: ${ankiNoteId}` : "Pushed to Anki"}
             >
                 Synced
@@ -16,7 +16,7 @@ export default function AnkiStatus({
         );
     }
     return (
-        <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+        <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
             Not synced
         </span>
     );

--- a/src/components/ChatWidget/index.tsx
+++ b/src/components/ChatWidget/index.tsx
@@ -188,7 +188,7 @@ export default function ChatWidget() {
       {/* Floating trigger button */}
       <Button
         onClick={toggleOpen}
-        className="fixed right-4 bottom-20 z-50 flex h-12 w-12 rounded-full bg-indigo-600 text-white shadow-lg transition-all hover:bg-indigo-700 hover:shadow-xl sm:right-6 sm:bottom-6"
+        className="fixed right-4 bottom-20 z-50 flex h-12 w-12 rounded-full shadow-lg transition-all hover:shadow-xl sm:right-6 sm:bottom-6"
         aria-label={isOpen ? 'Close chat' : 'Open chat'}
         data-testid="chat-toggle"
       >
@@ -198,23 +198,23 @@ export default function ChatWidget() {
       {/* Chat panel */}
       {isOpen && (
         <div
-          className="fixed right-4 bottom-36 z-50 flex h-[80vh] w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl sm:right-6 sm:bottom-20 sm:w-96 dark:border-gray-700 dark:bg-gray-800"
+          className="fixed right-4 bottom-36 z-50 flex h-[80vh] w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl sm:right-6 sm:bottom-20 sm:w-96"
           data-testid="chat-panel"
         >
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/80">
+          <div className="flex items-center justify-between border-b border-border bg-muted px-4 py-3">
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              <h3 className="text-sm font-semibold text-foreground">
                 {activeLang.name} Tutor
               </h3>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 Ask anything about {activeLang.name}
               </p>
             </div>
             <Button
               variant="ghost"
               onClick={clearChat}
-              className="text-xs text-gray-400 transition-colors hover:text-red-500 dark:hover:text-red-400"
+              className="text-xs text-muted-foreground transition-colors hover:text-destructive"
               title="Clear chat"
               data-testid="chat-clear"
             >
@@ -230,14 +230,14 @@ export default function ChatWidget() {
             data-testid="chat-messages"
           >
             {loadingHistory && (
-              <div className="py-2 text-center text-xs text-gray-400">
+              <div className="py-2 text-center text-xs text-muted-foreground">
                 Loading older messages...
               </div>
             )}
 
             {messages.length === 0 && !loading && (
               <div className="flex h-full flex-col items-center justify-center text-center">
-                <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+                <p className="mb-4 text-sm text-muted-foreground">
                   Ask a question about {activeLang.name}
                 </p>
                 <div className="w-full space-y-2">
@@ -246,7 +246,7 @@ export default function ChatWidget() {
                       variant="ghost"
                       key={prompt}
                       onClick={() => sendMessage(prompt)}
-                      className="block h-auto w-full cursor-pointer rounded-lg bg-gray-100 px-3 py-2 text-left text-xs whitespace-normal text-gray-600 transition-colors hover:bg-indigo-50 hover:text-indigo-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-indigo-900/30 dark:hover:text-indigo-400"
+                      className="block h-auto w-full cursor-pointer rounded-lg bg-muted px-3 py-2 text-left text-xs whitespace-normal text-muted-foreground transition-colors hover:bg-[var(--primary-soft)] hover:text-primary"
                       data-testid="chat-example-prompt"
                     >
                       {prompt}
@@ -264,8 +264,8 @@ export default function ChatWidget() {
                 <div
                   className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
                     msg.role === 'user'
-                      ? 'bg-indigo-600 text-white'
-                      : 'bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-foreground'
                   }`}
                 >
                   <div className="break-words whitespace-pre-wrap">{msg.content}</div>
@@ -280,7 +280,7 @@ export default function ChatWidget() {
 
             {loading && (
               <div className="flex justify-start">
-                <div className="rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-400 dark:bg-gray-700">
+                <div className="rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
                   <span className="inline-flex gap-1">
                     <span className="animate-bounce" style={{ animationDelay: '0ms' }}>
                       .
@@ -300,7 +300,7 @@ export default function ChatWidget() {
           </div>
 
           {/* Input */}
-          <div className="border-t border-gray-200 px-3 py-2 dark:border-gray-700">
+          <div className="border-t border-border px-3 py-2">
             <div className="flex items-end gap-2">
               <textarea
                 ref={inputRef}
@@ -309,14 +309,14 @@ export default function ChatWidget() {
                 onKeyDown={handleKeyDown}
                 placeholder="Ask about Afrikaans..."
                 rows={1}
-                className="flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
                 disabled={loading}
                 data-testid="chat-input"
               />
               <Button
                 onClick={() => sendMessage()}
                 disabled={loading || !input.trim()}
-                className="cursor-pointer bg-indigo-600 text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-40"
+                className="cursor-pointer transition-colors disabled:cursor-not-allowed disabled:opacity-40"
                 data-testid="chat-send"
               >
                 <SendHorizonal className="-rotate-90" />

--- a/src/components/ClozeFeedback/index.tsx
+++ b/src/components/ClozeFeedback/index.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, Check, ChevronRight, Info, Loader2, Plus, X } from 'lucide-react';
 import { useState } from 'react';
+import { Button } from '@/components/ui/button';
 
 interface ClozeFeedbackProps {
   isCorrect: boolean;
@@ -77,8 +78,8 @@ export default function ClozeFeedback({
     <div
       className={`rounded-xl border-2 p-6 transition-all ${
         isCorrect
-          ? 'border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 dark:border-green-800 dark:from-green-950/40 dark:to-emerald-950/40'
-          : 'border-red-200 bg-gradient-to-br from-red-50 to-rose-50 dark:border-red-800 dark:from-red-950/40 dark:to-rose-950/40'
+          ? 'border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))]'
+          : 'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))]'
       }`}
     >
       {/* Result header */}
@@ -86,8 +87,8 @@ export default function ClozeFeedback({
         <div
           className={`flex h-10 w-10 items-center justify-center rounded-full ${
             isCorrect
-              ? 'bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400'
-              : 'bg-red-100 text-red-600 dark:bg-red-900/50 dark:text-red-400'
+              ? 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
+              : 'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
           }`}
         >
           {isCorrect ? <Check className="h-6 w-6" /> : <X className="h-6 w-6" />}
@@ -95,13 +96,13 @@ export default function ClozeFeedback({
         <div>
           <h3
             className={`text-xl font-bold ${
-              isCorrect ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'
+              isCorrect ? 'text-primary' : 'text-destructive'
             }`}
           >
             {isCorrect ? 'Correct!' : 'Incorrect'}
           </h3>
           {isCorrect && points > 0 && (
-            <p className="text-sm font-medium text-green-600 dark:text-green-500">
+            <p className="text-sm font-medium text-[var(--gold-strong)]">
               +{points} points
             </p>
           )}
@@ -112,19 +113,19 @@ export default function ClozeFeedback({
       <div className="mb-4 space-y-2">
         {!isCorrect && (
           <div className="flex items-center gap-2 text-sm">
-            <span className="font-medium text-zinc-500 dark:text-zinc-400">Your answer:</span>
-            <span className="rounded bg-red-100 px-2 py-0.5 font-medium text-red-700 line-through dark:bg-red-900/50 dark:text-red-300">
+            <span className="font-medium text-muted-foreground">Your answer:</span>
+            <span className="rounded bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] px-2 py-0.5 font-medium text-destructive line-through">
               {userAnswer}
             </span>
           </div>
         )}
         <div className="flex items-center gap-2 text-sm">
-          <span className="font-medium text-zinc-500 dark:text-zinc-400">Correct answer:</span>
+          <span className="font-medium text-muted-foreground">Correct answer:</span>
           <span
             className={`rounded px-2 py-0.5 font-bold ${
               isCorrect
-                ? 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300'
-                : 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300'
+                ? 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
+                : 'bg-[var(--gold-soft)] text-[var(--gold-strong)]'
             }`}
           >
             {correctWord}
@@ -133,19 +134,19 @@ export default function ClozeFeedback({
       </div>
 
       {/* Translation */}
-      <div className="mb-4 rounded-lg bg-white/60 p-3 dark:bg-zinc-900/60">
-        <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">Translation</p>
-        <p className="text-zinc-900 dark:text-zinc-50">{translation}</p>
+      <div className="mb-4 rounded-lg bg-muted p-3">
+        <p className="text-sm font-medium text-muted-foreground">Translation</p>
+        <p className="text-foreground">{translation}</p>
       </div>
 
       {/* Mastery progress */}
       <div className="mb-4">
         <div className="mb-2 flex items-center justify-between text-sm">
-          <span className="font-medium text-zinc-500 dark:text-zinc-400">Mastery Level</span>
+          <span className="font-medium text-muted-foreground">Mastery Level</span>
           <span className="flex items-center gap-2">
             <span
               className={`font-semibold ${
-                isCorrect ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                isCorrect ? 'text-primary' : 'text-destructive'
               }`}
             >
               {masteryLabels[newMastery]}
@@ -153,7 +154,7 @@ export default function ClozeFeedback({
             {masteryChange !== 0 && (
               <span
                 className={`text-xs font-bold ${
-                  masteryChange > 0 ? 'text-green-500' : 'text-red-500'
+                  masteryChange > 0 ? 'text-primary' : 'text-destructive'
                 }`}
               >
                 {masteryChange > 0 ? '+' : ''}
@@ -162,12 +163,10 @@ export default function ClozeFeedback({
             )}
           </span>
         </div>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
           <div
             className={`h-full transition-all duration-500 ${
-              isCorrect
-                ? 'bg-gradient-to-r from-green-400 to-emerald-500'
-                : 'bg-gradient-to-r from-red-400 to-rose-500'
+              isCorrect ? 'bg-primary' : 'bg-destructive'
             }`}
             style={{ width: `${newMastery}%` }}
           />
@@ -176,11 +175,11 @@ export default function ClozeFeedback({
 
       {/* Explain section */}
       {explanation && (
-        <div className="mb-4 rounded-lg bg-white/60 p-4 dark:bg-zinc-900/60">
-          <p className="mb-2 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+        <div className="mb-4 rounded-lg bg-muted p-4">
+          <p className="mb-2 text-sm font-medium text-muted-foreground">
             Sentence Breakdown
           </p>
-          <div className="text-sm leading-relaxed whitespace-pre-wrap text-zinc-800 dark:text-zinc-200">
+          <div className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">
             {explanation}
           </div>
         </div>
@@ -195,12 +194,12 @@ export default function ClozeFeedback({
             disabled={isAddingToAnki || ankiAdded || !!ankiError}
             className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
               ankiAdded
-                ? 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-400'
+                ? 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
                 : ankiError
-                  ? 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400'
+                  ? 'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
                   : isAddingToAnki
-                    ? 'cursor-wait bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500'
-                    : 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/50 dark:text-purple-300 dark:hover:bg-purple-900/70'
+                    ? 'cursor-wait bg-muted text-muted-foreground'
+                    : 'bg-[var(--clay-soft)] text-[var(--clay)] hover:bg-[color-mix(in_srgb,var(--clay)_18%,transparent)]'
             }`}
             title={ankiError || undefined}
           >
@@ -234,12 +233,12 @@ export default function ClozeFeedback({
           disabled={isExplaining || !!explanation}
           className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
             explanation
-              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400'
+              ? 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
               : explainError
-                ? 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400'
+                ? 'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
                 : isExplaining
-                  ? 'cursor-wait bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500'
-                  : 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/50 dark:text-amber-300 dark:hover:bg-amber-900/70'
+                  ? 'cursor-wait bg-muted text-muted-foreground'
+                  : 'bg-[var(--gold-soft)] text-[var(--gold-strong)] hover:bg-[color-mix(in_srgb,var(--gold)_22%,transparent)]'
           }`}
         >
           {explanation ? (
@@ -262,16 +261,12 @@ export default function ClozeFeedback({
           )}
         </button>
         {ankiError && (
-          <div className="w-full text-xs text-red-600 dark:text-red-400">{ankiError}</div>
+          <div className="w-full text-xs text-destructive">{ankiError}</div>
         )}
-        <button
-          type="button"
-          onClick={onNext}
-          className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-blue-700 active:scale-95 dark:bg-blue-500 dark:hover:bg-blue-600"
-        >
+        <Button type="button" onClick={onNext} className="flex-1">
           Next Sentence
           <ChevronRight className="h-4 w-4" />
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/CollectionCard/index.tsx
+++ b/src/components/CollectionCard/index.tsx
@@ -14,10 +14,10 @@ export default function CollectionCard({ collection }: CollectionCardProps) {
   return (
     <Link
       href={`/collection/${collection.id}`}
-      className="group flex flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white transition-all hover:border-zinc-300 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700"
+      className="group flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-all hover:border-border hover:shadow-lg"
     >
       {/* Cover Image */}
-      <div className="relative aspect-[3/4] w-full overflow-hidden bg-gradient-to-br from-zinc-100 to-zinc-200 dark:from-zinc-800 dark:to-zinc-900">
+      <div className="relative aspect-[3/4] w-full overflow-hidden bg-muted">
         {collection.coverUrl ? (
           <img
             src={collection.coverUrl}
@@ -27,10 +27,10 @@ export default function CollectionCard({ collection }: CollectionCardProps) {
         ) : (
           <div className="flex h-full w-full flex-col items-center justify-center p-4 text-center">
             <BookOpen
-              className="mb-2 h-12 w-12 text-zinc-400 dark:text-zinc-600"
+              className="mb-2 h-12 w-12 text-muted-foreground"
               strokeWidth={1.5}
             />
-            <span className="text-sm font-medium text-zinc-500 dark:text-zinc-500">
+            <span className="text-sm font-medium text-muted-foreground">
               {collection.title.substring(0, 30)}
             </span>
           </div>
@@ -54,21 +54,21 @@ export default function CollectionCard({ collection }: CollectionCardProps) {
 
       {/* Collection Info */}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="line-clamp-2 text-base font-semibold text-zinc-900 dark:text-zinc-50">
+        <h3 className="line-clamp-2 text-base font-semibold text-foreground">
           {collection.title}
         </h3>
         {collection.author && (
-          <p className="mt-1 truncate text-sm text-zinc-500 dark:text-zinc-400">
+          <p className="mt-1 truncate text-sm text-muted-foreground">
             {collection.author}
           </p>
         )}
         <div className="mt-auto flex items-center justify-between pt-3">
-          <span className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500">
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
             <Clock className="h-3.5 w-3.5" />
             {collection.lastReadAt ? formatLastRead(collection.lastReadAt) : 'Not started'}
           </span>
           {collection.lessonCount > 1 && (
-            <span className="text-xs text-zinc-400 dark:text-zinc-500">
+            <span className="text-xs text-muted-foreground">
               {collection.lessonCount} lessons
             </span>
           )}

--- a/src/components/ImportDropdown/index.tsx
+++ b/src/components/ImportDropdown/index.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown, Plus } from 'lucide-react';
 import { useState, useRef, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
 import { IMPORT_OPTIONS } from './constants';
 import type { ImportDropdownProps, ImportSource } from './types';
 
@@ -62,14 +63,10 @@ export default function ImportDropdown({
 
   return (
     <div ref={dropdownRef} className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        disabled={disabled || isImporting}
-        className="inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-      >
+      <Button onClick={() => setIsOpen(!isOpen)} disabled={disabled || isImporting}>
         {isImporting ? (
           <>
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white dark:border-zinc-900/30 dark:border-t-zinc-900" />
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-current/30 border-t-current" />
             Importing...
           </>
         ) : (
@@ -79,15 +76,15 @@ export default function ImportDropdown({
             <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
           </>
         )}
-      </button>
+      </Button>
 
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-2 w-48 rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
+        <div className="absolute right-0 z-50 mt-2 w-48 rounded-lg border border-border bg-popover py-1 text-popover-foreground shadow-lg">
           {IMPORT_OPTIONS.map(({ source, label, icon: Icon }) => (
             <button
               key={source}
               onClick={() => handleSelect(source)}
-              className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-700"
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-popover-foreground transition-colors hover:bg-accent"
             >
               <Icon size="20" />
               {label}

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -42,7 +42,7 @@ export default function LanguageSelector({ compact = false }: { compact?: boolea
   const knownBadge = knownWordsCount ? (
     <span
       title={`Words known: ${knownWordsCount}`}
-      className="rounded-full border border-amber-500 bg-amber-100 px-1 py-px text-amber-700 sm:px-2 sm:py-1"
+      className="rounded-full border border-[var(--gold-lip)] bg-[var(--gold-soft)] px-1 py-px text-[var(--gold-strong)] sm:px-2 sm:py-1"
     >
       {knownWordsCount > 1000 ? `${(knownWordsCount / 1000).toFixed(1)}K` : knownWordsCount}
     </span>
@@ -67,7 +67,7 @@ export default function LanguageSelector({ compact = false }: { compact?: boolea
         <DropdownMenuTrigger
           data-testid="language-selector"
           aria-label={`Language: ${activeLang.native}`}
-          className="flex items-center gap-1.5 rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          className="flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted  "
         >
           <span>{activeLang.flag}</span>
           <span>{activeLang.code.toUpperCase()}</span>
@@ -87,7 +87,7 @@ export default function LanguageSelector({ compact = false }: { compact?: boolea
         <DropdownMenuTrigger
           data-testid="language-selector"
           aria-label={`Language: ${activeLang.native}`}
-          className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800/50"
+          className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent  "
         >
           <span className="text-lg">{activeLang.flag}</span>
           <span className="flex-1 text-left">{activeLang.native}</span>

--- a/src/components/LessonFormModal/index.tsx
+++ b/src/components/LessonFormModal/index.tsx
@@ -3,6 +3,7 @@
 import { X } from 'lucide-react';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
 import type { LessonFormModalProps } from './types';
 
 export default function LessonFormModal({
@@ -80,14 +81,14 @@ export default function LessonFormModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
       <div
         ref={modalRef}
-        className={`flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl transition-all duration-200 ease-out dark:border-zinc-700 dark:bg-zinc-900 ${isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+        className={`flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl transition-all duration-200 ease-out ${isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{heading}</h2>
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-lg font-semibold text-foreground">{heading}</h2>
           <button
             onClick={onClose}
-            className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+            className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             aria-label="Close"
           >
             <X className="h-5 w-5" />
@@ -99,7 +100,7 @@ export default function LessonFormModal({
           <div>
             <label
               htmlFor="lesson-title"
-              className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+              className="mb-2 block text-sm font-medium text-foreground"
             >
               Title
             </label>
@@ -111,7 +112,7 @@ export default function LessonFormModal({
               onChange={(e) => setTitle(e.target.value)}
               disabled={isSaving}
               placeholder="Lesson title"
-              className="w-full rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:ring-zinc-100"
+              className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
             />
           </div>
 
@@ -119,12 +120,12 @@ export default function LessonFormModal({
             <div className="mb-2 flex items-center justify-between">
               <label
                 htmlFor="lesson-content"
-                className="block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                className="block text-sm font-medium text-foreground"
               >
                 Text
               </label>
               {wordCount > 0 && (
-                <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                <span className="text-xs text-muted-foreground">
                   {wordCount.toLocaleString()} words
                 </span>
               )}
@@ -136,34 +137,29 @@ export default function LessonFormModal({
               disabled={isSaving}
               placeholder="Lesson text. Markdown is supported."
               rows={12}
-              className="w-full resize-none rounded-lg border border-zinc-300 bg-white px-4 py-3 text-sm leading-relaxed text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:ring-zinc-100"
+              className="w-full resize-none rounded-lg border border-input bg-background px-4 py-3 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
             />
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 border-t border-zinc-200 bg-zinc-50 px-6 py-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-          <button
-            onClick={onClose}
-            disabled={isSaving}
-            className="rounded-lg px-4 py-2 font-medium text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:text-zinc-300 dark:hover:bg-zinc-700"
-          >
+        <div className="flex items-center justify-end gap-3 border-t border-border bg-muted px-6 py-4">
+          <Button variant="ghost" onClick={onClose} disabled={isSaving}>
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleSave}
             disabled={isSaving || !title.trim() || !textContent.trim()}
-            className="rounded-lg bg-zinc-900 px-5 py-2 font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
           >
             {isSaving ? (
               <div className="flex items-center gap-2">
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white dark:border-zinc-900/30 dark:border-t-zinc-900" />
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-current/30 border-t-current" />
                 Saving...
               </div>
             ) : (
               submitLabel
             )}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/components/MarkdownReader/index.tsx
+++ b/src/components/MarkdownReader/index.tsx
@@ -13,6 +13,7 @@ import type { WordState } from '@/types';
 import { snapToWordBoundaries } from './utils';
 import { stateClasses } from './theme';
 import { MarkdownReaderProps } from './types';
+import { Button } from '@/components/ui/button';
 
 export default function MarkdownReader({
     lesson,
@@ -213,15 +214,15 @@ export default function MarkdownReader({
     }, [onWordClick, highlightPhrase]);
 
     return (
-        <div className="flex flex-col h-full bg-[#faf8f5] dark:bg-zinc-900">
+        <div className="flex flex-col h-full bg-card">
             {/* Header */}
-            <header className="flex items-center justify-between px-4 py-2 border-b border-zinc-200 dark:border-zinc-700">
+            <header className="flex items-center justify-between px-4 py-2 border-b border-border">
                 <button
                     onClick={onClose}
                     disabled={isEditing}
                     className="flex items-center gap-2 px-3 py-2 rounded-lg
-            text-zinc-600 dark:text-zinc-400
-            hover:bg-zinc-100 dark:hover:bg-zinc-800
+            text-muted-foreground
+            hover:bg-accent
             transition-colors
             disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                 >
@@ -229,40 +230,33 @@ export default function MarkdownReader({
                     <span className="hidden sm:inline">Back</span>
                 </button>
 
-                <h1 className="text-sm sm:text-lg font-medium text-zinc-900 dark:text-zinc-100 truncate flex-1 text-center mx-2">
+                <h1 className="text-sm sm:text-lg font-medium text-foreground truncate flex-1 text-center mx-2">
                     {lesson.title}
                 </h1>
 
                 {isEditing ? (
                     <div className="flex items-center gap-2">
-                        <button
+                        <Button
+                            variant="ghost"
+                            size="sm"
                             onClick={cancelEdit}
                             disabled={isSaving}
                             data-testid="edit-text-cancel"
-                            className="px-3 py-1.5 text-sm rounded-lg
-                text-zinc-700 dark:text-zinc-300
-                hover:bg-zinc-100 dark:hover:bg-zinc-800
-                transition-colors
-                disabled:opacity-40 disabled:cursor-not-allowed"
                         >
                             Cancel
-                        </button>
-                        <button
+                        </Button>
+                        <Button
+                            size="sm"
                             onClick={saveEdit}
                             disabled={isSaving}
                             data-testid="edit-text-save"
-                            className="px-3 py-1.5 text-sm font-medium rounded-lg
-                bg-blue-600 text-white
-                hover:bg-blue-700
-                transition-colors
-                disabled:opacity-60 disabled:cursor-not-allowed"
                         >
                             {isSaving ? 'Saving…' : 'Save changes'}
-                        </button>
+                        </Button>
                     </div>
                 ) : (
                     <div className="flex items-center gap-2">
-                        <div className="text-sm text-zinc-500 dark:text-zinc-400">
+                        <div className="text-sm text-muted-foreground">
                             {scrollPercentage}%
                         </div>
                         {onSaveText && (
@@ -272,8 +266,8 @@ export default function MarkdownReader({
                                 title="Edit text"
                                 aria-label="Edit text"
                                 className="p-2 rounded-lg
-                  text-zinc-600 dark:text-zinc-400
-                  hover:bg-zinc-100 dark:hover:bg-zinc-800
+                  text-muted-foreground
+                  hover:bg-accent
                   transition-colors"
                             >
                                 <SquarePen className="w-5 h-5" />
@@ -300,31 +294,31 @@ export default function MarkdownReader({
                             autoFocus
                             spellCheck={false}
                             className="w-full min-h-[60vh] p-4 rounded-lg
-                border border-zinc-300 dark:border-zinc-600
-                bg-white dark:bg-zinc-800
-                text-zinc-800 dark:text-zinc-200
+                border border-input
+                bg-background
+                text-foreground
                 text-base leading-relaxed
                 font-mono
-                focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring
                 disabled:opacity-60 disabled:cursor-not-allowed
                 resize-y"
                         />
                         {saveError && (
                             <p
                                 data-testid="edit-text-error"
-                                className="mt-2 text-sm text-red-500 dark:text-red-400"
+                                className="mt-2 text-sm text-destructive"
                             >
                                 {saveError}
                             </p>
                         )}
-                        <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
+                        <p className="mt-2 text-xs text-muted-foreground">
                             Markdown is supported. Vocab state is keyed by word, so edits don&apos;t reset your progress.
                         </p>
                     </div>
                 ) : (
                     <article className="max-w-[38em] mx-auto px-4 sm:px-8 py-8 sm:py-16 prose prose-zinc dark:prose-invert
-            prose-p:text-lg sm:prose-p:text-2xl prose-p:leading-[1.9] prose-p:text-zinc-700 dark:prose-p:text-zinc-300
-            prose-headings:font-sans prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100
+            prose-p:text-lg sm:prose-p:text-2xl prose-p:leading-[1.9] prose-p:text-foreground
+            prose-headings:font-sans prose-headings:text-foreground
             prose-li:text-lg sm:prose-li:text-xl prose-li:leading-relaxed"
                         style={{ fontFamily: 'var(--font-literata), Georgia, serif' }}>
                         <ReactMarkdown
@@ -348,8 +342,8 @@ export default function MarkdownReader({
                             <button
                                 onClick={() => router.push(`/read/${prevLesson.id}`)}
                                 className="flex items-center gap-2 px-4 py-3 rounded-lg text-sm
-                  text-zinc-600 dark:text-zinc-400
-                  hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+                  text-muted-foreground
+                  hover:bg-accent transition-colors"
                             >
                                 <ChevronLeft className="w-4 h-4" />
                                 <span className="truncate max-w-[12em]">{prevLesson.title}</span>
@@ -359,8 +353,8 @@ export default function MarkdownReader({
                             <button
                                 onClick={() => router.push(`/read/${nextLesson.id}`)}
                                 className="flex items-center gap-2 px-4 py-3 rounded-lg text-sm
-                  text-zinc-600 dark:text-zinc-400
-                  hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+                  text-muted-foreground
+                  hover:bg-accent transition-colors"
                             >
                                 <span className="truncate max-w-[12em]">{nextLesson.title}</span>
                                 <ChevronRight className="w-4 h-4" />

--- a/src/components/MarkdownReader/index.tsx
+++ b/src/components/MarkdownReader/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/lib/data-layer';
 import type { WordState } from '@/types';
 import { snapToWordBoundaries } from './utils';
-import { darkStateColors, stateColors } from './theme';
+import { stateClasses } from './theme';
 import { MarkdownReaderProps } from './types';
 
 export default function MarkdownReader({
@@ -28,7 +28,6 @@ export default function MarkdownReader({
     const containerRef = useRef<HTMLDivElement>(null);
     const [knownWordsMap, setKnownWordsMap] = useState<Map<string, WordState>>(new Map());
     const [highlightedPhrase, setHighlightedPhrase] = useState<string[]>([]);
-    const [isDarkMode, setIsDarkMode] = useState(false);
     const [scrollPercentage, setScrollPercentage] = useState(0);
     const [isEditing, setIsEditing] = useState(false);
     const [draftContent, setDraftContent] = useState('');
@@ -65,15 +64,6 @@ export default function MarkdownReader({
             setIsSaving(false);
         }
     }, [draftContent, onSaveText, onEditingChange]);
-
-    // Detect dark mode
-    useEffect(() => {
-        const check = () => setIsDarkMode(document.documentElement.classList.contains('dark'));
-        check();
-        const observer = new MutationObserver(check);
-        observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
-        return () => observer.disconnect();
-    }, []);
 
     // Load known words map
     useEffect(() => {
@@ -156,7 +146,7 @@ export default function MarkdownReader({
             }
         }
 
-        const colors = isDarkMode ? darkStateColors : stateColors;
+        const colors = stateClasses;
         let wordIndex = 0;
 
         return parts.map((part, i) => {
@@ -175,8 +165,8 @@ export default function MarkdownReader({
                             onWordClick(part.text, sentence);
                         }}
                         data-phrase-highlighted={isPhraseHighlighted || undefined}
-                        className={`cursor-pointer rounded px-0.5 hover:ring-2 hover:ring-blue-400 ${colorClass}`}
-                        style={isPhraseHighlighted ? { backgroundColor: 'rgba(99, 102, 241, 0.25)' } : undefined}
+                        className={`cursor-pointer rounded-[7px] px-[7px] font-bold hover:ring-2 hover:ring-ring/50 ${colorClass}`}
+                        style={isPhraseHighlighted ? { backgroundColor: 'color-mix(in srgb, var(--clay) 22%, transparent)' } : undefined}
                     >
                         {part.text}
                     </span>

--- a/src/components/MarkdownReader/theme.ts
+++ b/src/components/MarkdownReader/theme.ts
@@ -1,21 +1,16 @@
 import { WordState } from "@/types";
 
-export const stateColors: Record<WordState, string> = {
-    new: 'bg-blue-100',
-    level1: 'bg-yellow-300',
-    level2: 'bg-yellow-200',
-    level3: 'bg-yellow-100',
-    level4: 'bg-yellow-50',
+// One token-class map for both light and dark — the --w-* word-state tokens flip
+// under `.dark` (issue #147 §4.3), so a single map covers both modes. A single
+// warm ochre ramp (level1 deepest -> level4 faintest) plus a calm slate for
+// `new`. `known` renders as plain text (no chip); `ignored` is dimmed. Chip
+// shape and weight are applied at the render site in MarkdownReader.
+export const stateClasses: Record<WordState, string> = {
+    new: 'bg-[var(--w-new-bg)] text-[var(--w-new-fg)] border border-[var(--w-new-bd)]',
+    level1: 'bg-[var(--w-l1-bg)] text-[var(--w-l1-fg)] border border-[var(--w-l1-bd)]',
+    level2: 'bg-[var(--w-l2-bg)] text-[var(--w-l2-fg)] border border-[var(--w-l2-bd)]',
+    level3: 'bg-[var(--w-l3-bg)] text-[var(--w-l3-fg)] border border-[var(--w-l3-bd)]',
+    level4: 'bg-[var(--w-l4-bg)] text-[var(--w-l4-fg)] border border-[var(--w-l4-bd)]',
     known: '',
-    ignored: 'opacity-50',
-};
-
-export const darkStateColors: Record<WordState, string> = {
-    new: 'bg-blue-900/40',
-    level1: 'bg-yellow-700/50',
-    level2: 'bg-yellow-800/40',
-    level3: 'bg-yellow-900/30',
-    level4: 'bg-yellow-900/20',
-    known: '',
-    ignored: 'opacity-40',
+    ignored: 'opacity-60 text-muted-foreground',
 };

--- a/src/components/NavHeader/components/AppName/index.tsx
+++ b/src/components/NavHeader/components/AppName/index.tsx
@@ -5,7 +5,7 @@ export default function AppName() {
   return (
     <Link href="/" className="flex items-center gap-2">
       <Image src="/logo.svg" alt="Lector" width={28} height={28} className="rounded" />
-      <span className="text-md font-bold tracking-tight text-zinc-900 sm:text-lg dark:text-zinc-50">
+      <span className="text-md font-extrabold tracking-tight text-foreground sm:text-lg">
         Lector
       </span>
     </Link>

--- a/src/components/NavHeader/components/NavLink/index.tsx
+++ b/src/components/NavHeader/components/NavLink/index.tsx
@@ -14,12 +14,12 @@ export default function NavLink({
   const Icon = iconMap[link.href];
   const linkClasses = isMobile
     ? `flex flex-1 flex-col items-center justify-center gap-1 py-2 text-[10px] font-medium transition-colors ${
-        isActive ? 'text-blue-600 dark:text-blue-400' : 'text-zinc-500 dark:text-zinc-400'
+        isActive ? 'text-primary' : 'text-muted-foreground'
       }`
     : `flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
         isActive
-          ? 'bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50'
-          : 'text-zinc-600 hover:bg-zinc-50 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800/50 dark:hover:text-zinc-50'
+          ? 'bg-[var(--primary-soft)] font-bold text-primary'
+          : 'text-muted-foreground hover:bg-accent hover:text-foreground'
       }`;
 
   return (

--- a/src/components/NavHeader/index.tsx
+++ b/src/components/NavHeader/index.tsx
@@ -10,18 +10,18 @@ export default function NavHeader() {
   return (
     <>
       {/* Mobile top bar — language selector, visible only on mobile */}
-      <div className="flex h-[var(--mobile-topbar-h)] items-center justify-between border-b border-zinc-200 bg-white/80 px-3 py-2 backdrop-blur-sm sm:hidden dark:border-zinc-800 dark:bg-zinc-950/80">
+      <div className="flex h-[var(--mobile-topbar-h)] items-center justify-between border-b border-border bg-card/80 px-3 py-2 backdrop-blur-sm sm:hidden">
         <AppName />
         <LanguageSelector compact />
       </div>
 
       {/* Desktop left sidebar — hidden on mobile */}
-      <aside className="sticky top-0 z-50 hidden h-screen w-56 border-r border-zinc-200 bg-white sm:flex sm:flex-col dark:border-zinc-800 dark:bg-zinc-950">
+      <aside className="sticky top-0 z-50 hidden h-screen w-56 border-r border-border bg-card sm:flex sm:flex-col">
         <div className="flex h-16 items-center px-5">
           <AppName />
         </div>
 
-        <div className="border-b border-zinc-200 pb-2 dark:border-zinc-800">
+        <div className="border-b border-border pb-2">
           <LanguageSelector />
         </div>
 
@@ -31,13 +31,13 @@ export default function NavHeader() {
           })}
         </nav>
 
-        <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <div className="border-t border-border px-4 py-3">
           <ThemeToggle />
         </div>
       </aside>
 
       {/* Mobile bottom nav — hidden on sm+ */}
-      <nav className="fixed right-0 bottom-0 left-0 z-50 border-t border-zinc-200 bg-white sm:hidden dark:border-zinc-800 dark:bg-zinc-950">
+      <nav className="fixed right-0 bottom-0 left-0 z-50 border-t border-border bg-card sm:hidden">
         <div className="flex items-stretch">
           {navLinks.map((link) => {
             return <NavLink key={link.href} link={link} isMobile />;

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -3,7 +3,7 @@ import { IPageHeaderProps } from './types';
 export default function PageHeader({ children, title }: IPageHeaderProps) {
   return (
     <div className="mb-6 flex items-center justify-between">
-      <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">{title}</h1>
+      <h1 className="text-2xl font-extrabold text-foreground">{title}</h1>
       {children}
     </div>
   );

--- a/src/components/PasteImportModal/index.tsx
+++ b/src/components/PasteImportModal/index.tsx
@@ -3,6 +3,7 @@
 import { X } from 'lucide-react';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
 import type { PasteImportModalProps } from './types';
 
 export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImportModalProps) {
@@ -77,18 +78,14 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
       <div
         ref={modalRef}
-        className={`flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl transition-all duration-200 ease-out dark:border-zinc-700 dark:bg-zinc-900 ${isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+        className={`flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl transition-all duration-200 ease-out ${isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Paste Text</h2>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
-            aria-label="Close"
-          >
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-lg font-semibold text-foreground">Paste Text</h2>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
             <X className="h-5 w-5" />
-          </button>
+          </Button>
         </div>
 
         {/* Content */}
@@ -97,7 +94,7 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
             <div>
               <label
                 htmlFor="paste-title"
-                className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                className="mb-2 block text-sm font-medium text-foreground"
               >
                 Title
               </label>
@@ -109,13 +106,13 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
                 onChange={(e) => setTitle(e.target.value)}
                 disabled={isSaving}
                 placeholder="Article or text title"
-                className="w-full rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:ring-zinc-100"
+                className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
               />
             </div>
             <div>
               <label
                 htmlFor="paste-author"
-                className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                className="mb-2 block text-sm font-medium text-foreground"
               >
                 Author / Source
               </label>
@@ -126,7 +123,7 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
                 onChange={(e) => setAuthor(e.target.value)}
                 disabled={isSaving}
                 placeholder="Optional"
-                className="w-full rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:ring-zinc-100"
+                className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
               />
             </div>
           </div>
@@ -135,12 +132,12 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
             <div className="mb-2 flex items-center justify-between">
               <label
                 htmlFor="paste-content"
-                className="block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                className="block text-sm font-medium text-foreground"
               >
                 Text
               </label>
               {wordCount > 0 && (
-                <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                <span className="text-xs text-muted-foreground">
                   {wordCount.toLocaleString()} words
                 </span>
               )}
@@ -152,34 +149,29 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
               disabled={isSaving}
               placeholder="Paste your Afrikaans text here..."
               rows={12}
-              className="w-full resize-none rounded-lg border border-zinc-300 bg-white px-4 py-3 text-sm leading-relaxed text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:ring-zinc-100"
+              className="w-full resize-none rounded-lg border border-input bg-background px-4 py-3 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
             />
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 border-t border-zinc-200 bg-zinc-50 px-6 py-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-          <button
-            onClick={onClose}
-            disabled={isSaving}
-            className="rounded-lg px-4 py-2 font-medium text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:text-zinc-300 dark:hover:bg-zinc-700"
-          >
+        <div className="flex items-center justify-end gap-3 border-t border-border bg-muted px-6 py-4">
+          <Button variant="ghost" onClick={onClose} disabled={isSaving}>
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleSave}
             disabled={isSaving || !title.trim() || !content.trim()}
-            className="rounded-lg bg-zinc-900 px-5 py-2 font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
           >
             {isSaving ? (
               <div className="flex items-center gap-2">
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white dark:border-zinc-900/30 dark:border-t-zinc-900" />
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
                 Saving...
               </div>
             ) : (
               'Save to Library'
             )}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/src/components/SetupGuard/index.tsx
+++ b/src/components/SetupGuard/index.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
 import { getSetting } from '@/lib/data-layer';
 
 export default function SetupGuard({ children }: { children: React.ReactNode }) {
@@ -52,25 +53,24 @@ export default function SetupGuard({ children }: { children: React.ReactNode }) 
 
   if (error) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-50 dark:bg-zinc-950">
-        <p className="text-sm text-zinc-500 dark:text-zinc-400">Could not connect to the server.</p>
-        <button
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background">
+        <p className="text-sm text-muted-foreground">Could not connect to the server.</p>
+        <Button
           onClick={() => {
             setError(false);
             setChecked(false);
           }}
-          className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
         >
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
 
   if (!checked) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-950">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-zinc-900 dark:border-zinc-700 dark:border-t-zinc-100" />
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
       </div>
     );
   }

--- a/src/components/StateIndicator/index.tsx
+++ b/src/components/StateIndicator/index.tsx
@@ -6,48 +6,48 @@ export default function StateIndicator({ state }: { state: WordState }) {
         case "new":
             return (
                 <span
-                    className="inline-block h-3 w-3 rounded-full bg-gray-400 dark:bg-gray-500"
+                    className="inline-block h-3 w-3 rounded-full bg-[var(--w-new-bd)]"
                     title="New - Not yet studied"
                 />
             );
         case "level1":
             return (
                 <span
-                    className="inline-block h-3 w-3 rounded-full bg-blue-800"
+                    className="inline-block h-3 w-3 rounded-full bg-[var(--w-l1-bd)]"
                     title="Level 1 - Just started learning"
                 />
             );
         case "level2":
             return (
                 <span
-                    className="inline-block h-3 w-3 rounded-full bg-blue-600"
+                    className="inline-block h-3 w-3 rounded-full bg-[var(--w-l2-bd)]"
                     title="Level 2 - Learning"
                 />
             );
         case "level3":
             return (
                 <span
-                    className="inline-block h-3 w-3 rounded-full bg-blue-400"
+                    className="inline-block h-3 w-3 rounded-full bg-[var(--w-l3-bd)]"
                     title="Level 3 - Familiar"
                 />
             );
         case "level4":
             return (
                 <span
-                    className="inline-block h-3 w-3 rounded-full bg-blue-200"
+                    className="inline-block h-3 w-3 rounded-full bg-[var(--w-l4-bd)]"
                     title="Level 4 - Almost known"
                 />
             );
         case "known":
             return (
-                <Check className="h-4 w-4 text-green-600" strokeWidth={3} aria-label="Known">
+                <Check className="h-4 w-4 text-primary" strokeWidth={3} aria-label="Known">
                     <title>Known - Fully learned</title>
                 </Check>
             );
         case "ignored":
             return (
                 <span
-                    className="inline-block h-0.5 w-3 rounded bg-gray-400"
+                    className="inline-block h-0.5 w-3 rounded bg-muted-foreground"
                     title="Ignored - Hidden from study"
                 />
             );

--- a/src/components/StatsCard/index.tsx
+++ b/src/components/StatsCard/index.tsx
@@ -12,26 +12,26 @@ export default function StatsCard({
       data-testid={testId}
       className={`flex items-center gap-4 rounded-xl border p-4 ${
         highlight
-          ? 'border-amber-200 bg-gradient-to-br from-amber-50 to-orange-50 dark:border-amber-900/50 dark:from-amber-950/30 dark:to-orange-950/30'
-          : 'border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900'
+          ? 'border-[var(--gold-lip)] bg-[var(--gold-soft)]'
+          : 'panel'
       }`}
     >
       {icon && (
         <div
           className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-lg ${
             highlight
-              ? 'bg-amber-100 text-amber-600 dark:bg-amber-900/50 dark:text-amber-400'
-              : 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400'
+              ? 'bg-[var(--gold-soft)] text-[var(--gold-strong)]'
+              : 'bg-muted text-muted-foreground'
           }`}
         >
           {icon}
         </div>
       )}
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-zinc-500 dark:text-zinc-400">{label}</p>
+        <p className="truncate text-sm font-medium text-muted-foreground">{label}</p>
         <p
           className={`text-2xl font-bold tracking-tight ${
-            highlight ? 'text-amber-700 dark:text-amber-400' : 'text-zinc-900 dark:text-zinc-50'
+            highlight ? 'text-[var(--gold-strong)]' : 'text-foreground'
           }`}
         >
           {value}

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -16,7 +16,7 @@ export default function ThemeToggle() {
   if (!mounted) return null;
 
   return (
-    <div className="flex items-center gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
+    <div className="flex items-center gap-1 rounded-lg bg-muted p-1">
       {options.map((opt) => {
         const Icon = opt.icon;
         const isActive = theme === opt.value;
@@ -28,8 +28,8 @@ export default function ThemeToggle() {
             title={opt.label}
             className={`rounded-md p-1.5 transition-colors ${
               isActive
-                ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-100'
-                : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200'
+                ? 'bg-card text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
             }`}
           >
             <Icon size="14" />

--- a/src/components/TranslationDrawer/constants.ts
+++ b/src/components/TranslationDrawer/constants.ts
@@ -1,13 +1,13 @@
 import { WordState } from "@/types";
 
 export const wordStateColors: Record<WordState, { bg: string; text: string; dot: string; ring: string }> = {
-  'new':     { bg: 'bg-blue-100 dark:bg-blue-900/40',     text: 'text-blue-700 dark:text-blue-300',     dot: 'bg-blue-500',   ring: 'ring-blue-500' },
-  'level1':  { bg: 'bg-red-100 dark:bg-red-900/40',       text: 'text-red-700 dark:text-red-300',       dot: 'bg-red-500',    ring: 'ring-red-500' },
-  'level2':  { bg: 'bg-orange-100 dark:bg-orange-900/40', text: 'text-orange-700 dark:text-orange-300', dot: 'bg-orange-500', ring: 'ring-orange-500' },
-  'level3':  { bg: 'bg-yellow-100 dark:bg-yellow-900/40', text: 'text-yellow-700 dark:text-yellow-300', dot: 'bg-yellow-500', ring: 'ring-yellow-500' },
-  'level4':  { bg: 'bg-lime-100 dark:bg-lime-900/40',     text: 'text-lime-700 dark:text-lime-300',     dot: 'bg-lime-500',   ring: 'ring-lime-500' },
-  'known':   { bg: 'bg-green-100 dark:bg-green-900/40',   text: 'text-green-700 dark:text-green-300',   dot: 'bg-green-500',  ring: 'ring-green-500' },
-  'ignored': { bg: 'bg-gray-100 dark:bg-gray-800',        text: 'text-gray-500 dark:text-gray-400',     dot: 'bg-gray-400',   ring: 'ring-gray-400' },
+  'new':     { bg: 'bg-[var(--w-new-bg)]', text: 'text-[var(--w-new-fg)]', dot: 'bg-[var(--w-new-bd)]', ring: 'ring-[var(--w-new-bd)]' },
+  'level1':  { bg: 'bg-[var(--w-l1-bg)]',  text: 'text-[var(--w-l1-fg)]',  dot: 'bg-[var(--w-l1-bd)]',  ring: 'ring-[var(--w-l1-bd)]' },
+  'level2':  { bg: 'bg-[var(--w-l2-bg)]',  text: 'text-[var(--w-l2-fg)]',  dot: 'bg-[var(--w-l2-bd)]',  ring: 'ring-[var(--w-l2-bd)]' },
+  'level3':  { bg: 'bg-[var(--w-l3-bg)]',  text: 'text-[var(--w-l3-fg)]',  dot: 'bg-[var(--w-l3-bd)]',  ring: 'ring-[var(--w-l3-bd)]' },
+  'level4':  { bg: 'bg-[var(--w-l4-bg)]',  text: 'text-[var(--w-l4-fg)]',  dot: 'bg-[var(--w-l4-bd)]',  ring: 'ring-[var(--w-l4-bd)]' },
+  'known':   { bg: 'bg-[var(--primary-soft)]', text: 'text-[var(--primary-text)]', dot: 'bg-primary', ring: 'ring-primary' },
+  'ignored': { bg: 'bg-muted',             text: 'text-muted-foreground', dot: 'bg-muted-foreground', ring: 'ring-muted-foreground' },
 };
 
 export const wordStateLabels: Record<WordState, string> = {

--- a/src/components/TranslationDrawer/index.tsx
+++ b/src/components/TranslationDrawer/index.tsx
@@ -85,8 +85,8 @@ export default function TranslationDrawer({
       className={`
         fixed inset-y-0 right-0 z-50
         w-full sm:w-96 max-w-full
-        bg-white dark:bg-zinc-900
-        border-l border-zinc-200 dark:border-zinc-700
+        bg-popover
+        border-l border-border
         shadow-2xl
         flex flex-col
         transition-transform duration-300 ease-out
@@ -97,35 +97,35 @@ export default function TranslationDrawer({
       aria-label={`Definition of ${word}`}
     >
       {/* Header */}
-      <div className="flex-shrink-0 px-4 py-3 bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-200 dark:border-zinc-700">
+      <div className="flex-shrink-0 px-4 py-3 bg-muted/50 border-b border-border">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 flex-wrap">
               <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${stateColors.dot}`} title={wordStateLabels[currentState]} />
-              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100 break-words">
+              <h2 className="text-xl font-semibold text-foreground break-words">
                 {word}
               </h2>
               <button
                 onClick={handleSpeakWord}
-                className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors"
+                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
                 title="Hear pronunciation"
                 aria-label="Hear pronunciation"
               >
                 <Volume2 className="w-5 h-5" />
               </button>
               {entry?.ipa && (
-                <span className="text-sm font-mono text-zinc-500 dark:text-zinc-400">
+                <span className="text-sm font-mono text-muted-foreground">
                   {entry.ipa}
                 </span>
               )}
             </div>
             {entry?.lemmaInfo && (
-              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              <p className="mt-1 text-xs text-muted-foreground">
                 {entry.lemmaInfo.label}{' '}
                 {onLookupWord ? (
                   <NestedWordButton word={entry.lemmaInfo.stem} onLookupWord={onLookupWord} testId="lemma-stem-link" />
                 ) : (
-                  <span className="font-medium text-zinc-700 dark:text-zinc-300">{entry.lemmaInfo.stem}</span>
+                  <span className="font-medium text-foreground">{entry.lemmaInfo.stem}</span>
                 )}
               </p>
             )}
@@ -137,23 +137,23 @@ export default function TranslationDrawer({
               {/* Source attribution — always tells the user where the
                   currently-displayed translation came from. */}
               {aiContextTranslation ? (
-                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300">
-                  <span className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
+                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-[var(--clay-soft)] text-[var(--clay)]">
+                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--clay)]" />
                   AI · in context
                 </span>
               ) : entry?.source === 'cache' ? (
-                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
-                  <span className="w-1.5 h-1.5 rounded-full bg-violet-500" />
+                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-[var(--gold-soft)] text-[var(--gold-strong)]">
+                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--gold-strong)]" />
                   learned
                 </span>
               ) : isDictionaryResult ? (
-                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">
-                  <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-[var(--primary-soft)] text-[var(--primary-text)]">
+                  <span className="w-1.5 h-1.5 rounded-full bg-primary" />
                   on-device
                 </span>
               ) : (fallbackTranslation || aiPhraseDetails) && !isLoading ? (
-                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
-                  <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-md bg-muted text-muted-foreground">
+                  <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
                   AI
                 </span>
               ) : null}
@@ -161,7 +161,7 @@ export default function TranslationDrawer({
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors flex-shrink-0"
+            className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
             aria-label="Close"
             title="Close (Esc)"
           >
@@ -173,45 +173,45 @@ export default function TranslationDrawer({
       {/* Body — scrollable */}
       <div className="flex-1 overflow-y-auto">
         {/* Definition section */}
-        <section className="px-4 py-4 border-b border-zinc-200 dark:border-zinc-700">
+        <section className="px-4 py-4 border-b border-border">
           {isLoading ? (
-            <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400 text-sm">
-              <span className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <span className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
               Looking up…
             </div>
           ) : error ? (
-            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            <p className="text-sm text-destructive">{error}</p>
           ) : aiContextTranslation ? (
             <div>
               <div>
                 {aiContextPartOfSpeech && (
-                  <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 mr-2 align-middle">
+                  <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground mr-2 align-middle">
                     {aiContextPartOfSpeech}
                   </span>
                 )}
-                <span className="text-zinc-800 dark:text-zinc-200 leading-relaxed">
+                <span className="text-foreground leading-relaxed">
                   {aiContextTranslation}
                 </span>
               </div>
               {hasRichEntry && (
                 <details className="mt-3 group">
-                  <summary className="cursor-pointer text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 list-none flex items-center gap-1">
+                  <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground list-none flex items-center gap-1">
                     <ChevronRight className="w-3 h-3 transition-transform group-open:rotate-90" />
                     Show dictionary ({senses.length})
                   </summary>
                   <ol className="mt-2 space-y-2">
                     {senses.map((sense, i) => (
                       <li key={i} className="flex gap-3 text-sm">
-                        <span className="flex-shrink-0 text-xs font-medium text-zinc-400 dark:text-zinc-500 mt-0.5 tabular-nums">
+                        <span className="flex-shrink-0 text-xs font-medium text-muted-foreground mt-0.5 tabular-nums">
                           {i + 1}.
                         </span>
                         <div className="min-w-0 flex-1">
                           {sense.partOfSpeech && (
-                            <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 mr-2 align-middle">
+                            <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground mr-2 align-middle">
                               {sense.partOfSpeech}
                             </span>
                           )}
-                          <span className="text-zinc-700 dark:text-zinc-300">
+                          <span className="text-foreground">
                             <Gloss text={sense.gloss} onLookupWord={onLookupWord} />
                           </span>
                         </div>
@@ -225,16 +225,16 @@ export default function TranslationDrawer({
             <ol className="space-y-3">
               {senses.map((sense, i) => (
                 <li key={i} className="flex gap-3">
-                  <span className="flex-shrink-0 text-xs font-medium text-zinc-400 dark:text-zinc-500 mt-0.5 tabular-nums">
+                  <span className="flex-shrink-0 text-xs font-medium text-muted-foreground mt-0.5 tabular-nums">
                     {i + 1}.
                   </span>
                   <div className="min-w-0 flex-1">
                     {sense.partOfSpeech && (
-                      <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 mr-2 align-middle">
+                      <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground mr-2 align-middle">
                         {sense.partOfSpeech}
                       </span>
                     )}
-                    <span className="text-zinc-800 dark:text-zinc-200 leading-relaxed">
+                    <span className="text-foreground leading-relaxed">
                       <Gloss text={sense.gloss} onLookupWord={onLookupWord} />
                     </span>
                   </div>
@@ -244,16 +244,16 @@ export default function TranslationDrawer({
           ) : fallbackTranslation ? (
             <div>
               {aiPartOfSpeech && (
-                <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 mr-2 align-middle">
+                <span className="inline-block text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground mr-2 align-middle">
                   {aiPartOfSpeech}
                 </span>
               )}
-              <span className="text-zinc-800 dark:text-zinc-200 leading-relaxed">
+              <span className="text-foreground leading-relaxed">
                 {fallbackTranslation}
               </span>
             </div>
           ) : (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400 italic">No definition found.</p>
+            <p className="text-sm text-muted-foreground italic">No definition found.</p>
           )}
 
           {/* In-context AI button — always offered for single-word lookups so the
@@ -263,8 +263,8 @@ export default function TranslationDrawer({
             <button
               onClick={onRequestContextTranslation}
               className="mt-3 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md
-                bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400
-                hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors"
+                bg-[var(--clay-soft)] text-[var(--clay)]
+                hover:bg-[color-mix(in_srgb,var(--clay)_18%,transparent)] transition-colors"
               title="Translate using AI with sentence context"
             >
               <Zap className="w-3 h-3" />
@@ -272,8 +272,8 @@ export default function TranslationDrawer({
             </button>
           )}
           {isContextLoading && (
-            <span className="mt-3 inline-flex items-center gap-1.5 text-xs text-indigo-500">
-              <span className="w-3 h-3 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+            <span className="mt-3 inline-flex items-center gap-1.5 text-xs text-[var(--clay)]">
+              <span className="w-3 h-3 border-2 border-[var(--clay)] border-t-transparent rounded-full animate-spin" />
               Asking AI…
             </span>
           )}
@@ -281,39 +281,39 @@ export default function TranslationDrawer({
 
         {/* Rich phrase details (idiom, literal breakdown, usage notes, register) */}
         {aiPhraseDetails && (aiPhraseDetails.literalBreakdown || aiPhraseDetails.idiomaticMeaning || aiPhraseDetails.usageNotes || aiPhraseDetails.register) && (
-          <section className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-700 space-y-3">
+          <section className="px-4 py-3 border-b border-border space-y-3">
             {aiPhraseDetails.idiomaticMeaning && (
               <div>
-                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-1">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
                   Idiomatic meaning
                 </h3>
-                <p className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed">
+                <p className="text-sm text-foreground leading-relaxed">
                   {aiPhraseDetails.idiomaticMeaning}
                 </p>
               </div>
             )}
             {aiPhraseDetails.literalBreakdown && (
               <div>
-                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-1">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
                   Literally
                 </h3>
-                <p className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed italic">
+                <p className="text-sm text-foreground leading-relaxed italic">
                   {aiPhraseDetails.literalBreakdown}
                 </p>
               </div>
             )}
             {aiPhraseDetails.usageNotes && (
               <div>
-                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-1">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
                   Usage
                 </h3>
-                <p className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed">
+                <p className="text-sm text-foreground leading-relaxed">
                   {aiPhraseDetails.usageNotes}
                 </p>
               </div>
             )}
             {aiPhraseDetails.register && aiPhraseDetails.register !== 'neutral' && (
-              <div className="inline-flex items-center gap-1.5 text-[11px] font-medium px-2 py-0.5 rounded-md bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">
+              <div className="inline-flex items-center gap-1.5 text-[11px] font-medium px-2 py-0.5 rounded-md bg-secondary text-secondary-foreground">
                 {aiPhraseDetails.register}
               </div>
             )}
@@ -322,11 +322,11 @@ export default function TranslationDrawer({
 
         {/* Etymology */}
         {entry?.etymology && (
-          <section className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-700">
-            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-1">
+          <section className="px-4 py-3 border-b border-border">
+            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
               Etymology
             </h3>
-            <p className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed">
+            <p className="text-sm text-foreground leading-relaxed">
               {entry.etymology}
             </p>
           </section>
@@ -340,8 +340,8 @@ export default function TranslationDrawer({
           const shown = relatedExpanded ? entry.relatedForms : entry.relatedForms.slice(0, COLLAPSED_COUNT);
           const hiddenCount = total - shown.length;
           return (
-            <section className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-700">
-              <h3 className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-2">
+            <section className="px-4 py-3 border-b border-border">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
                 Related forms
               </h3>
               <ul className="space-y-1">
@@ -350,20 +350,20 @@ export default function TranslationDrawer({
                     {onLookupWord ? (
                       <NestedWordButton word={r.form} onLookupWord={onLookupWord} testId="related-form-link" />
                     ) : (
-                      <span className="font-medium text-zinc-800 dark:text-zinc-200">{r.form}</span>
+                      <span className="font-medium text-foreground">{r.form}</span>
                     )}
-                    <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">{r.relation}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">{r.relation}</span>
                   </li>
                 ))}
               </ul>
               {total > COLLAPSED_COUNT && (
                 <button
                   onClick={() => setRelatedExpanded((v) => !v)}
-                  className="mt-2 text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+                  className="mt-2 text-xs font-medium text-primary hover:text-[var(--primary-text)] transition-colors"
                 >
                   {relatedExpanded ? 'Show fewer' : `Show all (${total})`}
                   {!relatedExpanded && hiddenCount > 0 && (
-                    <span className="ml-1 text-zinc-400 dark:text-zinc-500">+{hiddenCount}</span>
+                    <span className="ml-1 text-muted-foreground">+{hiddenCount}</span>
                   )}
                 </button>
               )}
@@ -373,14 +373,14 @@ export default function TranslationDrawer({
 
         {/* Sentence — only render if a sentence was provided */}
         {sentence && (
-          <section className="px-4 py-3 border-b border-zinc-200 dark:border-zinc-700">
+          <section className="px-4 py-3 border-b border-border">
             <div className="flex items-start gap-2">
-              <p className="flex-1 text-sm text-zinc-600 dark:text-zinc-400 italic leading-relaxed">
+              <p className="flex-1 text-sm text-muted-foreground italic leading-relaxed">
                 {sentence}
               </p>
               <button
                 onClick={handleSpeakSentence}
-                className="p-1 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors flex-shrink-0"
+                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
                 title="Hear sentence"
                 aria-label="Hear sentence"
               >
@@ -393,7 +393,7 @@ export default function TranslationDrawer({
 
       {/* Footer — action buttons. Hidden if no level/known/ignore/retranslate callbacks are provided. */}
       {(onSetLevel || onMarkKnown || onIgnore || onRetranslate) && (
-        <div className="flex-shrink-0 px-4 py-3 border-t border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 space-y-2">
+        <div className="flex-shrink-0 px-4 py-3 border-t border-border bg-muted/50 space-y-2">
           {(onSetLevel || onMarkKnown || onIgnore) && (
             <div className="flex items-center gap-2 flex-wrap">
               {onSetLevel && (
@@ -408,8 +408,8 @@ export default function TranslationDrawer({
                         onClick={() => onSetLevel(level as 1 | 2 | 3 | 4)}
                         className={`w-9 h-9 rounded-lg text-sm font-semibold transition-all
                           ${isActive
-                            ? `${colors.bg} ${colors.text} ring-2 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ${colors.ring}`
-                            : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700'
+                            ? `${colors.bg} ${colors.text} ring-2 ring-offset-1 ring-offset-popover ${colors.ring}`
+                            : 'bg-muted text-muted-foreground hover:bg-accent'
                           }`}
                         title={`Level ${level}`}
                       >
@@ -424,8 +424,8 @@ export default function TranslationDrawer({
                   onClick={onMarkKnown}
                   className={`px-3 h-9 rounded-lg text-sm font-medium transition-colors
                     ${currentState === 'known'
-                      ? 'bg-green-500 text-white ring-2 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ring-green-500'
-                      : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-green-50 dark:hover:bg-green-900/20 hover:text-green-700 dark:hover:text-green-300'
+                      ? 'bg-primary text-primary-foreground ring-2 ring-offset-1 ring-offset-popover ring-primary'
+                      : 'bg-muted text-foreground hover:bg-[var(--primary-soft)] hover:text-[var(--primary-text)]'
                     }`}
                   title="Mark as known (K)"
                 >
@@ -437,8 +437,8 @@ export default function TranslationDrawer({
                   onClick={onIgnore}
                   className={`px-3 h-9 rounded-lg text-sm font-medium transition-colors
                     ${currentState === 'ignored'
-                      ? 'bg-zinc-500 text-white ring-2 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ring-zinc-500'
-                      : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700'
+                      ? 'bg-muted-foreground text-card ring-2 ring-offset-1 ring-offset-popover ring-muted-foreground'
+                      : 'bg-muted text-foreground hover:bg-accent'
                     }`}
                   title="Ignore (X)"
                 >
@@ -450,7 +450,7 @@ export default function TranslationDrawer({
           {onRetranslate && (
             <button
               onClick={onRetranslate}
-              className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
+              className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
               title="Force fresh AI lookup (ignores dictionary)"
             >
               <RefreshCw className="w-3.5 h-3.5" />

--- a/src/components/VocabGrowthChart/components/CustomTooltip/index.tsx
+++ b/src/components/VocabGrowthChart/components/CustomTooltip/index.tsx
@@ -4,8 +4,8 @@ export default function CustomTooltip({ active, payload, label }: CustomTooltipP
   if (!active || !payload || payload.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-3 shadow-xl dark:border-slate-700 dark:bg-slate-800">
-      <p className="mb-2 text-sm text-zinc-500 dark:text-slate-400">{label}</p>
+    <div className="rounded-lg border border-border bg-popover p-3 shadow-xl">
+      <p className="mb-2 text-sm text-muted-foreground">{label}</p>
       {payload.map((entry, index) => (
         <p key={index} className="text-sm" style={{ color: entry.color }}>
           <span className="capitalize">{entry.dataKey}: </span>

--- a/src/components/VocabGrowthChart/components/SummaryStat/index.tsx
+++ b/src/components/VocabGrowthChart/components/SummaryStat/index.tsx
@@ -10,7 +10,7 @@ export default function SummaryStat({
   return (
     <div className="text-center">
       <div className={`text-2xl font-bold ${colorClassName}`}>{value.toLocaleString()}</div>
-      <div className="text-xs text-zinc-500 dark:text-slate-400">{label}</div>
+      <div className="text-xs text-muted-foreground dark:text-slate-400">{label}</div>
     </div>
   );
 }

--- a/src/components/VocabGrowthChart/index.tsx
+++ b/src/components/VocabGrowthChart/index.tsx
@@ -34,8 +34,8 @@ export default function VocabGrowthChart({
   const latest = data.length > 0 ? data[data.length - 1] : null;
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-      <h3 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-white">
+    <div className="panel p-6">
+      <h3 className="mb-4 text-lg font-semibold text-foreground">
         Vocabulary Growth
       </h3>
 
@@ -118,10 +118,10 @@ export default function VocabGrowthChart({
       </ResponsiveContainer>
 
       {latest && (
-        <div className="mt-4 grid grid-cols-3 gap-4 border-t border-zinc-200 pt-4 dark:border-slate-800">
-          <SummaryStat value={latest.known} label="Known Words" colorClassName="text-green-500" />
-          <SummaryStat value={latest.learning} label="Learning" colorClassName="text-yellow-500" />
-          <SummaryStat value={latest.total} label="Total" colorClassName="text-blue-500" />
+        <div className="mt-4 grid grid-cols-3 gap-4 border-t border-border pt-4">
+          <SummaryStat value={latest.known} label="Known Words" colorClassName="text-primary" />
+          <SummaryStat value={latest.learning} label="Learning" colorClassName="text-[var(--gold-strong)]" />
+          <SummaryStat value={latest.total} label="Total" colorClassName="text-clay" />
         </div>
       )}
     </div>

--- a/src/components/VocabList/components/VocabRow/index.tsx
+++ b/src/components/VocabList/components/VocabRow/index.tsx
@@ -19,7 +19,7 @@ export default function VocabRow({
 
     return (
         <tr
-            className="cursor-pointer border-b border-gray-200 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+            className="cursor-pointer border-b border-border transition-colors hover:bg-accent"
             onClick={() => onClick(entry)}
         >
             {/* Checkbox */}
@@ -32,18 +32,18 @@ export default function VocabRow({
                         onSelect(entry.id, e.target.checked);
                     }}
                     onClick={(e) => e.stopPropagation()}
-                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                    className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                 />
             </td>
 
             {/* Word/Phrase */}
             <td className="px-4 py-3">
                 <div className="flex flex-col">
-                    <span className="font-medium text-gray-900 dark:text-gray-100">
+                    <span className="font-medium text-foreground">
                         {entry.text}
                     </span>
                     {entry.type === "phrase" && (
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                        <span className="text-xs text-muted-foreground">
                             phrase
                         </span>
                     )}
@@ -52,7 +52,7 @@ export default function VocabRow({
 
             {/* Translation */}
             <td className="max-w-xs px-4 py-3">
-                <span className="line-clamp-2 text-gray-700 dark:text-gray-300">
+                <span className="line-clamp-2 text-muted-foreground">
                     {entry.translation}
                 </span>
             </td>
@@ -65,11 +65,11 @@ export default function VocabRow({
             </td>
 
             <td className="max-w-[150px] px-4 py-3">
-                <span className="line-clamp-1 text-sm text-gray-600 dark:text-gray-400">
+                <span className="line-clamp-1 text-sm text-muted-foreground">
                     {bookTitle || "-"}
                 </span>
             </td>
-            <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+            <td className="whitespace-nowrap px-4 py-3 text-sm text-muted-foreground">
                 {formattedDate}
             </td>
             <td className="px-4 py-3">

--- a/src/components/VocabList/index.tsx
+++ b/src/components/VocabList/index.tsx
@@ -1,501 +1,474 @@
-"use client";
+'use client';
 
-import { Check, ChevronDown, ChevronUp, Loader2, RefreshCw, Upload } from "lucide-react";
-import { useState, useMemo, useCallback } from "react";
-import type { WordState } from "@/lib/data-layer";
-import VocabRow from "./components/VocabRow";
-import { stateFilters, stateOrder } from "./constants";
-import { AnkiCardType, SortDirection, SortField, VocabListProps } from "./types";
+import { Check, ChevronDown, ChevronUp, Loader2, RefreshCw, Upload } from 'lucide-react';
+import { useState, useMemo, useCallback } from 'react';
+import type { WordState } from '@/lib/data-layer';
+import VocabRow from './components/VocabRow';
+import { stateFilters, stateOrder } from './constants';
+import { AnkiCardType, SortDirection, SortField, VocabListProps } from './types';
+import { Button } from '../ui/button';
 
 export default function VocabList({
-    entries,
-    collections,
-    onEntryClick,
-    onExportToAnki,
-    onMarkAsKnown,
-    onSyncWithAnki,
-    isLoading = false,
+  entries,
+  collections,
+  onEntryClick,
+  onExportToAnki,
+  onMarkAsKnown,
+  onSyncWithAnki,
+  isLoading = false,
 }: VocabListProps) {
-    // Filter state
-    const [stateFilter, setStateFilter] = useState<WordState | "all" | "learning">("all");
-    const [bookFilter, setBookFilter] = useState<string>("all");
-    const [searchQuery, setSearchQuery] = useState("");
+  // Filter state
+  const [stateFilter, setStateFilter] = useState<WordState | 'all' | 'learning'>('all');
+  const [bookFilter, setBookFilter] = useState<string>('all');
+  const [searchQuery, setSearchQuery] = useState('');
 
-    // Sort state
-    const [sortField, setSortField] = useState<SortField>("createdAt");
-    const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  // Sort state
+  const [sortField, setSortField] = useState<SortField>('createdAt');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
-    // Selection state
-    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Selection state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-    // Action loading states
-    const [isExporting, setIsExporting] = useState(false);
-    const [isMarkingKnown, setIsMarkingKnown] = useState(false);
-    const [isSyncing, setIsSyncing] = useState(false);
+  // Action loading states
+  const [isExporting, setIsExporting] = useState(false);
+  const [isMarkingKnown, setIsMarkingKnown] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
 
-    // Export-to-Anki modal state. Card type pre-selects the user's last choice
-    // (persisted to localStorage) so heavy Cloze users don't flip on every open.
-    const [exportModalOpen, setExportModalOpen] = useState(false);
-    const [cardType, setCardType] = useState<AnkiCardType>(() => {
-        if (typeof window === 'undefined') return 'basic';
-        const saved = localStorage.getItem('lector-anki-card-type');
-        return saved === 'cloze' ? 'cloze' : 'basic';
+  // Export-to-Anki modal state. Card type pre-selects the user's last choice
+  // (persisted to localStorage) so heavy Cloze users don't flip on every open.
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [cardType, setCardType] = useState<AnkiCardType>(() => {
+    if (typeof window === 'undefined') return 'basic';
+    const saved = localStorage.getItem('lector-anki-card-type');
+    return saved === 'cloze' ? 'cloze' : 'basic';
+  });
+  const updateCardType = (next: AnkiCardType) => {
+    setCardType(next);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('lector-anki-card-type', next);
+    }
+  };
+
+  // Create a map of collectionId to title for display
+  const bookTitleMap = useMemo(() => {
+    const map = new Map<string, string>();
+    collections.forEach((c) => map.set(c.id, c.title));
+    return map;
+  }, [collections]);
+
+  // Filter and sort entries
+  const filteredEntries = useMemo(() => {
+    let result = [...entries];
+
+    // Apply state filter
+    if (stateFilter !== 'all') {
+      if (stateFilter === 'learning') {
+        // "Learning" includes new, level1-4 (not known or ignored)
+        result = result.filter((e) => e.state !== 'known' && e.state !== 'ignored');
+      } else {
+        result = result.filter((e) => e.state === stateFilter);
+      }
+    }
+
+    // Apply book filter
+    if (bookFilter !== 'all') {
+      result = result.filter((e) => e.bookId === bookFilter);
+    }
+
+    // Apply search filter
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase().trim();
+      result = result.filter(
+        (e) =>
+          e.text.toLowerCase().includes(query) ||
+          e.translation.toLowerCase().includes(query) ||
+          e.sentence.toLowerCase().includes(query),
+      );
+    }
+
+    // Apply sorting
+    result.sort((a, b) => {
+      let comparison = 0;
+
+      switch (sortField) {
+        case 'text':
+          comparison = a.text.localeCompare(b.text);
+          break;
+        case 'createdAt':
+          comparison = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
+        case 'state':
+          comparison = stateOrder[a.state] - stateOrder[b.state];
+          break;
+        case 'bookId':
+          const titleA = a.bookId ? bookTitleMap.get(a.bookId) || '' : '';
+          const titleB = b.bookId ? bookTitleMap.get(b.bookId) || '' : '';
+          comparison = titleA.localeCompare(titleB);
+          break;
+      }
+
+      return sortDirection === 'asc' ? comparison : -comparison;
     });
-    const updateCardType = (next: AnkiCardType) => {
-        setCardType(next);
-        if (typeof window !== 'undefined') {
-            localStorage.setItem('lector-anki-card-type', next);
-        }
-    };
 
-    // Create a map of collectionId to title for display
-    const bookTitleMap = useMemo(() => {
-        const map = new Map<string, string>();
-        collections.forEach((c) => map.set(c.id, c.title));
-        return map;
-    }, [collections]);
+    return result;
+  }, [entries, stateFilter, bookFilter, searchQuery, sortField, sortDirection, bookTitleMap]);
 
-    // Filter and sort entries
-    const filteredEntries = useMemo(() => {
-        let result = [...entries];
+  // Handle selection
+  const handleSelect = useCallback((id: string, selected: boolean) => {
+    setSelectedIds((prev) => {
+      const newSet = new Set(prev);
+      if (selected) {
+        newSet.add(id);
+      } else {
+        newSet.delete(id);
+      }
+      return newSet;
+    });
+  }, []);
 
-        // Apply state filter
-        if (stateFilter !== "all") {
-            if (stateFilter === "learning") {
-                // "Learning" includes new, level1-4 (not known or ignored)
-                result = result.filter(
-                    (e) => e.state !== "known" && e.state !== "ignored"
-                );
-            } else {
-                result = result.filter((e) => e.state === stateFilter);
-            }
-        }
+  const handleSelectAll = useCallback(
+    (selected: boolean) => {
+      if (selected) {
+        setSelectedIds(new Set(filteredEntries.map((e) => e.id)));
+      } else {
+        setSelectedIds(new Set());
+      }
+    },
+    [filteredEntries],
+  );
 
-        // Apply book filter
-        if (bookFilter !== "all") {
-            result = result.filter((e) => e.bookId === bookFilter);
-        }
+  // Handle sort column click
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+  };
 
-        // Apply search filter
-        if (searchQuery.trim()) {
-            const query = searchQuery.toLowerCase().trim();
-            result = result.filter(
-                (e) =>
-                    e.text.toLowerCase().includes(query) ||
-                    e.translation.toLowerCase().includes(query) ||
-                    e.sentence.toLowerCase().includes(query)
-            );
-        }
-
-        // Apply sorting
-        result.sort((a, b) => {
-            let comparison = 0;
-
-            switch (sortField) {
-                case "text":
-                    comparison = a.text.localeCompare(b.text);
-                    break;
-                case "createdAt":
-                    comparison =
-                        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-                    break;
-                case "state":
-                    comparison = stateOrder[a.state] - stateOrder[b.state];
-                    break;
-                case "bookId":
-                    const titleA = a.bookId ? bookTitleMap.get(a.bookId) || "" : "";
-                    const titleB = b.bookId ? bookTitleMap.get(b.bookId) || "" : "";
-                    comparison = titleA.localeCompare(titleB);
-                    break;
-            }
-
-            return sortDirection === "asc" ? comparison : -comparison;
-        });
-
-        return result;
-    }, [
-        entries,
-        stateFilter,
-        bookFilter,
-        searchQuery,
-        sortField,
-        sortDirection,
-        bookTitleMap,
-    ]);
-
-    // Handle selection
-    const handleSelect = useCallback((id: string, selected: boolean) => {
-        setSelectedIds((prev) => {
-            const newSet = new Set(prev);
-            if (selected) {
-                newSet.add(id);
-            } else {
-                newSet.delete(id);
-            }
-            return newSet;
-        });
-    }, []);
-
-    const handleSelectAll = useCallback(
-        (selected: boolean) => {
-            if (selected) {
-                setSelectedIds(new Set(filteredEntries.map((e) => e.id)));
-            } else {
-                setSelectedIds(new Set());
-            }
-        },
-        [filteredEntries]
-    );
-
-    // Handle sort column click
-    const handleSort = (field: SortField) => {
-        if (sortField === field) {
-            setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
-        } else {
-            setSortField(field);
-            setSortDirection("asc");
-        }
-    };
-
-    // Sort indicator component
-    const SortIndicator = ({ field }: { field: SortField }) => {
-        if (sortField !== field) return null;
-        return (
-            <span className="ml-1">
-                {sortDirection === "asc" ? (
-                    <ChevronUp className="inline h-4 w-4" />
-                ) : (
-                    <ChevronDown className="inline h-4 w-4" />
-                )}
-            </span>
-        );
-    };
-
-    // Bulk action handlers. The export button opens a modal that confirms the
-    // card type; the actual onExportToAnki call fires from the modal's Export
-    // action so the user has a moment to switch Basic <-> Cloze.
-    const openExportModal = () => {
-        if (selectedIds.size === 0) return;
-        setExportModalOpen(true);
-    };
-    const confirmExportToAnki = async () => {
-        setExportModalOpen(false);
-        setIsExporting(true);
-        try {
-            await onExportToAnki(Array.from(selectedIds), cardType);
-            setSelectedIds(new Set());
-        } finally {
-            setIsExporting(false);
-        }
-    };
-
-    const handleMarkAsKnown = async () => {
-        if (selectedIds.size === 0) return;
-        setIsMarkingKnown(true);
-        try {
-            await onMarkAsKnown(Array.from(selectedIds));
-            setSelectedIds(new Set());
-        } finally {
-            setIsMarkingKnown(false);
-        }
-    };
-
-    const handleSyncWithAnki = async () => {
-        setIsSyncing(true);
-        try {
-            await onSyncWithAnki();
-        } finally {
-            setIsSyncing(false);
-        }
-    };
-
-    const allSelected =
-        filteredEntries.length > 0 &&
-        filteredEntries.every((e) => selectedIds.has(e.id));
-    const someSelected = selectedIds.size > 0;
-
+  // Sort indicator component
+  const SortIndicator = ({ field }: { field: SortField }) => {
+    if (sortField !== field) return null;
     return (
-        <div className="flex flex-col gap-4">
-            {/* Filters and Search */}
-            <div className="flex flex-wrap items-center gap-4">
-                {/* Search */}
-                <div className="flex-1 min-w-[200px]">
-                    <input
-                        type="text"
-                        placeholder="Search words, translations, or sentences..."
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
-                    />
-                </div>
-
-                {/* State Filter */}
-                <select
-                    value={stateFilter}
-                    onChange={(e) =>
-                        setStateFilter(e.target.value as WordState | "all" | "learning")
-                    }
-                    className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-                >
-                    {stateFilters.map((filter) => (
-                        <option key={filter.value} value={filter.value}>
-                            {filter.label}
-                        </option>
-                    ))}
-                </select>
-
-                {/* Book Filter */}
-                <select
-                    value={bookFilter}
-                    onChange={(e) => setBookFilter(e.target.value)}
-                    className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-                >
-                    <option value="all">All Collections</option>
-                    {collections.map((c) => (
-                        <option key={c.id} value={c.id}>
-                            {c.title}
-                        </option>
-                    ))}
-                </select>
-            </div>
-
-            {/* Bulk Actions */}
-            <div className="flex flex-wrap items-center gap-3">
-                <button
-                    onClick={openExportModal}
-                    disabled={!someSelected || isExporting}
-                    className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400 dark:disabled:bg-gray-600"
-                >
-                    {isExporting ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Exporting...
-                        </>
-                    ) : (
-                        <>
-                            <Upload className="h-4 w-4" />
-                            Export to Anki ({selectedIds.size})
-                        </>
-                    )}
-                </button>
-
-                <button
-                    onClick={handleMarkAsKnown}
-                    disabled={!someSelected || isMarkingKnown}
-                    className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-400 dark:disabled:bg-gray-600"
-                >
-                    {isMarkingKnown ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Updating...
-                        </>
-                    ) : (
-                        <>
-                            <Check className="h-4 w-4" />
-                            Mark as Known ({selectedIds.size})
-                        </>
-                    )}
-                </button>
-
-                <div className="flex-1" />
-
-                <button
-                    onClick={handleSyncWithAnki}
-                    disabled={isSyncing}
-                    className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-                >
-                    {isSyncing ? (
-                        <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Syncing...
-                        </>
-                    ) : (
-                        <>
-                            <RefreshCw className="h-4 w-4" />
-                            Sync with Anki
-                        </>
-                    )}
-                </button>
-            </div>
-
-            {/* Results count */}
-            <div className="text-sm text-gray-600 dark:text-gray-400">
-                Showing {filteredEntries.length} of {entries.length} entries
-                {someSelected && ` (${selectedIds.size} selected)`}
-            </div>
-
-            {/* Table */}
-            <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
-                <table className="w-full text-left">
-                    <thead className="bg-gray-50 dark:bg-gray-800">
-                        <tr>
-                            <th className="w-12 px-4 py-3">
-                                <input
-                                    type="checkbox"
-                                    checked={allSelected}
-                                    onChange={(e) => handleSelectAll(e.target.checked)}
-                                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
-                                />
-                            </th>
-                            <th
-                                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
-                                onClick={() => handleSort("text")}
-                            >
-                                Word/Phrase
-                                <SortIndicator field="text" />
-                            </th>
-                            <th className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-                                Translation
-                            </th>
-                            <th
-                                className="cursor-pointer px-4 py-3 text-center text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
-                                onClick={() => handleSort("state")}
-                            >
-                                State
-                                <SortIndicator field="state" />
-                            </th>
-                            <th
-                                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
-                                onClick={() => handleSort("bookId")}
-                            >
-                                Source
-                                <SortIndicator field="bookId" />
-                            </th>
-                            <th
-                                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
-                                onClick={() => handleSort("createdAt")}
-                            >
-                                Date Added
-                                <SortIndicator field="createdAt" />
-                            </th>
-                            <th className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-                                Anki
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {isLoading ? (
-                            <tr>
-                                <td colSpan={7} className="px-4 py-12 text-center">
-                                    <div className="flex flex-col items-center gap-3">
-                                        <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
-                                        <span className="text-gray-600 dark:text-gray-400">
-                                            Loading vocabulary...
-                                        </span>
-                                    </div>
-                                </td>
-                            </tr>
-                        ) : filteredEntries.length === 0 ? (
-                            <tr>
-                                <td
-                                    colSpan={7}
-                                    className="px-4 py-12 text-center text-gray-500 dark:text-gray-400"
-                                >
-                                    {entries.length === 0
-                                        ? "No vocabulary entries yet. Start reading to add words!"
-                                        : "No entries match your filters."}
-                                </td>
-                            </tr>
-                        ) : (
-                            filteredEntries.map((entry) => (
-                                <VocabRow
-                                    key={entry.id}
-                                    entry={entry}
-                                    bookTitle={entry.bookId ? bookTitleMap.get(entry.bookId) : undefined}
-                                    isSelected={selectedIds.has(entry.id)}
-                                    onSelect={handleSelect}
-                                    onClick={onEntryClick}
-                                />
-                            ))
-                        )}
-                    </tbody>
-                </table>
-            </div>
-
-            {/* Export-to-Anki modal */}
-            {exportModalOpen && (
-                <div
-                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-                    onClick={() => setExportModalOpen(false)}
-                    role="dialog"
-                    aria-modal="true"
-                    aria-label="Export to Anki"
-                >
-                    <div
-                        className="w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-zinc-900"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-                            Export to Anki
-                        </h2>
-                        <p className="mb-5 text-sm text-zinc-500 dark:text-zinc-400">
-                            {selectedIds.size} {selectedIds.size === 1 ? 'word' : 'words'} selected. Choose a card type.
-                        </p>
-
-                        <div className="mb-6 grid grid-cols-2 gap-3">
-                            <button
-                                type="button"
-                                data-testid="anki-card-type-basic"
-                                aria-pressed={cardType === 'basic'}
-                                onClick={() => updateCardType('basic')}
-                                className={`rounded-lg border p-4 text-left transition-colors ${cardType === 'basic'
-                                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
-                                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
-                                    }`}
-                            >
-                                <div className="flex items-center justify-between">
-                                    <span className="font-medium text-zinc-900 dark:text-zinc-100">Basic</span>
-                                    {cardType === 'basic' && (
-                                        <Check className="h-4 w-4 text-blue-600 dark:text-blue-400" strokeWidth={3} />
-                                    )}
-                                </div>
-                                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                                    Front/back card. Sentence on front, translation on back.
-                                </p>
-                            </button>
-
-                            <button
-                                type="button"
-                                data-testid="anki-card-type-cloze"
-                                aria-pressed={cardType === 'cloze'}
-                                onClick={() => updateCardType('cloze')}
-                                className={`rounded-lg border p-4 text-left transition-colors ${cardType === 'cloze'
-                                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
-                                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
-                                    }`}
-                            >
-                                <div className="flex items-center justify-between">
-                                    <span className="font-medium text-zinc-900 dark:text-zinc-100">Cloze</span>
-                                    {cardType === 'cloze' && (
-                                        <Check className="h-4 w-4 text-blue-600 dark:text-blue-400" strokeWidth={3} />
-                                    )}
-                                </div>
-                                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                                    Word is hidden in the sentence; recall it from context.
-                                </p>
-                            </button>
-                        </div>
-
-                        <div className="flex justify-end gap-2">
-                            <button
-                                type="button"
-                                onClick={() => setExportModalOpen(false)}
-                                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                type="button"
-                                data-testid="anki-export-confirm"
-                                onClick={confirmExportToAnki}
-                                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-                            >
-                                Export {selectedIds.size} {selectedIds.size === 1 ? 'card' : 'cards'}
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            )}
-        </div>
+      <span className="ml-1">
+        {sortDirection === 'asc' ? (
+          <ChevronUp className="inline h-4 w-4" />
+        ) : (
+          <ChevronDown className="inline h-4 w-4" />
+        )}
+      </span>
     );
+  };
+
+  // Bulk action handlers. The export button opens a modal that confirms the
+  // card type; the actual onExportToAnki call fires from the modal's Export
+  // action so the user has a moment to switch Basic <-> Cloze.
+  const openExportModal = () => {
+    if (selectedIds.size === 0) return;
+    setExportModalOpen(true);
+  };
+  const confirmExportToAnki = async () => {
+    setExportModalOpen(false);
+    setIsExporting(true);
+    try {
+      await onExportToAnki(Array.from(selectedIds), cardType);
+      setSelectedIds(new Set());
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleMarkAsKnown = async () => {
+    if (selectedIds.size === 0) return;
+    setIsMarkingKnown(true);
+    try {
+      await onMarkAsKnown(Array.from(selectedIds));
+      setSelectedIds(new Set());
+    } finally {
+      setIsMarkingKnown(false);
+    }
+  };
+
+  const handleSyncWithAnki = async () => {
+    setIsSyncing(true);
+    try {
+      await onSyncWithAnki();
+    } finally {
+      setIsSyncing(false);
+    }
+  };
+
+  const allSelected =
+    filteredEntries.length > 0 && filteredEntries.every((e) => selectedIds.has(e.id));
+  const someSelected = selectedIds.size > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filters and Search */}
+      <div className="flex flex-wrap items-center gap-4">
+        {/* Search */}
+        <div className="min-w-[200px] flex-1">
+          <input
+            type="text"
+            placeholder="Search words, translations, or sentences..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
+          />
+        </div>
+
+        {/* State Filter */}
+        <select
+          value={stateFilter}
+          onChange={(e) => setStateFilter(e.target.value as WordState | 'all' | 'learning')}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        >
+          {stateFilters.map((filter) => (
+            <option key={filter.value} value={filter.value}>
+              {filter.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Book Filter */}
+        <select
+          value={bookFilter}
+          onChange={(e) => setBookFilter(e.target.value)}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        >
+          <option value="all">All Collections</option>
+          {collections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.title}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Bulk Actions */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Button onClick={openExportModal} disabled={!someSelected || isExporting}>
+          {isExporting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Exporting...
+            </>
+          ) : (
+            <>
+              <Upload className="h-4 w-4" />
+              Export to Anki ({selectedIds.size})
+            </>
+          )}
+        </Button>
+
+        <Button onClick={handleMarkAsKnown} disabled={!someSelected || isMarkingKnown}>
+          {isMarkingKnown ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Updating...
+            </>
+          ) : (
+            <>
+              <Check className="h-4 w-4" />
+              Mark as Known ({selectedIds.size})
+            </>
+          )}
+        </Button>
+
+        <div className="flex-1" />
+
+        <Button onClick={handleSyncWithAnki} disabled={isSyncing}>
+          {isSyncing ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Syncing...
+            </>
+          ) : (
+            <>
+              <RefreshCw className="h-4 w-4" />
+              Sync with Anki
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Results count */}
+      <div className="text-sm text-gray-600 dark:text-gray-400">
+        Showing {filteredEntries.length} of {entries.length} entries
+        {someSelected && ` (${selectedIds.size} selected)`}
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+        <table className="w-full text-left">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th className="w-12 px-4 py-3">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={(e) => handleSelectAll(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                />
+              </th>
+              <th
+                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                onClick={() => handleSort('text')}
+              >
+                Word/Phrase
+                <SortIndicator field="text" />
+              </th>
+              <th className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                Translation
+              </th>
+              <th
+                className="cursor-pointer px-4 py-3 text-center text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                onClick={() => handleSort('state')}
+              >
+                State
+                <SortIndicator field="state" />
+              </th>
+              <th
+                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                onClick={() => handleSort('bookId')}
+              >
+                Source
+                <SortIndicator field="bookId" />
+              </th>
+              <th
+                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                onClick={() => handleSort('createdAt')}
+              >
+                Date Added
+                <SortIndicator field="createdAt" />
+              </th>
+              <th className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                Anki
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-12 text-center">
+                  <div className="flex flex-col items-center gap-3">
+                    <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+                    <span className="text-gray-600 dark:text-gray-400">Loading vocabulary...</span>
+                  </div>
+                </td>
+              </tr>
+            ) : filteredEntries.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-12 text-center text-gray-500 dark:text-gray-400">
+                  {entries.length === 0
+                    ? 'No vocabulary entries yet. Start reading to add words!'
+                    : 'No entries match your filters.'}
+                </td>
+              </tr>
+            ) : (
+              filteredEntries.map((entry) => (
+                <VocabRow
+                  key={entry.id}
+                  entry={entry}
+                  bookTitle={entry.bookId ? bookTitleMap.get(entry.bookId) : undefined}
+                  isSelected={selectedIds.has(entry.id)}
+                  onSelect={handleSelect}
+                  onClick={onEntryClick}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Export-to-Anki modal */}
+      {exportModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setExportModalOpen(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Export to Anki"
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-zinc-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              Export to Anki
+            </h2>
+            <p className="mb-5 text-sm text-zinc-500 dark:text-zinc-400">
+              {selectedIds.size} {selectedIds.size === 1 ? 'word' : 'words'} selected. Choose a card
+              type.
+            </p>
+
+            <div className="mb-6 grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                data-testid="anki-card-type-basic"
+                aria-pressed={cardType === 'basic'}
+                onClick={() => updateCardType('basic')}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  cardType === 'basic'
+                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
+                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-zinc-900 dark:text-zinc-100">Basic</span>
+                  {cardType === 'basic' && (
+                    <Check className="h-4 w-4 text-blue-600 dark:text-blue-400" strokeWidth={3} />
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Front/back card. Sentence on front, translation on back.
+                </p>
+              </button>
+
+              <button
+                type="button"
+                data-testid="anki-card-type-cloze"
+                aria-pressed={cardType === 'cloze'}
+                onClick={() => updateCardType('cloze')}
+                className={`rounded-lg border p-4 text-left transition-colors ${
+                  cardType === 'cloze'
+                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
+                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-zinc-900 dark:text-zinc-100">Cloze</span>
+                  {cardType === 'cloze' && (
+                    <Check className="h-4 w-4 text-blue-600 dark:text-blue-400" strokeWidth={3} />
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Word is hidden in the sentence; recall it from context.
+                </p>
+              </button>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setExportModalOpen(false)}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="anki-export-confirm"
+                onClick={confirmExportToAnki}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Export {selectedIds.size} {selectedIds.size === 1 ? 'card' : 'cards'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/VocabList/index.tsx
+++ b/src/components/VocabList/index.tsx
@@ -214,7 +214,7 @@ export default function VocabList({
             placeholder="Search words, translations, or sentences..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
+            className="w-full rounded-lg border border-input bg-background px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
           />
         </div>
 
@@ -222,7 +222,7 @@ export default function VocabList({
         <select
           value={stateFilter}
           onChange={(e) => setStateFilter(e.target.value as WordState | 'all' | 'learning')}
-          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
         >
           {stateFilters.map((filter) => (
             <option key={filter.value} value={filter.value}>
@@ -235,7 +235,7 @@ export default function VocabList({
         <select
           value={bookFilter}
           onChange={(e) => setBookFilter(e.target.value)}
-          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          className="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
         >
           <option value="all">All Collections</option>
           {collections.map((c) => (
@@ -294,56 +294,56 @@ export default function VocabList({
       </div>
 
       {/* Results count */}
-      <div className="text-sm text-gray-600 dark:text-gray-400">
+      <div className="text-sm text-muted-foreground">
         Showing {filteredEntries.length} of {entries.length} entries
         {someSelected && ` (${selectedIds.size} selected)`}
       </div>
 
       {/* Table */}
-      <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <div className="overflow-x-auto rounded-lg border border-border">
         <table className="w-full text-left">
-          <thead className="bg-gray-50 dark:bg-gray-800">
+          <thead className="bg-muted">
             <tr>
               <th className="w-12 px-4 py-3">
                 <input
                   type="checkbox"
                   checked={allSelected}
                   onChange={(e) => handleSelectAll(e.target.checked)}
-                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+                  className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                 />
               </th>
               <th
-                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                className="cursor-pointer px-4 py-3 text-sm font-semibold text-foreground hover:text-foreground"
                 onClick={() => handleSort('text')}
               >
                 Word/Phrase
                 <SortIndicator field="text" />
               </th>
-              <th className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+              <th className="px-4 py-3 text-sm font-semibold text-foreground">
                 Translation
               </th>
               <th
-                className="cursor-pointer px-4 py-3 text-center text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                className="cursor-pointer px-4 py-3 text-center text-sm font-semibold text-foreground hover:text-foreground"
                 onClick={() => handleSort('state')}
               >
                 State
                 <SortIndicator field="state" />
               </th>
               <th
-                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                className="cursor-pointer px-4 py-3 text-sm font-semibold text-foreground hover:text-foreground"
                 onClick={() => handleSort('bookId')}
               >
                 Source
                 <SortIndicator field="bookId" />
               </th>
               <th
-                className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                className="cursor-pointer px-4 py-3 text-sm font-semibold text-foreground hover:text-foreground"
                 onClick={() => handleSort('createdAt')}
               >
                 Date Added
                 <SortIndicator field="createdAt" />
               </th>
-              <th className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+              <th className="px-4 py-3 text-sm font-semibold text-foreground">
                 Anki
               </th>
             </tr>
@@ -353,14 +353,14 @@ export default function VocabList({
               <tr>
                 <td colSpan={7} className="px-4 py-12 text-center">
                   <div className="flex flex-col items-center gap-3">
-                    <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
-                    <span className="text-gray-600 dark:text-gray-400">Loading vocabulary...</span>
+                    <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                    <span className="text-muted-foreground">Loading vocabulary...</span>
                   </div>
                 </td>
               </tr>
             ) : filteredEntries.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-4 py-12 text-center text-gray-500 dark:text-gray-400">
+                <td colSpan={7} className="px-4 py-12 text-center text-muted-foreground">
                   {entries.length === 0
                     ? 'No vocabulary entries yet. Start reading to add words!'
                     : 'No entries match your filters.'}
@@ -392,13 +392,13 @@ export default function VocabList({
           aria-label="Export to Anki"
         >
           <div
-            className="w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-zinc-900"
+            className="w-full max-w-md rounded-xl bg-card p-6 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            <h2 className="mb-1 text-lg font-semibold text-foreground">
               Export to Anki
             </h2>
-            <p className="mb-5 text-sm text-zinc-500 dark:text-zinc-400">
+            <p className="mb-5 text-sm text-muted-foreground">
               {selectedIds.size} {selectedIds.size === 1 ? 'word' : 'words'} selected. Choose a card
               type.
             </p>
@@ -411,17 +411,17 @@ export default function VocabList({
                 onClick={() => updateCardType('basic')}
                 className={`rounded-lg border p-4 text-left transition-colors ${
                   cardType === 'basic'
-                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
-                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
+                    ? 'border-primary bg-[var(--primary-soft)] ring-2 ring-primary'
+                    : 'border-border hover:border-foreground/30'
                 }`}
               >
                 <div className="flex items-center justify-between">
-                  <span className="font-medium text-zinc-900 dark:text-zinc-100">Basic</span>
+                  <span className="font-medium text-foreground">Basic</span>
                   {cardType === 'basic' && (
-                    <Check className="h-4 w-4 text-blue-600 dark:text-blue-400" strokeWidth={3} />
+                    <Check className="h-4 w-4 text-primary" strokeWidth={3} />
                   )}
                 </div>
-                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                <p className="mt-1 text-xs text-muted-foreground">
                   Front/back card. Sentence on front, translation on back.
                 </p>
               </button>
@@ -433,38 +433,37 @@ export default function VocabList({
                 onClick={() => updateCardType('cloze')}
                 className={`rounded-lg border p-4 text-left transition-colors ${
                   cardType === 'cloze'
-                    ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-900/20'
-                    : 'border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600'
+                    ? 'border-primary bg-[var(--primary-soft)] ring-2 ring-primary'
+                    : 'border-border hover:border-foreground/30'
                 }`}
               >
                 <div className="flex items-center justify-between">
-                  <span className="font-medium text-zinc-900 dark:text-zinc-100">Cloze</span>
+                  <span className="font-medium text-foreground">Cloze</span>
                   {cardType === 'cloze' && (
-                    <Check className="h-4 w-4 text-blue-600 dark:text-blue-400" strokeWidth={3} />
+                    <Check className="h-4 w-4 text-primary" strokeWidth={3} />
                   )}
                 </div>
-                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                <p className="mt-1 text-xs text-muted-foreground">
                   Word is hidden in the sentence; recall it from context.
                 </p>
               </button>
             </div>
 
             <div className="flex justify-end gap-2">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={() => setExportModalOpen(false)}
-                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
                 data-testid="anki-export-confirm"
                 onClick={confirmExportToAnki}
-                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
               >
                 Export {selectedIds.size} {selectedIds.size === 1 ? 'card' : 'cards'}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/components/WebImportModal/components/PreviewStep/index.tsx
+++ b/src/components/WebImportModal/components/PreviewStep/index.tsx
@@ -21,7 +21,7 @@ export default function PreviewStep({
         <div>
           <label
             htmlFor="title-input"
-            className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+            className="mb-2 block text-sm font-medium text-foreground"
           >
             Title
           </label>
@@ -31,13 +31,13 @@ export default function PreviewStep({
             value={title}
             onChange={(e) => onTitleChange(e.target.value)}
             disabled={isSaving}
-            className="w-full rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:ring-zinc-100"
+            className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
           />
         </div>
         <div>
           <label
             htmlFor="author-input"
-            className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+            className="mb-2 block text-sm font-medium text-foreground"
           >
             Author / Source
           </label>
@@ -47,23 +47,23 @@ export default function PreviewStep({
             value={author}
             onChange={(e) => onAuthorChange(e.target.value)}
             disabled={isSaving}
-            className="w-full rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-zinc-900 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:ring-zinc-100"
+            className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
           />
         </div>
       </div>
 
       {article && (
-        <div className="flex items-center gap-4 text-sm text-zinc-500 dark:text-zinc-400">
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
           <span>{article.wordCount.toLocaleString()} words</span>
           {article.siteName && <span>from {article.siteName}</span>}
         </div>
       )}
 
       <div>
-        <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        <label className="mb-2 block text-sm font-medium text-foreground">
           Content Preview
         </label>
-        <div className="h-64 overflow-y-auto rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-sm whitespace-pre-wrap text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-300">
+        <div className="h-64 overflow-y-auto rounded-lg border border-border bg-muted p-4 text-sm whitespace-pre-wrap text-muted-foreground">
           {article?.content}
         </div>
       </div>

--- a/src/components/WebImportModal/components/UrlInputStep/index.tsx
+++ b/src/components/WebImportModal/components/UrlInputStep/index.tsx
@@ -1,4 +1,5 @@
 import type { KeyboardEvent, Ref } from 'react';
+import { Button } from '@/components/ui/button';
 
 export default function UrlInputStep({
   url,
@@ -24,7 +25,7 @@ export default function UrlInputStep({
       <div>
         <label
           htmlFor="url-input"
-          className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+          className="mb-2 block text-sm font-medium text-foreground"
         >
           Article URL
         </label>
@@ -38,38 +39,38 @@ export default function UrlInputStep({
             onKeyDown={onKeyDown}
             placeholder="https://www.netwerk24.com/..."
             disabled={isLoading}
-            className="flex-1 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-zinc-900 placeholder-zinc-400 focus:ring-2 focus:ring-zinc-900 focus:outline-none disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:ring-zinc-100"
+            className="flex-1 rounded-lg border border-input bg-background px-4 py-2.5 text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
           />
-          <button
+          <Button
             onClick={onExtract}
             disabled={!url.trim() || isLoading}
-            className="rounded-lg bg-zinc-900 px-5 py-2.5 font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            className="px-5 py-2.5"
           >
             {isLoading ? (
               <div className="flex items-center gap-2">
-                <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white dark:border-zinc-900/30 dark:border-t-zinc-900" />
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
                 Extracting...
               </div>
             ) : (
               'Extract'
             )}
-          </button>
+          </Button>
         </div>
       </div>
 
       {errorMessage !== null && (
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
-          <p className="text-sm text-red-700 dark:text-red-300">{errorMessage}</p>
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4">
+          <p className="text-sm text-destructive">{errorMessage}</p>
           <button
             onClick={onRetry}
-            className="mt-2 text-sm font-medium text-red-600 hover:underline dark:text-red-400"
+            className="mt-2 text-sm font-medium text-destructive hover:underline"
           >
             Try again
           </button>
         </div>
       )}
 
-      <p className="text-sm text-zinc-500 dark:text-zinc-400">
+      <p className="text-sm text-muted-foreground">
         Paste a URL to an Afrikaans news article or blog post. The article content will be extracted
         and added to your library.
       </p>

--- a/src/components/WebImportModal/index.tsx
+++ b/src/components/WebImportModal/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { X } from 'lucide-react';
 import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
 import PreviewStep from './components/PreviewStep';
 import UrlInputStep from './components/UrlInputStep';
 import type { ModalState, WebImportModalProps } from './types';
@@ -119,20 +120,21 @@ export default function WebImportModal({ isOpen, onClose, onSave }: WebImportMod
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
       <div
         ref={modalRef}
-        className={`flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl transition-all duration-200 ease-out dark:border-zinc-700 dark:bg-zinc-900 ${isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+        className={`flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl transition-all duration-200 ease-out ${isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2 className="text-lg font-semibold text-foreground">
             Import from Web
           </h2>
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={onClose}
-            className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
             aria-label="Close"
           >
             <X size="20" />
-          </button>
+          </Button>
         </div>
 
         {/* Content */}
@@ -164,28 +166,27 @@ export default function WebImportModal({ isOpen, onClose, onSave }: WebImportMod
 
         {/* Footer */}
         {(state.phase === 'preview' || state.phase === 'saving') && (
-          <div className="flex items-center justify-end gap-3 border-t border-zinc-200 bg-zinc-50 px-6 py-4 dark:border-zinc-700 dark:bg-zinc-800/50">
-            <button
+          <div className="flex items-center justify-end gap-3 border-t border-border bg-muted px-6 py-4">
+            <Button
+              variant="ghost"
               onClick={() => setState({ phase: 'input' })}
               disabled={state.phase === 'saving'}
-              className="rounded-lg px-4 py-2 font-medium text-zinc-700 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:text-zinc-300 dark:hover:bg-zinc-700"
             >
               Back
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={handleSave}
               disabled={state.phase === 'saving' || !editedTitle.trim()}
-              className="rounded-lg bg-zinc-900 px-5 py-2 font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
             >
               {state.phase === 'saving' ? (
                 <div className="flex items-center gap-2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white dark:border-zinc-900/30 dark:border-t-zinc-900" />
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
                   Saving...
                 </div>
               ) : (
                 'Save to Library'
               )}
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,19 +4,21 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 motion-safe:active:not-aria-[haspopup]:translate-y-px disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default:
+          'bg-primary text-primary-foreground font-bold shadow-[0_5px_0_var(--primary-lip)] hover:bg-primary/90 motion-safe:active:shadow-[0_3px_0_var(--primary-lip)]',
         outline:
           'border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+          'bg-secondary text-secondary-foreground font-bold shadow-[0_4px_0_var(--lip)] hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] motion-safe:active:shadow-[0_2px_0_var(--lip)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        clay: 'bg-clay text-clay-foreground font-bold shadow-[0_4px_0_var(--clay-lip)] hover:bg-clay/90 motion-safe:active:shadow-[0_2px_0_var(--clay-lip)]',
         ghost:
           'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
         destructive:
-          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
+          'bg-destructive text-destructive-foreground font-bold shadow-[0_4px_0_var(--destructive-lip)] hover:bg-destructive/90 focus-visible:ring-destructive/30 motion-safe:active:shadow-[0_2px_0_var(--destructive-lip)]',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {


### PR DESCRIPTION
## Summary

Implements the "grown-up gamified" visual language from #147 — moves Lector off the default zinc/shadcn look onto a warm **sand/sage** palette (light) + a warm **espresso** dark mode, shipped as a coherent token pair. **Skinning only**: no structural or functional changes — SRS, cloze, streaks, dictionary, and data behaviour are all untouched.

### Foundation
- `globals.css`: warm `:root`/`.dark` tokens, `--radius` 0.75rem, custom tokens (`--lip`, `--clay`, `--gold`, word-state ramp, glows), `@theme` font map.
- Fonts: **Nunito** for UI/chrome, **Literata** kept for the reading body (§2.1); Inter retired.
- Primitives: `Button` gains the shallow 3D "lip" (default/secondary), a `clay` variant, solid+lip `destructive`, and a reduced-motion press; new `.panel` card class.

### Surfaces migrated to semantic tokens
Nav/chrome, reader word-state chips, translation drawer (+ word-state constants), cloze practice + feedback, vocab, journal, library/collections, import modals, setup, stats (cards + activity heatmap + charts retinted), **all** settings panels, chat widget, theme toggle, language selector. Hardcoded `zinc/blue/green/red/amber` → tokens throughout: success→sage, error→destructive, warning→gold, accent→clay.

## Out of scope (deferred — features, not skinning)
Per #147 §1/§4.6/§4.7, the gamified **additions** are intentionally not in this PR: streak / known-words chips in the nav, the daily-goal ring, and the always-on HUD top bar (all need API wiring). The drawer's 3-way state simplification was also deferred — all 7 word states are kept, just restyled.

## Test plan
- [ ] Toggle light/dark on every page — palette flips cleanly, no zinc/white leaks or undefined-token flash
- [ ] Reader word-state chips use the warm ramp; `known` is plain text, `ignored` dimmed; selected word reads correctly; long passages wrap OK
- [ ] Buttons show the 3D lip; press-translate respects `prefers-reduced-motion`
- [ ] Translation drawer: all 7 states settable; Add-to-Anki + listen work
- [ ] Cloze practice restyled; correct/incorrect states read right; SRS scoring unchanged
- [ ] Settings panels, import modals, vocab / journal / stats render correctly in both modes
- [ ] `npm test`, e2e (CI), `tsc`, `eslint` green

Verified locally: `tsc` clean; light + dark confirmed on vocab & stats.

Part of #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
