### PR TITLE
feat(stats): Anki review stats — heatmap/streak fold-in, reviews chart, activity tooltip

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -115,6 +115,7 @@ function getDb(): Database {
       clozePracticed INTEGER DEFAULT 0,
       points INTEGER DEFAULT 0,
       dictionaryLookups INTEGER DEFAULT 0,
+      ankiReviews INTEGER DEFAULT 0,
       sessionStartedAt TEXT
     );
 
@@ -180,6 +181,14 @@ function getDb(): Database {
   migrateVocabForeignKey(_db);
   migrateBooks(_db);
   migrateAddLanguageColumn(_db);
+
+  // dailyStats.ankiReviews — Anki reviews/day synced from AnkiConnect, counted
+  // toward the activity heatmap + streak. Added after the language migration
+  // (which recreates dailyStats) so the column survives the table rebuild.
+  const dailyCols = _db.prepare('PRAGMA table_info(dailyStats)').all() as { name: string }[];
+  if (!dailyCols.some((c) => c.name === 'ankiReviews')) {
+    _db.exec('ALTER TABLE dailyStats ADD COLUMN ankiReviews INTEGER DEFAULT 0');
+  }
 
   return _db;
 }
@@ -507,6 +516,7 @@ export interface DailyStatsRow {
   clozePracticed: number;
   points: number;
   dictionaryLookups: number;
+  ankiReviews: number;
   sessionStartedAt: string | null;
 }
 

--- a/api/src/lib/streak.ts
+++ b/api/src/lib/streak.ts
@@ -1,6 +1,7 @@
 // Mirror of src/lib/streak.ts for the Bun API — keep in sync.
 // Single source of truth for streak math (issue #108): a day counts toward
-// the streak when any study activity happened (lookup, practice, or reading).
+// the streak when any study activity happened (lookup, practice, reading, or
+// an Anki review synced into dailyStats.ankiReviews).
 
 import { addDaysToDateString } from './dates';
 
@@ -9,13 +10,15 @@ export interface DailyActivityRow {
   dictionaryLookups?: number | null;
   clozePracticed?: number | null;
   minutesRead?: number | null;
+  ankiReviews?: number | null;
 }
 
 export function isActiveDay(row: DailyActivityRow): boolean {
   return (
     (row.dictionaryLookups ?? 0) > 0 ||
     (row.clozePracticed ?? 0) > 0 ||
-    (row.minutesRead ?? 0) > 0
+    (row.minutesRead ?? 0) > 0 ||
+    (row.ankiReviews ?? 0) > 0
   );
 }
 

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -64,7 +64,7 @@ app.put('/today', async (c) => {
   const field = body.field as string;
   const amount = body.amount ?? 1;
 
-  const allowedFields = ['wordsRead', 'newWordsSaved', 'wordsMarkedKnown', 'minutesRead', 'clozePracticed', 'points', 'dictionaryLookups'];
+  const allowedFields = ['wordsRead', 'newWordsSaved', 'wordsMarkedKnown', 'minutesRead', 'clozePracticed', 'points', 'dictionaryLookups', 'ankiReviews'];
   if (!allowedFields.includes(field)) {
     return c.json({ error: 'Invalid field' }, 400);
   }
@@ -160,15 +160,18 @@ app.get('/fluency', (c) => {
 
 // GET /api/stats/streak
 // Unified streak definition (issue #108): a day is active when it has any
-// study activity (lookups, practice, or reading time), with day rollover in
-// the configured time zone. Keep in sync with src/app/api/stats/streak.
+// study activity (lookups, practice, reading time, or Anki reviews), with day
+// rollover in the configured time zone. Keep in sync with src/app/api/stats/streak.
 app.get('/streak', (c) => {
   const lang = resolveLanguage(c.req.query('language'));
   const today = getTodayDate();
 
   const rows = db.prepare(
-    'SELECT date, dictionaryLookups, clozePracticed, minutesRead FROM dailyStats WHERE language = ?'
-  ).all(lang) as Pick<DailyStatsRow, 'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead'>[];
+    'SELECT date, dictionaryLookups, clozePracticed, minutesRead, ankiReviews FROM dailyStats WHERE language = ?'
+  ).all(lang) as Pick<
+    DailyStatsRow,
+    'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead' | 'ankiReviews'
+  >[];
 
   const { current, longest, activeToday } = computeStreaks(activeDateSet(rows), today);
 

--- a/e2e/anki-stats.spec.ts
+++ b/e2e/anki-stats.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+// Anki integration on the stats page: the dedicated "Anki Reviews" card (with a
+// blurred Connect-your-Anki preview when no reviews are synced) plus the
+// fold-in of Anki review-days into the activity heatmap.
+//
+// These tests run with no AnkiConnect available (the CI case). When a real Anki
+// IS reachable (local dev), the stats-page sync would write/overwrite
+// dailyStats.ankiReviews, so the data-dependent assertions skip themselves.
+test.describe("Anki stats", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+  });
+
+  test("shows the Connect-your-Anki preview when no reviews are synced", async ({
+    page,
+  }) => {
+    const sync = await page.request.post("/api/anki/sync-reviews");
+    const syncBody = await sync.json();
+    test.skip(syncBody.connected === true, "live Anki would populate review data");
+
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    const card = page.locator('[data-testid="anki-reviews-card"]');
+    await expect(card).toBeVisible({ timeout: 10000 });
+
+    // Blurred placeholder + call-to-action, not the real chart.
+    await expect(page.locator('[data-testid="anki-reviews-preview"]')).toBeVisible();
+    await expect(page.locator('[data-testid="anki-reviews-chart"]')).toHaveCount(0);
+    await expect(
+      page.getByText("Connect your Anki to see your review history"),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Connect Anki" })).toHaveAttribute(
+      "href",
+      "/settings",
+    );
+  });
+
+  test("shows the review chart and counts Anki toward the heatmap once synced", async ({
+    page,
+  }) => {
+    const sync = await page.request.post("/api/anki/sync-reviews");
+    const syncBody = await sync.json();
+    test.skip(syncBody.connected === true, "live Anki would overwrite the seeded count");
+
+    await page.goto("/stats");
+    await page.waitForLoadState("networkidle");
+
+    // Activity heatmap total before seeding — Anki reviews fold into it.
+    const total = page.locator('[data-testid="activity-heatmap-total"]');
+    const initialText = (await total.textContent()) ?? "";
+    const initialCount = parseInt(initialText.replace(/[^\d]/g, ""), 10) || 0;
+
+    // Seed today's Anki reviews the same way the other activity tests seed —
+    // dailyStats.ankiReviews is in the today-incrementer's allow-list.
+    const bump = 5;
+    for (let i = 0; i < bump; i++) {
+      const res = await page.request.put("/api/stats/today", {
+        data: { field: "ankiReviews", amount: 1 },
+      });
+      expect(res.ok()).toBeTruthy();
+    }
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    // The card flips from preview to the real chart...
+    await expect(page.locator('[data-testid="anki-reviews-chart"]')).toBeVisible();
+    await expect(page.locator('[data-testid="anki-reviews-preview"]')).toHaveCount(0);
+
+    // ...and the reviews count toward the activity heatmap (fold-in).
+    const updatedText = (await total.textContent()) ?? "";
+    const updatedCount = parseInt(updatedText.replace(/[^\d]/g, ""), 10) || 0;
+    expect(updatedCount).toBe(initialCount + bump);
+  });
+
+  test("sync-reviews endpoint degrades gracefully (never errors the page)", async ({
+    page,
+  }) => {
+    // The stats page calls this on every load. Whether or not Anki is running it
+    // must return 200 with a well-formed body — a 500 here would break stats.
+    const res = await page.request.post("/api/anki/sync-reviews");
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(typeof body.connected).toBe("boolean");
+    expect(typeof body.synced).toBe("number");
+    // When Anki is unreachable (the CI case) nothing is written.
+    if (body.connected === false) {
+      expect(body.synced).toBe(0);
+    }
+  });
+});

--- a/src/app/api/anki/sync-reviews/route.ts
+++ b/src/app/api/anki/sync-reviews/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/server/database';
+import { getActiveLanguageCode } from '@/lib/server/active-language';
+import { getTodayDate } from '@/lib/server/dates';
+
+const DEFAULT_ANKI_CONNECT_URL = 'http://localhost:8765';
+// Guard against a hung AnkiConnect. A *closed* port (Anki not running) refuses
+// the connection instantly, so this only bites the rare reachable-but-stuck case.
+const ANKI_TIMEOUT_MS = 2500;
+
+/**
+ * Resolve the AnkiConnect URL the same way the browser client (src/lib/anki.ts)
+ * does: the `ankiConnectUrl` setting wins (lets a user point at a remote Anki,
+ * e.g. over Tailscale), then the env var, then localhost. Settings values are
+ * stored JSON-encoded, so strip surrounding quotes.
+ */
+function getAnkiConnectUrl(): string {
+  try {
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('ankiConnectUrl') as
+      | { value: string }
+      | undefined;
+    const raw = row?.value?.replace(/^"|"$/g, '').trim();
+    if (raw) return raw;
+  } catch {
+    // fall through to env / default
+  }
+  return process.env.ANKI_CONNECT_URL || DEFAULT_ANKI_CONNECT_URL;
+}
+
+async function ankiRequest<T>(
+  url: string,
+  action: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, version: 6, params }),
+    signal: AbortSignal.timeout(ANKI_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`AnkiConnect HTTP ${res.status}`);
+  const data = (await res.json()) as { result: T; error: string | null };
+  if (data.error) throw new Error(data.error);
+  return data.result;
+}
+
+// POST /api/anki/sync-reviews
+//
+// Pull Anki's per-day review counts (getNumCardsReviewedByDay) and persist them
+// into dailyStats.ankiReviews, so the activity heatmap and streak count Anki
+// study days — even when Anki isn't running later.
+//
+// Best-effort by design: if AnkiConnect is unreachable we return
+// { connected: false } and leave the previously-synced data untouched. That
+// keeps the streak deterministic (it never silently drops Anki days just
+// because the desktop app happens to be closed when the page loads).
+export async function POST() {
+  const url = getAnkiConnectUrl();
+
+  let byDay: Array<[string, number]>;
+  try {
+    byDay = await ankiRequest<Array<[string, number]>>(url, 'getNumCardsReviewedByDay');
+  } catch (err) {
+    return NextResponse.json({
+      connected: false,
+      synced: 0,
+      error: err instanceof Error ? err.message : 'Could not reach AnkiConnect',
+    });
+  }
+
+  const language = getActiveLanguageCode();
+
+  // Upsert each day's review count, touching ONLY ankiReviews so the day's
+  // other counters (lookups, cloze, reading) are preserved. getNumCardsReviewedByDay
+  // returns [date, count] pairs for days with reviews only — days with none are
+  // left absent (correctly not Anki-active).
+  const upsert = db.prepare(
+    `INSERT INTO dailyStats (date, language, ankiReviews) VALUES (?, ?, ?)
+     ON CONFLICT(date, language) DO UPDATE SET ankiReviews = excluded.ankiReviews`,
+  );
+  const writeAll = db.transaction((rows: Array<[string, number]>) => {
+    for (const [date, count] of rows) {
+      if (typeof date === 'string' && Number.isFinite(count)) {
+        upsert.run(date, language, Math.trunc(count));
+      }
+    }
+  });
+  writeAll(byDay);
+
+  const reviewsToday = byDay.find(([d]) => d === getTodayDate())?.[1] ?? 0;
+
+  return NextResponse.json({ connected: true, synced: byDay.length, reviewsToday });
+}

--- a/src/app/api/stats/streak/route.ts
+++ b/src/app/api/stats/streak/route.ts
@@ -6,15 +6,19 @@ import { activeDateSet, computeStreaks } from '@/lib/streak';
 // GET /api/stats/streak - Current and longest study streak.
 //
 // One streak definition for the whole app (issue #108): a day is active when
-// it has any study activity (dictionary lookups, cloze practice, or reading
-// time), with day rollover in the configured time zone. The home page and
-// stats page both render from this endpoint instead of computing their own.
+// it has any study activity (dictionary lookups, cloze practice, reading time,
+// or Anki reviews), with day rollover in the configured time zone. The home
+// page and stats page both render from this endpoint instead of computing
+// their own.
 export async function GET() {
   const today = getTodayDate();
 
   const rows = db.prepare(
-    'SELECT date, dictionaryLookups, clozePracticed, minutesRead FROM dailyStats'
-  ).all() as Pick<DailyStatsRow, 'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead'>[];
+    'SELECT date, dictionaryLookups, clozePracticed, minutesRead, ankiReviews FROM dailyStats'
+  ).all() as Pick<
+    DailyStatsRow,
+    'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead' | 'ankiReviews'
+  >[];
 
   const { current, longest, activeToday } = computeStreaks(activeDateSet(rows), today);
 

--- a/src/app/api/stats/today/route.ts
+++ b/src/app/api/stats/today/route.ts
@@ -34,7 +34,7 @@ export async function PUT(request: NextRequest) {
   const field = body.field as string;
   const amount = body.amount ?? 1;
 
-  const allowedFields = ['wordsRead', 'newWordsSaved', 'wordsMarkedKnown', 'minutesRead', 'clozePracticed', 'points', 'dictionaryLookups'];
+  const allowedFields = ['wordsRead', 'newWordsSaved', 'wordsMarkedKnown', 'minutesRead', 'clozePracticed', 'points', 'dictionaryLookups', 'ankiReviews'];
   if (!allowedFields.includes(field)) {
     return NextResponse.json({ error: 'Invalid field' }, { status: 400 });
   }

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -11,10 +11,12 @@ import {
   getReadingStats,
   getStreak,
   getSetting,
+  syncAnkiReviews,
 } from '@/lib/data-layer';
 import { dateStringInTimeZone, isValidTimeZone } from '@/lib/dates';
 import { compositeActivityCount, sliceSeriesByDays } from '@/lib/stats-derive';
 import ActivityHeatmap from '@/components/ActivityHeatmap';
+import AnkiReviewsChart from '@/components/AnkiReviewsChart';
 import PageHeader from '@/components/PageHeader';
 import VocabGrowthChart from '@/components/VocabGrowthChart';
 import {
@@ -37,6 +39,11 @@ export default function StatsPage() {
   useEffect(() => {
     async function loadStats() {
       try {
+        // Best-effort: pull Anki's review history into dailyStats first, so the
+        // streak and activity heatmap below include today's Anki study. No-ops
+        // when Anki isn't running (see /api/anki/sync-reviews).
+        await syncAnkiReviews().catch(() => {});
+
         const [collectionCounts, fluency, reading, streakData, tzSetting] = await Promise.all([
           getCollectionCounts(),
           getFluencyStats(),
@@ -76,6 +83,13 @@ export default function StatsPage() {
         const activityData = last365.map((d) => ({
           date: d.date,
           count: compositeActivityCount(d),
+          // Per-type breakdown so the heatmap tooltip can show what made up the day.
+          parts: {
+            dictionaryLookups: d.dictionaryLookups || 0,
+            clozePracticed: d.clozePracticed || 0,
+            minutesRead: d.minutesRead || 0,
+            ankiReviews: d.ankiReviews || 0,
+          },
         }));
 
         // Build vocab growth data (cumulative over all history)
@@ -110,6 +124,16 @@ export default function StatsPage() {
           lastEntry.total = fluency.totalKnownWords + fluency.totalLearning + fluency.totalNew;
         }
 
+        // Anki reviews/day: chart the last 90 days, but decide the
+        // connected-vs-preview state from full history so a previously-synced
+        // user keeps their chart even after a quiet spell.
+        const ankiHasData = sortedDailyStats.some((d) => (d.ankiReviews ?? 0) > 0);
+        const ankiReviews = sliceSeriesByDays(
+          sortedDailyStats.map((d) => ({ date: d.date, reviews: d.ankiReviews ?? 0 })),
+          90,
+          endDate,
+        );
+
         setStats({
           totalKnown: fluency.totalKnownWords,
           totalLearning: fluency.totalLearning,
@@ -123,6 +147,8 @@ export default function StatsPage() {
           dailyStats,
           vocabGrowth,
           activityData,
+          ankiReviews,
+          ankiHasData,
           collectionCounts,
           fluency,
           endDate,
@@ -220,6 +246,11 @@ export default function StatsPage() {
       {/* Activity Heatmap */}
       <div className="mb-8">
         <ActivityHeatmap data={stats.activityData} unit="actions" />
+      </div>
+
+      {/* Anki Reviews */}
+      <div className="mb-8">
+        <AnkiReviewsChart data={stats.ankiReviews} hasData={stats.ankiHasData} />
       </div>
 
       {/* Detailed breakdowns */}

--- a/src/app/stats/types.ts
+++ b/src/app/stats/types.ts
@@ -15,6 +15,11 @@ export interface StatsData {
   // Full-history cumulative series; the page windows it for display via the range selector.
   vocabGrowth: Array<{ date: string; known: number; learning: number; total: number }>;
   activityData: Array<{ date: string; count: number }>;
+  // Anki reviews/day for the chart (last 90 days). `ankiHasData` is computed from
+  // full history so a previously-connected user keeps their chart after a quiet
+  // spell; when false the chart shows the "Connect your Anki" preview.
+  ankiReviews: Array<{ date: string; reviews: number }>;
+  ankiHasData: boolean;
   collectionCounts: Record<ClozeCollection, { total: number; due: number; mastered: number }>;
   fluency: FluencyStats;
   // Today's date in the user's time zone — the anchor for windowing the series.

--- a/src/components/ActivityHeatmap/index.tsx
+++ b/src/components/ActivityHeatmap/index.tsx
@@ -1,11 +1,97 @@
 'use client';
 
-import { useMemo, } from 'react';
+import { useMemo } from 'react';
 import { useIsDark } from '@/utils/hooks';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DAYS_OF_WEEK, MONTHS } from './constants';
 import { darkColorScheme, lightColorScheme } from './theme';
-import { type ActivityHeatmapProps } from './types'
+import { type ActivityHeatmapProps, type ActivityParts } from './types';
 import { formatDate, getColor } from './utils';
+
+// The activities that fold into a day's composite count, in display order. Each
+// gets a colour dot in the tooltip; `suffix` distinguishes reading (minutes).
+const ACTIVITY_TYPES: {
+  key: keyof ActivityParts;
+  label: string;
+  color: string;
+  suffix?: string;
+}[] = [
+  { key: 'dictionaryLookups', label: 'Lookups', color: '#10b981' },
+  { key: 'clozePracticed', label: 'Cloze', color: '#a855f7' },
+  { key: 'minutesRead', label: 'Reading', color: '#f59e0b', suffix: ' min' },
+  { key: 'ankiReviews', label: 'Anki', color: '#3b82f6' },
+];
+
+// "Sat, 14 Jun 2026" — parse the parts so there's no UTC day-shift.
+function formatFullDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+interface HeatmapCell {
+  date: string;
+  count: number;
+  dayOfWeek: number;
+  parts?: ActivityParts;
+}
+
+function DayCell({ day, unit, color }: { day: HeatmapCell; unit: string; color: string }) {
+  const rows = day.parts
+    ? ACTIVITY_TYPES.map((t) => ({ ...t, value: day.parts![t.key] })).filter((r) => r.value > 0)
+    : [];
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div
+            data-testid="heatmap-cell"
+            className="h-[12px] w-[12px] rounded-sm transition-colors hover:ring-1 hover:ring-black/20 dark:hover:ring-white/30"
+            style={{ backgroundColor: color }}
+          />
+        }
+      />
+      <TooltipContent
+        sideOffset={6}
+        className="min-w-[172px] flex-col items-stretch gap-1.5 px-3 py-2"
+      >
+        <div className="font-medium">{formatFullDate(day.date)}</div>
+        {day.parts ? (
+          rows.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              {rows.map((r) => (
+                <div key={r.key} className="flex items-center justify-between gap-4">
+                  <span className="flex items-center gap-1.5">
+                    <span
+                      className="size-2 rounded-full"
+                      style={{ backgroundColor: r.color }}
+                    />
+                    <span className="text-background/75">{r.label}</span>
+                  </span>
+                  <span className="font-medium tabular-nums">
+                    {r.value.toLocaleString()}
+                    {r.suffix ?? ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-background/70">No activity</div>
+          )
+        ) : (
+          <div className="text-background/75">
+            {day.count.toLocaleString()} {unit}
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function ActivityHeatmap({
   data,
@@ -15,11 +101,11 @@ export default function ActivityHeatmap({
   const isDark = useIsDark();
   const colorScheme = colorSchemeProp || (isDark ? darkColorScheme : lightColorScheme);
   const { weeks, maxCount, monthLabels, totalActivity, activeDays } = useMemo(() => {
-    // Create a map of date -> count
-    const activityMap = new Map(data.map(d => [d.date, d.count]));
+    // date -> the full day record, so each cell can show its breakdown.
+    const activityMap = new Map(data.map((d) => [d.date, d]));
 
     // Calculate max count for color scaling
-    const maxCount = Math.max(1, ...data.map(d => d.count));
+    const maxCount = Math.max(1, ...data.map((d) => d.count));
 
     // Generate 365 days ending today
     const today = new Date();
@@ -30,8 +116,8 @@ export default function ActivityHeatmap({
     const startDayOfWeek = startDate.getDay();
     startDate.setDate(startDate.getDate() - startDayOfWeek);
 
-    const weeks: Array<Array<{ date: string; count: number; dayOfWeek: number }>> = [];
-    let currentWeek: Array<{ date: string; count: number; dayOfWeek: number }> = [];
+    const weeks: HeatmapCell[][] = [];
+    let currentWeek: HeatmapCell[] = [];
 
     const monthLabels: Array<{ label: string; weekIndex: number }> = [];
     let lastMonth = -1;
@@ -41,7 +127,8 @@ export default function ActivityHeatmap({
 
     while (currentDate <= today) {
       const dateStr = formatDate(currentDate);
-      const count = activityMap.get(dateStr) || 0;
+      const day = activityMap.get(dateStr);
+      const count = day?.count || 0;
       const month = currentDate.getMonth();
       const dayOfWeek = currentDate.getDay();
 
@@ -51,7 +138,7 @@ export default function ActivityHeatmap({
         lastMonth = month;
       }
 
-      currentWeek.push({ date: dateStr, count, dayOfWeek });
+      currentWeek.push({ date: dateStr, count, dayOfWeek, parts: day?.parts });
 
       if (currentWeek.length === 7) {
         weeks.push(currentWeek);
@@ -69,114 +156,123 @@ export default function ActivityHeatmap({
 
     // Calculate totals
     const totalActivity = data.reduce((sum, d) => sum + d.count, 0);
-    const activeDays = data.filter(d => d.count > 0).length;
+    const activeDays = data.filter((d) => d.count > 0).length;
 
     return { weeks, maxCount, monthLabels, totalActivity, activeDays };
   }, [data]);
 
   return (
-    <div data-testid="activity-heatmap" className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Activity</h3>
-        <div data-testid="activity-heatmap-total" className="text-sm text-zinc-500 dark:text-slate-400">
-          {totalActivity.toLocaleString()} {unit} in the last year
-        </div>
-      </div>
-
-      {/* Month labels */}
-      <div className="flex ml-8 mb-1">
-        {monthLabels.map((month, i) => (
+    <TooltipProvider delay={120} closeDelay={0}>
+      <div
+        data-testid="activity-heatmap"
+        className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-6"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Activity</h3>
           <div
-            key={i}
-            className="text-xs text-zinc-400 dark:text-slate-500"
-            style={{
-              position: 'relative',
-              left: `${month.weekIndex * 14}px`,
-              marginRight: '-8px'
-            }}
+            data-testid="activity-heatmap-total"
+            className="text-sm text-zinc-500 dark:text-slate-400"
           >
-            {month.label}
+            {totalActivity.toLocaleString()} {unit} in the last year
           </div>
-        ))}
-      </div>
+        </div>
 
-      {/* Heatmap grid */}
-      <div className="flex">
-        {/* Day of week labels */}
-        <div className="flex flex-col mr-2 text-xs text-zinc-400 dark:text-slate-500">
-          {DAYS_OF_WEEK.map((day, i) => (
+        {/* Month labels */}
+        <div className="flex ml-8 mb-1">
+          {monthLabels.map((month, i) => (
             <div
-              key={day}
-              className="h-[12px] flex items-center"
-              style={{ visibility: i % 2 === 1 ? 'visible' : 'hidden' }}
+              key={i}
+              className="text-xs text-zinc-400 dark:text-slate-500"
+              style={{
+                position: 'relative',
+                left: `${month.weekIndex * 14}px`,
+                marginRight: '-8px',
+              }}
             >
-              {day}
+              {month.label}
             </div>
           ))}
         </div>
 
-        {/* Weeks */}
-        <div className="flex gap-[2px]">
-          {weeks.map((week, weekIdx) => (
-            <div key={weekIdx} className="flex flex-col gap-[2px]">
-              {week.map((day) => (
-                <div
-                  key={day.date}
-                  className="w-[12px] h-[12px] rounded-sm transition-colors hover:ring-1 hover:ring-black/20 dark:hover:ring-white/30"
-                  style={{ backgroundColor: getColor(day.count, maxCount, colorScheme) }}
-                  title={`${day.date}: ${day.count} ${unit}`}
-                />
-              ))}
-              {/* Fill empty days for incomplete weeks */}
-              {week.length < 7 && Array(7 - week.length).fill(null).map((_, i) => (
-                <div key={`empty-${i}`} className="w-[12px] h-[12px]" />
-              ))}
-            </div>
-          ))}
-        </div>
-      </div>
+        {/* Heatmap grid */}
+        <div className="flex">
+          {/* Day of week labels */}
+          <div className="flex flex-col mr-2 text-xs text-zinc-400 dark:text-slate-500">
+            {DAYS_OF_WEEK.map((day, i) => (
+              <div
+                key={day}
+                className="h-[12px] flex items-center"
+                style={{ visibility: i % 2 === 1 ? 'visible' : 'hidden' }}
+              >
+                {day}
+              </div>
+            ))}
+          </div>
 
-      {/* Legend */}
-      <div className="flex items-center justify-end mt-4 gap-2 text-xs text-zinc-400 dark:text-slate-500">
-        <span>Less</span>
-        <div className="flex gap-[2px]">
-          <div
-            className="w-[12px] h-[12px] rounded-sm"
-            style={{ backgroundColor: colorScheme.empty }}
-          />
-          <div
-            className="w-[12px] h-[12px] rounded-sm"
-            style={{ backgroundColor: colorScheme.level1 }}
-          />
-          <div
-            className="w-[12px] h-[12px] rounded-sm"
-            style={{ backgroundColor: colorScheme.level2 }}
-          />
-          <div
-            className="w-[12px] h-[12px] rounded-sm"
-            style={{ backgroundColor: colorScheme.level3 }}
-          />
-          <div
-            className="w-[12px] h-[12px] rounded-sm"
-            style={{ backgroundColor: colorScheme.level4 }}
-          />
+          {/* Weeks */}
+          <div className="flex gap-[2px]">
+            {weeks.map((week, weekIdx) => (
+              <div key={weekIdx} className="flex flex-col gap-[2px]">
+                {week.map((day) => (
+                  <DayCell
+                    key={day.date}
+                    day={day}
+                    unit={unit}
+                    color={getColor(day.count, maxCount, colorScheme)}
+                  />
+                ))}
+                {/* Fill empty days for incomplete weeks */}
+                {week.length < 7 &&
+                  Array(7 - week.length)
+                    .fill(null)
+                    .map((_, i) => <div key={`empty-${i}`} className="w-[12px] h-[12px]" />)}
+              </div>
+            ))}
+          </div>
         </div>
-        <span>More</span>
-      </div>
 
-      {/* Stats row */}
-      <div className="flex gap-6 mt-4 pt-4 border-t border-zinc-200 dark:border-slate-800">
-        <div className="text-sm">
-          <span className="text-zinc-500 dark:text-slate-400">Active days: </span>
-          <span className="text-zinc-900 dark:text-white font-medium">{activeDays}</span>
+        {/* Legend */}
+        <div className="flex items-center justify-end mt-4 gap-2 text-xs text-zinc-400 dark:text-slate-500">
+          <span>Less</span>
+          <div className="flex gap-[2px]">
+            <div
+              className="w-[12px] h-[12px] rounded-sm"
+              style={{ backgroundColor: colorScheme.empty }}
+            />
+            <div
+              className="w-[12px] h-[12px] rounded-sm"
+              style={{ backgroundColor: colorScheme.level1 }}
+            />
+            <div
+              className="w-[12px] h-[12px] rounded-sm"
+              style={{ backgroundColor: colorScheme.level2 }}
+            />
+            <div
+              className="w-[12px] h-[12px] rounded-sm"
+              style={{ backgroundColor: colorScheme.level3 }}
+            />
+            <div
+              className="w-[12px] h-[12px] rounded-sm"
+              style={{ backgroundColor: colorScheme.level4 }}
+            />
+          </div>
+          <span>More</span>
         </div>
-        <div className="text-sm">
-          <span className="text-zinc-500 dark:text-slate-400">Avg per active day: </span>
-          <span className="text-zinc-900 dark:text-white font-medium">
-            {activeDays > 0 ? Math.round(totalActivity / activeDays).toLocaleString() : 0}
-          </span>
+
+        {/* Stats row */}
+        <div className="flex gap-6 mt-4 pt-4 border-t border-zinc-200 dark:border-slate-800">
+          <div className="text-sm">
+            <span className="text-zinc-500 dark:text-slate-400">Active days: </span>
+            <span className="text-zinc-900 dark:text-white font-medium">{activeDays}</span>
+          </div>
+          <div className="text-sm">
+            <span className="text-zinc-500 dark:text-slate-400">Avg per active day: </span>
+            <span className="text-zinc-900 dark:text-white font-medium">
+              {activeDays > 0 ? Math.round(totalActivity / activeDays).toLocaleString() : 0}
+            </span>
+          </div>
         </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/ActivityHeatmap/types.ts
+++ b/src/components/ActivityHeatmap/types.ts
@@ -1,7 +1,17 @@
 
+export interface ActivityParts {
+  dictionaryLookups: number;
+  clozePracticed: number;
+  minutesRead: number;
+  ankiReviews: number;
+}
+
 export interface ActivityDay {
   date: string; // YYYY-MM-DD
   count: number;
+  // Per-activity breakdown for the hover tooltip. Optional so callers that only
+  // have a composite count still type-check; the sum should equal `count`.
+  parts?: ActivityParts;
 }
 
 export interface ActivityHeatmapProps {

--- a/src/components/AnkiReviewsChart/index.tsx
+++ b/src/components/AnkiReviewsChart/index.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import Link from 'next/link';
+import { Sparkles } from 'lucide-react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { useIsDark } from '@/utils/hooks';
+import { buttonVariants } from '@/components/ui/button';
+import { darkChartTheme, lightChartTheme } from '@/components/VocabGrowthChart/theme';
+import { formatDisplayDate } from '@/components/VocabGrowthChart/utils';
+
+export interface AnkiReviewPoint {
+  date: string;
+  reviews: number;
+}
+
+// blue-500 — matches the app's primary accent used elsewhere on the stats page.
+const ANKI_COLOR = '#3b82f6';
+
+// Distinct sequential dates across ~3 months (31 + 28 + 31 = 90) so the blurred
+// preview chart spans the full width like the real one.
+function previewDate(i: number): string {
+  const months: [string, number][] = [
+    ['01', 31],
+    ['02', 28],
+    ['03', 31],
+  ];
+  let day = i;
+  for (const [m, len] of months) {
+    if (day < len) return `2026-${m}-${String(day + 1).padStart(2, '0')}`;
+    day -= len;
+  }
+  return '2026-03-31';
+}
+
+// Deterministic sample curve for the disconnected preview (no Math.random — it
+// must be stable across renders so the blurred placeholder reads as a real
+// "this is what your review history will look like" teaser).
+const PREVIEW_DATA: AnkiReviewPoint[] = Array.from({ length: 90 }, (_, i) => ({
+  date: previewDate(i),
+  reviews: Math.round(28 + 32 * Math.abs(Math.sin(i / 4)) + (i % 6) * 5),
+}));
+
+function ReviewsAreaChart({ data, height = 240 }: { data: AnkiReviewPoint[]; height?: number }) {
+  const isDark = useIsDark();
+  const theme = isDark ? darkChartTheme : lightChartTheme;
+  const formatted = data.map((d) => ({ ...d, displayDate: formatDisplayDate(d.date) }));
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart data={formatted} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id="ankiReviewsGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor={ANKI_COLOR} stopOpacity={0.35} />
+            <stop offset="95%" stopColor={ANKI_COLOR} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} vertical={false} />
+        <XAxis
+          dataKey="displayDate"
+          stroke={theme.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={{ stroke: theme.grid }}
+          minTickGap={24}
+        />
+        <YAxis
+          stroke={theme.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={{ stroke: theme.grid }}
+          allowDecimals={false}
+        />
+        <Tooltip
+          cursor={{ stroke: theme.grid }}
+          contentStyle={{
+            borderRadius: 8,
+            border: `1px solid ${theme.grid}`,
+            background: isDark ? '#18181b' : '#ffffff',
+            color: isDark ? '#fafafa' : '#18181b',
+            fontSize: 12,
+          }}
+          formatter={(value: number | undefined) =>
+            [(value ?? 0).toLocaleString(), 'Reviews'] as [string, string]
+          }
+        />
+        <Area
+          type="monotone"
+          dataKey="reviews"
+          stroke={ANKI_COLOR}
+          strokeWidth={2}
+          fill="url(#ankiReviewsGradient)"
+          dot={false}
+          activeDot={{ r: 4, fill: ANKI_COLOR }}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+function Stat({ value, label, className }: { value: number; label: string; className: string }) {
+  return (
+    <div className="text-center">
+      <div className={`text-2xl font-bold ${className}`}>{value.toLocaleString()}</div>
+      <div className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{label}</div>
+    </div>
+  );
+}
+
+/**
+ * Anki review-history chart. Two states:
+ *  - hasData: the real reviews/day area chart + summary, from synced
+ *    dailyStats.ankiReviews (works offline — it renders the last sync).
+ *  - !hasData (never connected): the same chart blurred behind a "Connect your
+ *    Anki" call-to-action, so the user previews exactly what they'll unlock.
+ *
+ * `hasData` is decided by the caller from full history (not the visible window),
+ * so a user who has connected before keeps their chart even after a quiet spell.
+ */
+export default function AnkiReviewsChart({
+  data,
+  hasData,
+}: {
+  data: AnkiReviewPoint[];
+  hasData: boolean;
+}) {
+  const total = data.reduce((sum, d) => sum + d.reviews, 0);
+  const reviewDays = data.filter((d) => d.reviews > 0).length;
+  const perDay = reviewDays > 0 ? Math.round(total / reviewDays) : 0;
+
+  return (
+    <div
+      data-testid="anki-reviews-card"
+      className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">Anki Reviews</h3>
+        {hasData && (
+          <span className="text-sm text-zinc-500 dark:text-zinc-400">Last 90 days</span>
+        )}
+      </div>
+
+      {hasData ? (
+        <div data-testid="anki-reviews-chart">
+          <ReviewsAreaChart data={data} />
+          <div className="mt-4 grid grid-cols-3 gap-4 border-t border-zinc-200 pt-4 dark:border-zinc-800">
+            <Stat value={total} label="Reviews" className="text-blue-500" />
+            <Stat value={reviewDays} label="Review days" className="text-emerald-500" />
+            <Stat value={perDay} label="Avg / review day" className="text-purple-500" />
+          </div>
+        </div>
+      ) : (
+        <div data-testid="anki-reviews-preview" className="relative">
+          {/* Blurred preview of the real chart — shows what connecting unlocks. */}
+          <div aria-hidden className="pointer-events-none select-none blur-[3px] opacity-50">
+            <ReviewsAreaChart data={PREVIEW_DATA} />
+          </div>
+          {/* Connect-your-Anki overlay */}
+          <div className="absolute inset-0 flex items-center justify-center px-4">
+            <div className="max-w-xs rounded-2xl border border-zinc-200/70 bg-white/80 px-6 py-5 text-center shadow-sm backdrop-blur-sm dark:border-zinc-700/60 dark:bg-zinc-900/80">
+              <div className="mb-2 flex justify-center text-blue-500">
+                <Sparkles className="h-6 w-6" />
+              </div>
+              <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                Connect your Anki to see your review history
+              </p>
+              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                Reviews sync automatically and count toward your streak.
+              </p>
+              <Link href="/settings" className={`${buttonVariants({ size: 'sm' })} mt-3`}>
+                Connect Anki
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/lib/__tests__/stats-derive.test.ts
+++ b/src/lib/__tests__/stats-derive.test.ts
@@ -58,19 +58,28 @@ describe('deriveReadingStats', () => {
 });
 
 describe('compositeActivityCount', () => {
-  it('sums the three streak signals', () => {
+  it('sums the activity signals (lookups + cloze + reading + Anki)', () => {
     expect(
-      compositeActivityCount({ dictionaryLookups: 5, clozePracticed: 3, minutesRead: 12 }),
-    ).toBe(20);
+      compositeActivityCount({
+        dictionaryLookups: 5,
+        clozePracticed: 3,
+        minutesRead: 12,
+        ankiReviews: 7,
+      }),
+    ).toBe(27);
   });
 
   it('is non-zero whenever any single signal is present (matches the streak)', () => {
-    expect(compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 4, minutesRead: 0 })).toBe(
-      4,
-    );
-    expect(compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0 })).toBe(
-      0,
-    );
+    expect(
+      compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 4, minutesRead: 0, ankiReviews: 0 }),
+    ).toBe(4);
+    // An Anki-only day still registers on the heatmap, like the streak.
+    expect(
+      compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0, ankiReviews: 6 }),
+    ).toBe(6);
+    expect(
+      compositeActivityCount({ dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0, ankiReviews: 0 }),
+    ).toBe(0);
   });
 
   it('tolerates missing fields', () => {

--- a/src/lib/__tests__/streak.test.ts
+++ b/src/lib/__tests__/streak.test.ts
@@ -62,12 +62,18 @@ describe('isActiveDay', () => {
     expect(isActiveDay({ date: 'd', dictionaryLookups: 1 })).toBe(true);
     expect(isActiveDay({ date: 'd', clozePracticed: 5 })).toBe(true);
     expect(isActiveDay({ date: 'd', minutesRead: 12 })).toBe(true);
+    // An Anki-only day keeps the streak alive (reviews synced from AnkiConnect).
+    expect(isActiveDay({ date: 'd', ankiReviews: 8 })).toBe(true);
   });
 
   it('is false for zero or missing activity', () => {
-    expect(isActiveDay({ date: 'd', dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0 })).toBe(false);
+    expect(
+      isActiveDay({ date: 'd', dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0, ankiReviews: 0 }),
+    ).toBe(false);
     expect(isActiveDay({ date: 'd' })).toBe(false);
-    expect(isActiveDay({ date: 'd', dictionaryLookups: null, minutesRead: null })).toBe(false);
+    expect(isActiveDay({ date: 'd', dictionaryLookups: null, minutesRead: null, ankiReviews: null })).toBe(
+      false,
+    );
   });
 });
 
@@ -79,5 +85,12 @@ describe('activeDateSet', () => {
     ]);
     expect(set.has('2026-06-09')).toBe(true);
     expect(set.has('2026-06-10')).toBe(false);
+  });
+
+  it('includes a day that only had Anki reviews', () => {
+    const set = activeDateSet([
+      { date: '2026-06-09', dictionaryLookups: 0, clozePracticed: 0, minutesRead: 0, ankiReviews: 12 },
+    ]);
+    expect(set.has('2026-06-09')).toBe(true);
   });
 });

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -714,6 +714,19 @@ export async function getRecentStats(days: number = 7): Promise<DailyStats[]> {
   return res.json();
 }
 
+// Best-effort sync of Anki's per-day review counts into dailyStats.ankiReviews,
+// so the activity heatmap + streak reflect Anki study. Returns connected:false
+// (a no-op) when AnkiConnect is unreachable. Safe to call on every stats load —
+// a closed Anki refuses the connection instantly.
+export async function syncAnkiReviews(): Promise<{
+  connected: boolean;
+  synced: number;
+  reviewsToday?: number;
+}> {
+  const res = await fetch('/api/anki/sync-reviews', { method: 'POST' });
+  return res.json();
+}
+
 // ============================================================================
 // Helper Functions - Settings
 // ============================================================================

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -118,6 +118,7 @@ function getDb(): DatabaseType {
       clozePracticed INTEGER DEFAULT 0,
       points INTEGER DEFAULT 0,
       dictionaryLookups INTEGER DEFAULT 0,
+      ankiReviews INTEGER DEFAULT 0,
       sessionStartedAt TEXT
     );
 
@@ -255,6 +256,14 @@ function getDb(): DatabaseType {
 
   // Add language column to tables for multi-language support
   migrateAddLanguageColumn(_db);
+
+  // dailyStats.ankiReviews — Anki reviews/day synced from AnkiConnect, counted
+  // toward the activity heatmap + streak. Added after the language migration
+  // (which recreates dailyStats) so the column survives the table rebuild.
+  const dailyCols = _db.prepare('PRAGMA table_info(dailyStats)').all() as { name: string }[];
+  if (!dailyCols.some((c) => c.name === 'ankiReviews')) {
+    _db.exec('ALTER TABLE dailyStats ADD COLUMN ankiReviews INTEGER DEFAULT 0');
+  }
 
   return _db;
 }
@@ -620,6 +629,7 @@ export interface DailyStatsRow {
   clozePracticed: number;
   points: number;
   dictionaryLookups: number;
+  ankiReviews: number;
   sessionStartedAt: string | null;
 }
 

--- a/src/lib/stats-derive.ts
+++ b/src/lib/stats-derive.ts
@@ -63,14 +63,19 @@ export function deriveReadingStats(rows: LessonReadingRow[]): ReadingStats {
 /**
  * Composite daily study-activity magnitude. Matches the streak's definition of
  * an active day (`isActiveDay` in ./streak: a dictionary lookup, cloze review,
- * or reading minute), so the activity heatmap agrees with the streak. Before
- * this the heatmap counted dictionary lookups only, leaving cloze-only days
- * uncoloured even though they keep a streak alive.
+ * reading minute, or an Anki review), so the activity heatmap agrees with the
+ * streak. Before this the heatmap counted dictionary lookups only, leaving
+ * cloze-only days uncoloured even though they keep a streak alive.
  */
 export function compositeActivityCount(
-  d: Pick<DailyStats, 'dictionaryLookups' | 'clozePracticed' | 'minutesRead'>,
+  d: Pick<DailyStats, 'dictionaryLookups' | 'clozePracticed' | 'minutesRead' | 'ankiReviews'>,
 ): number {
-  return (d.dictionaryLookups || 0) + (d.clozePracticed || 0) + (d.minutesRead || 0);
+  return (
+    (d.dictionaryLookups || 0) +
+    (d.clozePracticed || 0) +
+    (d.minutesRead || 0) +
+    (d.ankiReviews || 0)
+  );
 }
 
 /**

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -2,7 +2,8 @@
 // three conflicting streak definitions). Mirrored in api/src/lib/streak.ts.
 //
 // A day counts toward the streak when any study activity happened: a
-// dictionary lookup, cloze practice, or reading time.
+// dictionary lookup, cloze practice, reading time, or an Anki review (synced
+// from AnkiConnect into dailyStats.ankiReviews).
 
 import { addDaysToDateString } from './dates';
 
@@ -11,13 +12,15 @@ export interface DailyActivityRow {
   dictionaryLookups?: number | null;
   clozePracticed?: number | null;
   minutesRead?: number | null;
+  ankiReviews?: number | null;
 }
 
 export function isActiveDay(row: DailyActivityRow): boolean {
   return (
     (row.dictionaryLookups ?? 0) > 0 ||
     (row.clozePracticed ?? 0) > 0 ||
-    (row.minutesRead ?? 0) > 0
+    (row.minutesRead ?? 0) > 0 ||
+    (row.ankiReviews ?? 0) > 0
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -108,6 +108,9 @@ export interface DailyStats {
   clozePracticed: number;
   points: number;
   dictionaryLookups: number;
+  // Anki reviews done on this day, synced from AnkiConnect
+  // (getNumCardsReviewedByDay). Counts toward the activity heatmap + streak.
+  ankiReviews: number;
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary

Integrates Anki review activity into the stats page, in three parts:

1. **Heatmap + streak fold-in** — Anki reviews now count toward the **streak** and the **activity heatmap**. A new `dailyStats.ankiReviews` column is synced from AnkiConnect, and `isActiveDay` + `compositeActivityCount` include it — so a day you only did Anki still keeps your streak alive and colours the heatmap.
2. **Anki Reviews chart** — a dedicated card showing reviews/day over the last 90 days. When Anki has never been synced it shows a blurred preview of the chart behind a **"Connect your Anki"** call-to-action (links to settings).
3. **Activity tooltip** — replaces the heatmap's bare native `title` with a proper shadcn (Base UI) tooltip that breaks each day down by activity type: lookups / cloze / reading / Anki.

## How it works

- `POST /api/anki/sync-reviews` pulls `getNumCardsReviewedByDay` from AnkiConnect (honouring the `ankiConnectUrl` setting → env → localhost) and upserts per-day counts into `dailyStats.ankiReviews`, touching only that column so other counters are preserved.
- **Best-effort & deterministic**: a closed Anki refuses the connection instantly; the endpoint returns `{ connected: false }` and writes nothing, so the streak never silently changes based on whether Anki happens to be running. The stats page syncs on load.
- The column is added on both the Next (`better-sqlite3`) and Bun (`bun:sqlite`) schemas, via an idempotent `ALTER` placed **after** the language migration that recreates `dailyStats`.

## Test plan

- [x] **Unit** — `streak` + `stats-derive` extended (Anki counts toward active-day + composite). `npm test` green.
- [x] **E2E** — `e2e/anki-stats.spec.ts`: the Connect-your-Anki preview, the chart + heatmap fold-in, and graceful degradation when Anki is unreachable. Runs in CI; locally it self-skips the data-dependent cases when a real Anki is reachable.
- [x] `tsc --noEmit` + ESLint clean on both the Next and Bun sides.
- [x] Verified end-to-end against a live Anki: synced 182 days / ~27k reviews into `dailyStats`; both chart states and the breakdown tooltip render in a browser.

## Notes

- Kept the fold-in *and* added the dedicated chart — they're complementary (the fold-in gives the streak/heatmap integration; the card gives Anki a visible home + the connect prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
