### PR TITLE
feat(practice): shortcut hints, translation toggle, Clozemaster scoring

### DIFF
--- a/e2e/explain.spec.ts
+++ b/e2e/explain.spec.ts
@@ -59,8 +59,8 @@ test.describe('Explain Feature', () => {
       page.getByText('This is a test explanation of the Afrikaans sentence')
     ).toBeVisible({ timeout: 10000 });
 
-    // Button should change to "Explained" state
-    await expect(page.getByText('Explained')).toBeVisible();
+    // Button is disabled once the explanation has been fetched
+    await expect(explainBtn).toBeDisabled();
   });
 
   test.fixme('should handle explain API error gracefully', async ({ page }) => {
@@ -78,7 +78,9 @@ test.describe('Explain Feature', () => {
     const explainBtn = page.getByRole('button', { name: 'Explain' });
     await explainBtn.click();
 
-    // Should show error state on button
-    await expect(page.getByText('Error')).toBeVisible({ timeout: 5000 });
+    // Should surface an error toast
+    await expect(
+      page.getByText('Failed to fetch explanation')
+    ).toBeVisible({ timeout: 5000 });
   });
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,9 @@ export default function RootLayout({
         <ChatWidget />
         {/* Spacer for mobile bottom nav — invisible on sm+ */}
         <div className="h-16 sm:hidden" aria-hidden="true" />
-        <Toaster theme="system" duration={5000} />
+        {/* Move Sonner's focus hotkey off its Alt+T default — Alt+T toggles the
+            translation on the Practice page. */}
+        <Toaster theme="system" duration={5000} hotkey={['altKey', 'KeyN']} />
       </body>
     </html>
   );

--- a/src/app/practice/__tests__/utils.test.ts
+++ b/src/app/practice/__tests__/utils.test.ts
@@ -108,53 +108,63 @@ describe('calculateNextReview', () => {
 });
 
 describe('calculatePoints', () => {
-  it('awards more points at higher mastery (no hints used)', () => {
-    expect(calculatePoints(0, 0, 4)).toBe(10);
-    expect(calculatePoints(25, 0, 4)).toBe(15);
-    expect(calculatePoints(50, 0, 4)).toBe(20);
-    expect(calculatePoints(75, 0, 4)).toBe(25);
-    expect(calculatePoints(100, 0, 4)).toBe(30);
+  it('scales with the mastery reached: base × (mastery ÷ 25)', () => {
+    // Typed answers use base 8.
+    expect(calculatePoints(0, 0, 4, 'type')).toBe(0);
+    expect(calculatePoints(25, 0, 4, 'type')).toBe(8);
+    expect(calculatePoints(50, 0, 4, 'type')).toBe(16);
+    expect(calculatePoints(75, 0, 4, 'type')).toBe(24);
+    expect(calculatePoints(100, 0, 4, 'type')).toBe(32);
   });
 
-  it('deducts points for each letter revealed via hints', () => {
-    // 4-letter word at mastery 100 (base 30): each hint reveals 25% of the word.
-    expect(calculatePoints(100, 0, 4)).toBe(30);
-    expect(calculatePoints(100, 1, 4)).toBe(23); // 30 * 3/4 = 22.5 -> 23
-    expect(calculatePoints(100, 2, 4)).toBe(15); // 30 * 2/4
-    expect(calculatePoints(100, 3, 4)).toBe(8); // 30 * 1/4 = 7.5 -> 8
-    expect(calculatePoints(100, 4, 4)).toBe(0); // whole word revealed
+  it('awards half as much for multiple choice (base 4 vs 8)', () => {
+    expect(calculatePoints(25, 0, 4, 'mc')).toBe(4);
+    expect(calculatePoints(50, 0, 4, 'mc')).toBe(8);
+    expect(calculatePoints(75, 0, 4, 'mc')).toBe(12);
+    expect(calculatePoints(100, 0, 4, 'mc')).toBe(16);
+  });
+
+  it('deducts points for each letter revealed via hints (typed answers)', () => {
+    // 4-letter word at mastery 100 (base 8 × 4 = 32): each hint reveals 25%.
+    expect(calculatePoints(100, 0, 4, 'type')).toBe(32);
+    expect(calculatePoints(100, 1, 4, 'type')).toBe(24); // 32 * 3/4
+    expect(calculatePoints(100, 2, 4, 'type')).toBe(16); // 32 * 2/4
+    expect(calculatePoints(100, 3, 4, 'type')).toBe(8); // 32 * 1/4
+    expect(calculatePoints(100, 4, 4, 'type')).toBe(0); // whole word revealed
   });
 
   it('scales the discount to the fraction revealed, not the absolute hint count', () => {
-    // One hint is worth less on a long word than on a short one.
-    expect(calculatePoints(100, 1, 2)).toBe(15); // revealed 1/2 -> 30 * 0.5
-    expect(calculatePoints(100, 1, 4)).toBe(23); // revealed 1/4 -> 30 * 0.75 = 22.5 -> 23
-    expect(calculatePoints(100, 1, 8)).toBe(26); // revealed 1/8 -> 30 * 0.875 = 26.25 -> 26
+    // One hint is worth less on a long word than on a short one (mastery 100 → 32).
+    expect(calculatePoints(100, 1, 2, 'type')).toBe(16); // revealed 1/2 -> 32 * 0.5
+    expect(calculatePoints(100, 1, 4, 'type')).toBe(24); // revealed 1/4 -> 32 * 0.75
+    expect(calculatePoints(100, 1, 8, 'type')).toBe(28); // revealed 1/8 -> 32 * 0.875
   });
 
   it('awards zero once the entire word has been revealed', () => {
-    expect(calculatePoints(0, 3, 3)).toBe(0);
-    expect(calculatePoints(50, 5, 5)).toBe(0);
-    expect(calculatePoints(100, 7, 7)).toBe(0);
+    expect(calculatePoints(25, 3, 3, 'type')).toBe(0);
+    expect(calculatePoints(50, 5, 5, 'type')).toBe(0);
+    expect(calculatePoints(100, 7, 7, 'type')).toBe(0);
   });
 
   it('never returns negative points when more letters are revealed than the word has', () => {
-    expect(calculatePoints(100, 10, 4)).toBe(0);
-    expect(calculatePoints(0, 8, 4)).toBe(0);
+    expect(calculatePoints(100, 10, 4, 'type')).toBe(0);
+    expect(calculatePoints(25, 8, 4, 'type')).toBe(0);
   });
 
-  it('always returns whole-number points, including when clamped', () => {
-    for (const mastery of [0, 25, 50, 75, 100] as const) {
-      for (let hints = 0; hints <= 5; hints++) {
-        const points = calculatePoints(mastery, hints, 4);
-        expect(Number.isInteger(points)).toBe(true);
-        expect(points).toBeGreaterThanOrEqual(0);
+  it('always returns whole-number, non-negative points across both modes', () => {
+    for (const mode of ['type', 'mc'] as const) {
+      for (const mastery of [0, 25, 50, 75, 100] as const) {
+        for (let hints = 0; hints <= 5; hints++) {
+          const points = calculatePoints(mastery, hints, 4, mode);
+          expect(Number.isInteger(points)).toBe(true);
+          expect(points).toBeGreaterThanOrEqual(0);
+        }
       }
     }
   });
 
   it('applies no discount for a zero-length word (guards divide-by-zero)', () => {
-    expect(calculatePoints(100, 1, 0)).toBe(30);
+    expect(calculatePoints(100, 1, 0, 'type')).toBe(32);
   });
 });
 

--- a/src/app/practice/components/Feedback/index.tsx
+++ b/src/app/practice/components/Feedback/index.tsx
@@ -1,0 +1,132 @@
+'use client';
+import { Volume2 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import ClozeFeedback from '@/components/ClozeFeedback';
+import { splitTrailingPunctuation } from '@/lib/words';
+import { addClozeCard } from '@/lib/anki';
+import { ANKI_CLOZE_DECK_SETTING_KEY, DEFAULT_ANKI_CLOZE_DECK } from '../../constants';
+import { CurrentSentence, IFeedbackData } from '../../types';
+import { isTTSAvailable, speak } from '@/lib/tts';
+
+export default function Feedback({
+  feedbackData,
+  current,
+  onWordClicked,
+  onNext,
+}: {
+  feedbackData: IFeedbackData | null;
+  current: CurrentSentence | null;
+  onWordClicked: (word: string) => void;
+  onNext: () => void;
+}) {
+  const [isAddingToAnki, setIsAddingToAnki] = useState(false);
+  const [ankiAdded, setAnkiAdded] = useState(false);
+
+  const handleNextButtonPressed = () => {
+    setAnkiAdded(false);
+    onNext();
+  };
+
+  // Handle add to Anki
+  const handleAddToAnki = async () => {
+    if (!current || !feedbackData || !feedbackData.isCorrect || isAddingToAnki || ankiAdded) {
+      return;
+    }
+
+    setIsAddingToAnki(true);
+    try {
+      const deckName = localStorage.getItem(ANKI_CLOZE_DECK_SETTING_KEY) || DEFAULT_ANKI_CLOZE_DECK;
+
+      const cleanWord = splitTrailingPunctuation(current.sentence.clozeWord)[0];
+      await addClozeCard(
+        deckName,
+        current.sentence.sentence,
+        cleanWord,
+        current.sentence.translation,
+        cleanWord,
+      );
+      setAnkiAdded(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to add to Anki';
+      toast.error(message);
+    } finally {
+      setIsAddingToAnki(false);
+    }
+  };
+
+  const handleSpeak = () => {
+    if (!current) return;
+    speak(current.sentence.sentence);
+  };
+
+  if (!feedbackData) {
+    return;
+  }
+
+  return (
+    <div>
+      <div className="mb-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium text-muted-foreground">
+            {feedbackData.isCorrect ? 'Correct!' : 'Incorrect'}
+          </span>
+          {isTTSAvailable() && feedbackData.isCorrect && (
+            <Button type="button" onClick={handleSpeak} variant="ghost">
+              <Volume2 className="h-4 w-4" />
+              Listen Again
+            </Button>
+          )}
+        </div>
+        <p className="text-xl leading-relaxed font-medium text-foreground">
+          {current &&
+            current.sentence.sentence.split(/\s+/).map((word, i) => (
+              <span key={i}>
+                {i > 0 && ' '}
+                {i === current.sentence.clozeIndex ? (
+                  <span
+                    data-testid="cloze-word"
+                    onClick={() => onWordClicked(word)}
+                    className={`cursor-pointer rounded px-1 font-bold ${
+                      feedbackData.isCorrect
+                        ? 'border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
+                        : 'border border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
+                    }`}
+                  >
+                    {word}
+                  </span>
+                ) : (
+                  <span
+                    data-testid="cloze-word"
+                    onClick={() => onWordClicked(word)}
+                    className="cursor-pointer rounded px-0.5 transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    {word}
+                  </span>
+                )}
+              </span>
+            ))}
+        </p>
+        <p className="mt-2 text-base text-muted-foreground italic">
+          {current && current.sentence.translation}
+        </p>
+      </div>
+
+      <ClozeFeedback
+        isCorrect={feedbackData.isCorrect}
+        correctWord={feedbackData.correctWord}
+        userAnswer={feedbackData.userAnswer}
+        translation={feedbackData.translation}
+        sentence={current ? current.sentence.sentence : ''}
+        points={feedbackData.points}
+        newMastery={feedbackData.newMastery}
+        previousMastery={feedbackData.previousMastery}
+        onNext={handleNextButtonPressed}
+        onAddToAnki={handleAddToAnki}
+        isAddingToAnki={isAddingToAnki}
+        ankiAdded={ankiAdded}
+      />
+    </div>
+  );
+}

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -43,6 +43,8 @@ import type {
 import { COLLECTION_LABELS, ROUND_SIZES, VISIBLE_COLLECTIONS } from './constants';
 import BlacklistSentence from './components/BlacklistSentence';
 import { Button } from '@/components/ui/button';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
+import { SETTINGS_KEYS } from '@/app/settings/constants';
 import EmptyState from './components/EmptyState';
 import PageHeader from '@/components/PageHeader';
 import Feedback from './components/Feedback';
@@ -59,6 +61,10 @@ export default function PracticePage() {
   const [roundCorrect, setRoundCorrect] = useState(0);
   const [points, setPoints] = useState(0);
   const [seeded, setSeeded] = useState(false);
+
+  // Translation visibility. Initialised from the "Hide translation by default"
+  // setting on mount; Alt+T toggles it live during a round.
+  const [showTranslation, setShowTranslation] = useState(true);
 
   // Practice mode
   const [practiceMode, setPracticeMode] = useState<PracticeMode>('type');
@@ -121,6 +127,9 @@ export default function PracticePage() {
       if (savedMode === 'mc' || savedMode === 'type') {
         setPracticeMode(savedMode);
       }
+
+      // Respect the "hide translation by default" setting (Alt+T toggles live)
+      setShowTranslation(localStorage.getItem(SETTINGS_KEYS.HIDE_TRANSLATION) !== 'true');
 
       await migrateClozeSentences();
       await seedSentenceBank();
@@ -197,8 +206,6 @@ export default function PracticePage() {
     },
     [current],
   );
-
-  console.log(current);
 
   // Ask the LLM to retranslate the active word using the full (un-blanked)
   // sentence as context. Replaces the on-device gloss with a richer in-context
@@ -357,91 +364,94 @@ export default function PracticePage() {
     inputRef.current?.focus();
   }, [current, hintLetters, userAnswer]);
 
-  // Core submission logic (shared between type and MC modes)
-  const processAnswer = async (submittedAnswer: string) => {
-    if (!current || submittingRef.current) return;
+  // Record a completed answer: update the SRS card, points, and round stats,
+  // then show feedback. Shared by typed answers and multiple choice — the only
+  // differences are how correctness is decided (the caller's job, before the
+  // pause/sound) and the points base (8 for typing, 4 for MC), passed via `mode`.
+  const recordAnswer = useCallback(
+    async (isCorrect: boolean, submittedAnswer: string, mode: PracticeMode) => {
+      if (!current) return;
+
+      const previousMastery = current.sentence.masteryLevel;
+      const newMastery: ClozeMasteryLevel = isCorrect
+        ? (Math.min(previousMastery + 25, 100) as ClozeMasteryLevel)
+        : 0;
+
+      // No points in the retry phase — the answer was revealed when the card
+      // was first missed this round. Points scale with the mastery just reached.
+      const earnedPoints =
+        isCorrect && !isRetryPhase
+          ? calculatePoints(
+              newMastery,
+              hintLetters,
+              normalize(current.sentence.clozeWord).length,
+              mode,
+            )
+          : 0;
+      const nextReview = calculateNextReview(newMastery);
+
+      // Update database
+      await updateClozeAfterReview(current.sentence.id, isCorrect, newMastery, nextReview);
+      if (newMastery === 100) {
+        // Strip trailing punctuation so the reader's known-word lookup (clean,
+        // lowercased tokens) matches and fluency stats don't double-count.
+        await updateWordState(splitTrailingPunctuation(current.sentence.clozeWord)[0], 'known');
+      }
+      await incrementDailyStat('clozePracticed');
+      if (earnedPoints > 0) {
+        await incrementDailyStat('points', earnedPoints);
+      }
+
+      // Update local state — only count first-pass answers toward round progress,
+      // so retried sentences don't push the counter past roundSize (issue #57).
+      if (!isRetryPhase) {
+        setRoundProgress((prev) => prev + 1);
+        if (isCorrect) setRoundCorrect((prev) => prev + 1);
+      }
+      if (earnedPoints > 0) {
+        setPoints((prev) => prev + earnedPoints);
+      }
+
+      setFeedbackData({
+        isCorrect,
+        correctWord: splitTrailingPunctuation(current.sentence.clozeWord)[0],
+        userAnswer: submittedAnswer,
+        translation: current.sentence.translation,
+        points: earnedPoints,
+        newMastery,
+        previousMastery,
+      });
+
+      setState('feedback');
+
+      if (isCorrect) {
+        speak(current.sentence.sentence);
+      } else {
+        // Add to retry queue so incorrect answers are re-tested. The card was
+        // just demoted to mastery 0 in the DB — the queued copy must carry that,
+        // or the retry would promote it straight back from its old level.
+        setRetryQueue((prev) => [
+          ...prev,
+          { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel },
+        ]);
+      }
+    },
+    [current, hintLetters, isRetryPhase],
+  );
+
+  // Handle answer submission (type mode)
+  const handleSubmit = async () => {
+    if (!current || !userAnswer.trim() || submittingRef.current) return;
     submittingRef.current = true;
 
-    const isCorrect = checkAnswer(submittedAnswer, current.sentence.clozeWord);
-    const previousMastery = current.sentence.masteryLevel;
-
-    // Sound effects
+    const answer = userAnswer.trim();
+    const isCorrect = checkAnswer(answer, current.sentence.clozeWord);
     if (isCorrect) {
       playCorrectSound();
     } else {
       playIncorrectSound();
     }
-
-    let newMastery: ClozeMasteryLevel;
-    if (isCorrect) {
-      newMastery = Math.min(previousMastery + 25, 100) as ClozeMasteryLevel;
-    } else {
-      newMastery = 0;
-    }
-
-    // No points in the retry phase — the answer was revealed when the card
-    // was first missed this round.
-    const earnedPoints =
-      isCorrect && !isRetryPhase
-        ? calculatePoints(
-            previousMastery,
-            hintLetters,
-            normalize(current.sentence.clozeWord).length,
-          )
-        : 0;
-    const nextReview = calculateNextReview(newMastery);
-
-    // Update database
-    await updateClozeAfterReview(current.sentence.id, isCorrect, newMastery, nextReview);
-    if (newMastery === 100) {
-      // Strip trailing punctuation so the reader's known-word lookup (clean,
-      // lowercased tokens) matches and fluency stats don't double-count.
-      await updateWordState(splitTrailingPunctuation(current.sentence.clozeWord)[0], 'known');
-    }
-    await incrementDailyStat('clozePracticed');
-    if (earnedPoints > 0) {
-      await incrementDailyStat('points', earnedPoints);
-    }
-
-    // Update local state — only count first-pass answers toward round progress,
-    // so retried sentences don't push the counter past roundSize (issue #57).
-    if (!isRetryPhase) {
-      setRoundProgress((prev) => prev + 1);
-      if (isCorrect) setRoundCorrect((prev) => prev + 1);
-    }
-    if (earnedPoints > 0) {
-      setPoints((prev) => prev + earnedPoints);
-    }
-
-    setFeedbackData({
-      isCorrect,
-      correctWord: splitTrailingPunctuation(current.sentence.clozeWord)[0],
-      userAnswer: submittedAnswer,
-      translation: current.sentence.translation,
-      points: earnedPoints,
-      newMastery,
-      previousMastery,
-    });
-
-    setState('feedback');
-
-    if (isCorrect) {
-      speak(current.sentence.sentence);
-    } else {
-      // Add to retry queue so incorrect answers are re-tested. The card was
-      // just demoted to mastery 0 in the DB — the queued copy must carry that,
-      // or the retry would promote it straight back from its old level.
-      setRetryQueue((prev) => [
-        ...prev,
-        { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel },
-      ]);
-    }
-  };
-
-  // Handle answer submission (type mode)
-  const handleSubmit = async () => {
-    if (!current || !userAnswer.trim()) return;
-    await processAnswer(userAnswer.trim());
+    await recordAnswer(isCorrect, answer, 'type');
   };
 
   // Handle MC option selection
@@ -461,76 +471,17 @@ export default function PracticePage() {
         playIncorrectSound();
       }
 
-      // Delay then submit (without duplicate sound)
+      // Brief pause so the chosen option's right/wrong highlight stays visible
+      // before the feedback panel replaces it — longer on a miss so the user can
+      // see which option was correct. This delay (not extra work) is why MC feels
+      // slower than typing, where feedback appears the instant you submit.
       const delay = isCorrect ? 600 : 1200;
-      mcTimerRef.current = setTimeout(async () => {
+      mcTimerRef.current = setTimeout(() => {
         mcTimerRef.current = null;
-        if (!current) return;
-
-        const previousMastery = current.sentence.masteryLevel;
-        let newMastery: ClozeMasteryLevel;
-        if (isCorrect) {
-          newMastery = Math.min(previousMastery + 25, 100) as ClozeMasteryLevel;
-        } else {
-          newMastery = 0;
-        }
-
-        // No points in the retry phase — the answer was revealed when the card
-        // was first missed this round.
-        const earnedPoints =
-          isCorrect && !isRetryPhase
-            ? calculatePoints(
-                previousMastery,
-                hintLetters,
-                normalize(current.sentence.clozeWord).length,
-              )
-            : 0;
-        const nextReview = calculateNextReview(newMastery);
-
-        await updateClozeAfterReview(current.sentence.id, isCorrect, newMastery, nextReview);
-        if (newMastery === 100) {
-          // Strip trailing punctuation so the reader's known-word lookup (clean,
-          // lowercased tokens) matches and fluency stats don't double-count.
-          await updateWordState(splitTrailingPunctuation(current.sentence.clozeWord)[0], 'known');
-        }
-        await incrementDailyStat('clozePracticed');
-        if (earnedPoints > 0) {
-          await incrementDailyStat('points', earnedPoints);
-        }
-
-        if (!isRetryPhase) {
-          setRoundProgress((prev) => prev + 1);
-          if (isCorrect) setRoundCorrect((prev) => prev + 1);
-        }
-        if (earnedPoints > 0) {
-          setPoints((prev) => prev + earnedPoints);
-        }
-
-        setFeedbackData({
-          isCorrect,
-          correctWord: splitTrailingPunctuation(current.sentence.clozeWord)[0],
-          userAnswer: selectedWord,
-          translation: current.sentence.translation,
-          points: earnedPoints,
-          newMastery,
-          previousMastery,
-        });
-
-        setState('feedback');
-
-        if (isCorrect) {
-          speak(current.sentence.sentence);
-        } else {
-          // Re-test wrong answers at the end of the round, demoted to mastery 0
-          // (same as type mode).
-          setRetryQueue((prev) => [
-            ...prev,
-            { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel },
-          ]);
-        }
+        recordAnswer(isCorrect, selectedWord, 'mc');
       }, delay);
     },
-    [mcLocked, hintLetters, current, mcOptions, mcCorrectIdx, isRetryPhase],
+    [mcLocked, current, mcCorrectIdx, mcOptions, recordAnswer],
   );
 
   // Handle next sentence
@@ -595,6 +546,21 @@ export default function PracticePage() {
       return () => window.removeEventListener('keydown', handleKeyDown);
     }
   }, [state, handleNext, practiceMode, mcLocked, mcOptions, handleMcSelect, current]);
+
+  // Alt+T toggles translation visibility (while practicing and on feedback)
+  useEffect(() => {
+    if (state !== 'practicing' && state !== 'feedback') return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Match on e.code so it's keyboard-layout independent — on macOS Alt+T
+      // (Option+T) would otherwise arrive as e.key === '†'.
+      if (e.altKey && e.code === 'KeyT') {
+        e.preventDefault();
+        setShowTranslation((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [state]);
 
   const handleBackPressed = async () => {
     setState('setup');
@@ -826,6 +792,17 @@ export default function PracticePage() {
                   words[current.sentence.clozeIndex] ?? '',
                 );
 
+                // Re-used in both the type and MC shortcut-hint rows below.
+                const translationHint = (
+                  <span className="inline-flex items-center gap-1.5">
+                    <KbdGroup>
+                      <Kbd>Alt</Kbd>
+                      <Kbd>T</Kbd>
+                    </KbdGroup>
+                    Translation
+                  </span>
+                );
+
                 return (
                   <div>
                     {/* Sentence with inline input or blank */}
@@ -889,10 +866,25 @@ export default function PracticePage() {
                           </span>
                         ))}
                       </p>
-                      {/* English translation */}
-                      <p className="mt-3 text-base text-muted-foreground italic">
-                        {current.sentence.translation}
-                      </p>
+                      {/* English translation — hidden when the user chooses to
+                          practise without it (toggle with Alt+T). */}
+                      {showTranslation ? (
+                        <p className="mt-3 text-base text-muted-foreground italic">
+                          {current.sentence.translation}
+                        </p>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setShowTranslation(true)}
+                          className="mt-3 inline-flex items-center gap-2 text-sm text-muted-foreground italic transition-colors hover:text-foreground"
+                        >
+                          Show translation
+                          <KbdGroup>
+                            <Kbd>Alt</Kbd>
+                            <Kbd>T</Kbd>
+                          </KbdGroup>
+                        </button>
+                      )}
                     </div>
 
                     {/* Multiple choice options */}
@@ -928,6 +920,26 @@ export default function PracticePage() {
                             </button>
                           );
                         })}
+                      </div>
+                    )}
+
+                    {/* Multiple-choice shortcut hints (real MC mode only — the
+                        number keys aren't wired up for the per-question fallback) */}
+                    {practiceMode === 'mc' && (
+                      <div className="mb-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                        <span className="inline-flex items-center gap-1.5">
+                          <KbdGroup>
+                            <Kbd>1</Kbd>
+                            <span aria-hidden>–</span>
+                            <Kbd>4</Kbd>
+                          </KbdGroup>
+                          Choose
+                        </span>
+                        <span className="inline-flex items-center gap-1.5">
+                          <Kbd>Space</Kbd>
+                          Listen
+                        </span>
+                        {translationHint}
                       </div>
                     )}
 
@@ -968,6 +980,18 @@ export default function PracticePage() {
                         </Button>
                       </div>
                     )}
+
+                    {/* Type mode shortcut hints */}
+                    {practiceMode === 'type' && !mcFallback && (
+                      <div className="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                        <span className="inline-flex items-center gap-1.5">
+                          <Kbd>Enter</Kbd>
+                          {fuzzyStatus === 'match' ? 'Submit' : 'Check'}
+                        </span>
+                        {translationHint}
+                      </div>
+                    )}
+
                     {/* Mastery indicator */}
                     <div className="mt-6 flex items-center justify-center gap-2 text-sm text-muted-foreground">
                       <span>Mastery:</span>

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { CheckCircle, Star, Volume2 } from 'lucide-react';
-import ClozeFeedback from '@/components/ClozeFeedback';
+import { CheckCircle, Star } from 'lucide-react';
 import TranslationDrawer from '@/components/TranslationDrawer';
 import {
   ClozeSentence,
@@ -18,9 +17,8 @@ import {
   seedSentenceBank,
   updateWordState,
 } from '@/lib/data-layer';
-import { speak, isTTSAvailable } from '@/lib/tts';
+import { speak } from '@/lib/tts';
 import { playCorrectSound, playIncorrectSound } from '@/lib/sounds';
-import { addClozeCard } from '@/lib/anki';
 import { translateWord } from '@/lib/claude';
 import { lookupWordRemote, type ExpandedDictionaryEntry } from '@/lib/dictionary-client';
 import { splitTrailingPunctuation } from '@/lib/words';
@@ -34,18 +32,20 @@ import {
   normalize,
   shuffle,
 } from './utils';
-import type { CurrentSentence, PracticeMode, PracticeState, RoundSize, RoundType } from './types';
-import {
-  ANKI_CLOZE_DECK_SETTING_KEY,
-  COLLECTION_LABELS,
-  DEFAULT_ANKI_CLOZE_DECK,
-  ROUND_SIZES,
-  VISIBLE_COLLECTIONS,
-} from './constants';
+import type {
+  CurrentSentence,
+  IFeedbackData,
+  PracticeMode,
+  PracticeState,
+  RoundSize,
+  RoundType,
+} from './types';
+import { COLLECTION_LABELS, ROUND_SIZES, VISIBLE_COLLECTIONS } from './constants';
 import BlacklistSentence from './components/BlacklistSentence';
 import { Button } from '@/components/ui/button';
 import EmptyState from './components/EmptyState';
 import PageHeader from '@/components/PageHeader';
+import Feedback from './components/Feedback';
 
 export default function PracticePage() {
   // State
@@ -58,7 +58,6 @@ export default function PracticePage() {
   const [roundProgress, setRoundProgress] = useState(0);
   const [roundCorrect, setRoundCorrect] = useState(0);
   const [points, setPoints] = useState(0);
-  const [ttsSupported, setTtsSupported] = useState(false);
   const [seeded, setSeeded] = useState(false);
 
   // Practice mode
@@ -80,18 +79,7 @@ export default function PracticePage() {
   > | null>(null);
 
   // Feedback state
-  const [feedbackData, setFeedbackData] = useState<{
-    isCorrect: boolean;
-    correctWord: string;
-    userAnswer: string;
-    translation: string;
-    points: number;
-    newMastery: ClozeMasteryLevel;
-    previousMastery: ClozeMasteryLevel;
-  } | null>(null);
-  const [isAddingToAnki, setIsAddingToAnki] = useState(false);
-  const [ankiAdded, setAnkiAdded] = useState(false);
-  const [ankiError, setAnkiError] = useState<string | null>(null);
+  const [feedbackData, setFeedbackData] = useState<IFeedbackData | null>(null);
   const [hintLetters, setHintLetters] = useState(0);
   const [retryQueue, setRetryQueue] = useState<ClozeSentence[]>([]);
   const [isRetryPhase, setIsRetryPhase] = useState(false);
@@ -125,8 +113,6 @@ export default function PracticePage() {
   // Load collection counts and seed on mount
   useEffect(() => {
     const init = async () => {
-      setTtsSupported(isTTSAvailable());
-
       const stats = await getTodayStats();
       setPoints(stats.points);
 
@@ -282,8 +268,6 @@ export default function PracticePage() {
       setCurrent({ sentence: nextSentence, blankedSentence });
       setUserAnswer('');
       setFeedbackData(null);
-      setAnkiAdded(false);
-      setAnkiError(null);
       setHintLetters(0);
       setMcFallback(false);
       setWordTooltip(null);
@@ -368,7 +352,7 @@ export default function PracticePage() {
 
     // Reveal one more letter beyond the correct prefix
     const revealCount = Math.min(Math.max(correctPrefix + 1, hintLetters + 1), correctWord.length);
-    setHintLetters(revealCount);
+    setHintLetters(hintLetters + 1);
     setUserAnswer(correctWord.slice(0, revealCount));
     inputRef.current?.focus();
   }, [current, hintLetters, userAnswer]);
@@ -612,41 +596,6 @@ export default function PracticePage() {
     }
   }, [state, handleNext, practiceMode, mcLocked, mcOptions, handleMcSelect, current]);
 
-  // Handle add to Anki
-  const handleAddToAnki = async () => {
-    if (!current || !feedbackData || !feedbackData.isCorrect || isAddingToAnki || ankiAdded) {
-      return;
-    }
-
-    setIsAddingToAnki(true);
-    setAnkiError(null);
-    try {
-      const deckName = localStorage.getItem(ANKI_CLOZE_DECK_SETTING_KEY) || DEFAULT_ANKI_CLOZE_DECK;
-
-      const cleanWord = splitTrailingPunctuation(current.sentence.clozeWord)[0];
-      await addClozeCard(
-        deckName,
-        current.sentence.sentence,
-        cleanWord,
-        current.sentence.translation,
-        cleanWord,
-      );
-      setAnkiAdded(true);
-    } catch (error) {
-      console.error('Failed to add to Anki:', error);
-      const message = error instanceof Error ? error.message : 'Failed to add to Anki';
-      setAnkiError(message);
-    } finally {
-      setIsAddingToAnki(false);
-    }
-  };
-
-  // Handle TTS
-  const handleSpeak = () => {
-    if (!current) return;
-    speak(current.sentence.sentence);
-  };
-
   const handleBackPressed = async () => {
     setState('setup');
     const counts = await getCollectionCounts();
@@ -726,9 +675,7 @@ export default function PracticePage() {
 
             {/* Learn New section */}
             <div className="rounded-2xl border border-border bg-card p-5">
-              <h2 className="mb-4 text-base font-semibold text-foreground">
-                Learn New
-              </h2>
+              <h2 className="mb-4 text-base font-semibold text-foreground">Learn New</h2>
 
               {/* Collection */}
               <div className="mb-4">
@@ -868,7 +815,8 @@ export default function PracticePage() {
                   empty: 'border-[var(--clay)] bg-[color-mix(in_srgb,var(--clay)_14%,var(--card))]',
                   match: 'border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))]',
                   partial: 'border-primary bg-[color-mix(in_srgb,var(--primary)_8%,var(--card))]',
-                  wrong: 'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))]',
+                  wrong:
+                    'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))]',
                 }[fuzzyStatus];
 
                 const words = current.sentence.sentence.split(/\s+/);
@@ -951,8 +899,7 @@ export default function PracticePage() {
                     {(practiceMode === 'mc' || mcFallback) && (
                       <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
                         {mcOptions.map((option, idx) => {
-                          let btnClass =
-                            'border-border bg-card text-foreground hover:bg-accent';
+                          let btnClass = 'border-border bg-card text-foreground hover:bg-accent';
 
                           if (mcSelected !== null) {
                             if (idx === mcCorrectIdx) {
@@ -962,8 +909,7 @@ export default function PracticePage() {
                               btnClass =
                                 'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive';
                             } else {
-                              btnClass =
-                                'border-border bg-card text-muted-foreground opacity-60';
+                              btnClass = 'border-border bg-card text-muted-foreground opacity-60';
                             }
                           }
 
@@ -1039,68 +985,12 @@ export default function PracticePage() {
 
             {/* Feedback state */}
             {state === 'feedback' && current && feedbackData && (
-              <div>
-                <div className="mb-4">
-                  <div className="mb-2 flex items-center justify-between">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      {feedbackData.isCorrect ? 'Correct!' : 'Incorrect'}
-                    </span>
-                    {ttsSupported && feedbackData.isCorrect && (
-                      <Button type="button" onClick={handleSpeak} variant="ghost">
-                        <Volume2 className="h-4 w-4" />
-                        Listen Again
-                      </Button>
-                    )}
-                  </div>
-                  <p className="text-xl leading-relaxed font-medium text-foreground">
-                    {current.sentence.sentence.split(/\s+/).map((word, i) => (
-                      <span key={i}>
-                        {i > 0 && ' '}
-                        {i === current.sentence.clozeIndex ? (
-                          <span
-                            data-testid="cloze-word"
-                            onClick={() => handleWordClick(word)}
-                            className={`cursor-pointer rounded px-1 font-bold ${
-                              feedbackData.isCorrect
-                                ? 'border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
-                                : 'border border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
-                            }`}
-                          >
-                            {word}
-                          </span>
-                        ) : (
-                          <span
-                            data-testid="cloze-word"
-                            onClick={() => handleWordClick(word)}
-                            className="cursor-pointer rounded px-0.5 transition-colors hover:bg-accent hover:text-foreground"
-                          >
-                            {word}
-                          </span>
-                        )}
-                      </span>
-                    ))}
-                  </p>
-                  <p className="mt-2 text-base text-muted-foreground italic">
-                    {current.sentence.translation}
-                  </p>
-                </div>
-
-                <ClozeFeedback
-                  isCorrect={feedbackData.isCorrect}
-                  correctWord={feedbackData.correctWord}
-                  userAnswer={feedbackData.userAnswer}
-                  translation={feedbackData.translation}
-                  sentence={current.sentence.sentence}
-                  points={feedbackData.points}
-                  newMastery={feedbackData.newMastery}
-                  previousMastery={feedbackData.previousMastery}
-                  onNext={handleNext}
-                  onAddToAnki={handleAddToAnki}
-                  isAddingToAnki={isAddingToAnki}
-                  ankiAdded={ankiAdded}
-                  ankiError={ankiError}
-                />
-              </div>
+              <Feedback
+                feedbackData={feedbackData}
+                current={current}
+                onNext={handleNext}
+                onWordClicked={handleWordClick}
+              />
             )}
 
             {state === 'complete' && (
@@ -1108,9 +998,7 @@ export default function PracticePage() {
                 <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary">
                   <CheckCircle className="h-8 w-8" />
                 </div>
-                <h2 className="mb-2 text-xl font-bold text-foreground">
-                  Round Complete!
-                </h2>
+                <h2 className="mb-2 text-xl font-bold text-foreground">Round Complete!</h2>
                 <p className="mb-1 text-muted-foreground">
                   {roundCorrect}/{roundProgress} correct
                 </p>

--- a/src/app/practice/types.ts
+++ b/src/app/practice/types.ts
@@ -1,14 +1,23 @@
-import { ClozeSentence } from "@/types";
-import { ROUND_SIZES } from "./constants";
+import type { ClozeMasteryLevel, ClozeSentence } from '@/types';
+import { ROUND_SIZES } from './constants';
 
 // Fuzzy match status for live feedback
 export type FuzzyStatus = 'empty' | 'match' | 'partial' | 'wrong';
 export type PracticeState = 'setup' | 'loading' | 'practicing' | 'feedback' | 'complete' | 'empty';
 export type PracticeMode = 'type' | 'mc';
 
-export type RoundSize = typeof ROUND_SIZES[number];
+export type RoundSize = (typeof ROUND_SIZES)[number];
 export type RoundType = 'new' | 'review';
 
+export interface IFeedbackData {
+  isCorrect: boolean;
+  correctWord: string;
+  userAnswer: string;
+  translation: string;
+  points: number;
+  newMastery: ClozeMasteryLevel;
+  previousMastery: ClozeMasteryLevel;
+}
 
 export interface CurrentSentence {
   sentence: ClozeSentence;

--- a/src/app/practice/utils.ts
+++ b/src/app/practice/utils.ts
@@ -1,6 +1,6 @@
 import { splitTrailingPunctuation } from '@/lib/words';
 import { ClozeMasteryLevel, ClozeSentence } from '@/types';
-import { FuzzyStatus } from './types';
+import { FuzzyStatus, PracticeMode } from './types';
 
 // Helper export function to create blanked sentence, moving punctuation outside the blank
 export function createBlankedSentence(sentence: string, wordIndex: number): string {
@@ -49,23 +49,23 @@ export function calculateNextReview(mastery: ClozeMasteryLevel): Date {
   return new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
 }
 
-// Calculate points for correct answer
+// Calculate points for a correct answer, following Clozemaster's formula:
+//   base × (mastery% ÷ 25)
+// where base is 8 for typed answers and 4 for multiple choice. `mastery` is the
+// level reached *after* the answer (0/25/50/75/100), so leveling a card up pays
+// more. Typed answers keep a hint penalty: revealing letters scales the award
+// down by the fraction of the word given away (MC has no hints, so it's unaffected).
 export function calculatePoints(
   mastery: ClozeMasteryLevel,
   hintLetters: number,
   wordLength: number,
+  mode: PracticeMode,
 ): number {
-  const pointsMap: Record<ClozeMasteryLevel, number> = {
-    0: 10,
-    25: 15,
-    50: 20,
-    75: 25,
-    100: 30,
-  };
-  const base = pointsMap[mastery];
+  const base = mode === 'mc' ? 4 : 8;
+  const masteryMultiplier = mastery / 25;
   const revealed = wordLength > 0 ? hintLetters / wordLength : 0;
 
-  return Math.max(0, Math.round(base * (1 - revealed)));
+  return Math.max(0, Math.round(base * masteryMultiplier * (1 - revealed)));
 }
 
 // Generate distractors from the queue/pool of cloze words

--- a/src/app/settings/components/PracticeSettings/index.tsx
+++ b/src/app/settings/components/PracticeSettings/index.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
+import { SETTINGS_KEYS } from '../../constants';
+
+export default function PracticeSettings() {
+  const [hideTranslation, setHideTranslation] = useState(false);
+
+  useEffect(() => {
+    const load = () =>
+      setHideTranslation(localStorage.getItem(SETTINGS_KEYS.HIDE_TRANSLATION) === 'true');
+    load();
+  }, []);
+
+  const handleHideTranslationChanged = (hide: boolean) => {
+    setHideTranslation(hide);
+    localStorage.setItem(SETTINGS_KEYS.HIDE_TRANSLATION, String(hide));
+  };
+
+  return (
+    <section className="panel p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">Practice</h2>
+
+      {/* Cloze settings sub-section */}
+      <h3 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+        Cloze settings
+      </h3>
+      <div>
+        <label className="block text-sm font-medium text-foreground">Translation</label>
+        <p className="mb-2 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          Hide the English translation by default while practicing. Toggle it anytime with
+          <KbdGroup>
+            <Kbd>Alt</Kbd>
+            <Kbd>T</Kbd>
+          </KbdGroup>
+          .
+        </p>
+        <div className="flex gap-2">
+          <Button
+            onClick={() => handleHideTranslationChanged(false)}
+            variant={hideTranslation ? 'secondary' : 'default'}
+          >
+            Shown
+          </Button>
+          <Button
+            onClick={() => handleHideTranslationChanged(true)}
+            variant={hideTranslation ? 'default' : 'secondary'}
+          >
+            Hidden
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/settings/constants.ts
+++ b/src/app/settings/constants.ts
@@ -5,4 +5,5 @@ export const SETTINGS_KEYS = {
   DEFAULT_CARD_TYPE: 'lector-card-type',
   TTS_SPEED: 'lector-tts-speed',
   THEME: 'lector-theme',
+  HIDE_TRANSLATION: 'lector-hide-translation',
 } as const;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import ThemeSettings from './components/ThemeSettings';
 import AnkiSettings from './components/AnkiSettings';
 import TTSSettings from './components/TTSSettings';
 import LLMSettings from './components/LLMSettings';
+import PracticeSettings from './components/PracticeSettings';
 import PageHeader from '@/components/PageHeader';
 
 export default function SettingsPage() {
@@ -16,6 +17,7 @@ export default function SettingsPage() {
     <main className="mx-auto max-w-3xl px-4 py-8">
       <PageHeader title="Settings" />
       <div className="space-y-8">
+        <PracticeSettings />
         <LLMSettings />
         <AnkiSettings />
         <TTSSettings />

--- a/src/components/ClozeFeedback/index.tsx
+++ b/src/components/ClozeFeedback/index.tsx
@@ -3,6 +3,7 @@
 import { Check, ChevronRight, Info, Loader2, Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Kbd } from '@/components/ui/kbd';
 import { ClozeFeedbackProps } from './types';
 import { toast } from 'sonner';
 import Markdown from 'react-markdown';
@@ -204,6 +205,14 @@ export default function ClozeFeedback({
           Next Sentence
           <ChevronRight className="h-4 w-4" />
         </Button>
+      </div>
+
+      {/* Keyboard hint */}
+      <div className="mt-4 flex items-center justify-center text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <Kbd>Enter</Kbd>
+          Next sentence
+        </span>
       </div>
     </div>
   );

--- a/src/components/ClozeFeedback/index.tsx
+++ b/src/components/ClozeFeedback/index.tsx
@@ -1,24 +1,11 @@
 'use client';
 
-import { AlertTriangle, Check, ChevronRight, Info, Loader2, Plus, X } from 'lucide-react';
+import { Check, ChevronRight, Info, Loader2, Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-
-interface ClozeFeedbackProps {
-  isCorrect: boolean;
-  correctWord: string;
-  userAnswer: string;
-  translation: string;
-  sentence: string;
-  points: number;
-  newMastery: number;
-  previousMastery: number;
-  onNext: () => void;
-  onAddToAnki: () => void;
-  isAddingToAnki?: boolean;
-  ankiAdded?: boolean;
-  ankiError?: string | null;
-}
+import { ClozeFeedbackProps } from './types';
+import { toast } from 'sonner';
+import Markdown from 'react-markdown';
 
 export default function ClozeFeedback({
   isCorrect,
@@ -33,7 +20,6 @@ export default function ClozeFeedback({
   onAddToAnki,
   isAddingToAnki = false,
   ankiAdded = false,
-  ankiError = null,
 }: ClozeFeedbackProps) {
   const [explanation, setExplanation] = useState<string | null>(null);
   const [isExplaining, setIsExplaining] = useState(false);
@@ -43,6 +29,7 @@ export default function ClozeFeedback({
     if (explanation || isExplaining) return;
     setIsExplaining(true);
     setExplainError(false);
+
     try {
       const res = await fetch('/api/explain', {
         method: 'POST',
@@ -58,7 +45,7 @@ export default function ClozeFeedback({
       const data = await res.json();
       setExplanation(data.explanation);
     } catch {
-      setExplainError(true);
+      toast.error('Failed to fetch explanation');
     } finally {
       setIsExplaining(false);
     }
@@ -94,17 +81,11 @@ export default function ClozeFeedback({
           {isCorrect ? <Check className="h-6 w-6" /> : <X className="h-6 w-6" />}
         </div>
         <div>
-          <h3
-            className={`text-xl font-bold ${
-              isCorrect ? 'text-primary' : 'text-destructive'
-            }`}
-          >
+          <h3 className={`text-xl font-bold ${isCorrect ? 'text-primary' : 'text-destructive'}`}>
             {isCorrect ? 'Correct!' : 'Incorrect'}
           </h3>
           {isCorrect && points > 0 && (
-            <p className="text-sm font-medium text-[var(--gold-strong)]">
-              +{points} points
-            </p>
+            <p className="text-sm font-medium text-[var(--gold-strong)]">+{points} points</p>
           )}
         </div>
       </div>
@@ -144,11 +125,7 @@ export default function ClozeFeedback({
         <div className="mb-2 flex items-center justify-between text-sm">
           <span className="font-medium text-muted-foreground">Mastery Level</span>
           <span className="flex items-center gap-2">
-            <span
-              className={`font-semibold ${
-                isCorrect ? 'text-primary' : 'text-destructive'
-              }`}
-            >
+            <span className={`font-semibold ${isCorrect ? 'text-primary' : 'text-destructive'}`}>
               {masteryLabels[newMastery]}
             </span>
             {masteryChange !== 0 && (
@@ -175,12 +152,9 @@ export default function ClozeFeedback({
 
       {/* Explain section */}
       {explanation && (
-        <div className="mb-4 rounded-lg bg-muted p-4">
-          <p className="mb-2 text-sm font-medium text-muted-foreground">
-            Sentence Breakdown
-          </p>
-          <div className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">
-            {explanation}
+        <div className="mb-4 rounded-lg bg-muted p-4 text-sm leading-tight whitespace-pre-wrap text-foreground">
+          <div className="">
+            <Markdown>{explanation}</Markdown>
           </div>
         </div>
       )}
@@ -188,32 +162,14 @@ export default function ClozeFeedback({
       {/* Action buttons */}
       <div className="flex flex-wrap gap-3">
         {isCorrect && (
-          <button
+          <Button
             type="button"
             onClick={onAddToAnki}
-            disabled={isAddingToAnki || ankiAdded || !!ankiError}
-            className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
-              ankiAdded
-                ? 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
-                : ankiError
-                  ? 'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
-                  : isAddingToAnki
-                    ? 'cursor-wait bg-muted text-muted-foreground'
-                    : 'bg-[var(--clay-soft)] text-[var(--clay)] hover:bg-[color-mix(in_srgb,var(--clay)_18%,transparent)]'
-            }`}
-            title={ankiError || undefined}
+            disabled={isAddingToAnki || ankiAdded}
+            variant="secondary"
+            title={ankiAdded ? 'Already added to Anki' : 'Add to Anki'}
           >
-            {ankiAdded ? (
-              <>
-                <Check className="h-4 w-4" />
-                Added to Anki
-              </>
-            ) : ankiError ? (
-              <>
-                <AlertTriangle className="h-4 w-4" />
-                Anki Error
-              </>
-            ) : isAddingToAnki ? (
+            {isAddingToAnki ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
                 Adding...
@@ -224,45 +180,26 @@ export default function ClozeFeedback({
                 Add to Anki
               </>
             )}
-          </button>
+          </Button>
         )}
-        {/* Explain button */}
-        <button
+        <Button
           type="button"
+          variant={explainError ? 'destructive' : 'clay'}
           onClick={handleExplain}
           disabled={isExplaining || !!explanation}
-          className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all ${
-            explanation
-              ? 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
-              : explainError
-                ? 'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
-                : isExplaining
-                  ? 'cursor-wait bg-muted text-muted-foreground'
-                  : 'bg-[var(--gold-soft)] text-[var(--gold-strong)] hover:bg-[color-mix(in_srgb,var(--gold)_22%,transparent)]'
-          }`}
         >
-          {explanation ? (
-            <>
-              <Check className="h-4 w-4" />
-              Explained
-            </>
-          ) : isExplaining ? (
+          {isExplaining ? (
             <>
               <Loader2 className="h-4 w-4 animate-spin" />
               Explaining...
             </>
-          ) : explainError ? (
-            <>Explain failed</>
           ) : (
             <>
               <Info className="h-4 w-4" />
               Explain
             </>
           )}
-        </button>
-        {ankiError && (
-          <div className="w-full text-xs text-destructive">{ankiError}</div>
-        )}
+        </Button>
         <Button type="button" onClick={onNext} className="flex-1">
           Next Sentence
           <ChevronRight className="h-4 w-4" />

--- a/src/components/ClozeFeedback/types.ts
+++ b/src/components/ClozeFeedback/types.ts
@@ -1,0 +1,14 @@
+export interface ClozeFeedbackProps {
+  isCorrect: boolean;
+  correctWord: string;
+  userAnswer: string;
+  translation: string;
+  sentence: string;
+  points: number;
+  newMastery: number;
+  previousMastery: number;
+  onNext: () => void;
+  onAddToAnki: () => void;
+  isAddingToAnki?: boolean;
+  ankiAdded?: boolean;
+}

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }

--- a/src/lib/sentence-bank.json
+++ b/src/lib/sentence-bank.json
@@ -22429,9 +22429,9 @@
   },
   {
     "id": 13368829,
-    "text": "Om goed vir geen goeie rede te breuk is 'n kinderagtige ding om te doen.",
+    "text": "Om goed vir geen goeie rede te breek is 'n kinderagtige ding om te doen.",
     "translation": "Breaking things for no good reason is a childish thing to do.",
-    "clozeWord": "breuk",
+    "clozeWord": "breek",
     "clozeIndex": 7,
     "wordRank": 1639,
     "collection": "top2000"


### PR DESCRIPTION
## Summary

A set of Practice-page improvements (on top of the cloze-feedback refactor in `6f1a8fa`): on-screen keyboard-shortcut hints, an optional hide-the-translation mode, the Clozemaster points formula, and a consolidation of the type/MC answer-handling code.

## Changes

- **Keyboard-shortcut hints (shadcn `kbd`)** — added the `kbd` component and contextual hint rows on the Practice page: `Enter` (check/submit), `1`–`4` (MC select), `Space` (listen), `Alt`+`T` (toggle translation), plus an `Enter` hint on the feedback screen.
- **Hide translation + `Alt+T` toggle** — new *Settings → Practice → Cloze settings* control to hide the English translation by default. `Alt+T` toggles it live during a round, and a "Show translation" affordance appears when hidden. Matched on `e.code === 'KeyT'` so macOS Option+T (which emits `†`) still works.
- **Freed up `Alt+T`** — Sonner's toast-focus hotkey defaulted to Alt+T and clashed with the toggle; moved it to Alt+N.
- **Clozemaster points formula** — `calculatePoints` is now `base × (mastery ÷ 25)`, base **8** for typed answers and **4** for multiple choice, using the mastery *reached* after the answer. The typed-answer hint penalty is preserved. Unit tests rewritten.
- **Unified answer handling** — extracted the duplicated type/MC logic into a single `recordAnswer()`; the two handlers now just determine correctness and delegate. The deliberate MC feedback delay (600 ms correct / 1200 ms wrong) that makes MC feel slower than typing is documented inline.

## Behaviour change

Points per correct answer change for everyone: a new word is now worth 8 (typed) / 4 (MC) instead of a flat 10, scaling up to 32 / 16 at mastery 100. No data migration needed.

## Testing

- `npm test` — Practice unit tests pass, including the rewritten `calculatePoints` cases. (The `dictionary-db` suite fails locally on a stale `better-sqlite3` native binding — environmental, unrelated to this diff; CI reinstalls/rebuilds it.)
- `npm run lint` — clean (0 errors).
- `tsc --noEmit` — clean.
- Verified the new Settings section and the Sonner hotkey change live on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
