### PR TITLE
Fix retired Anthropic model + per-task model config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,18 @@ ANTHROPIC_API_KEY=
 # Obtain via: claude setup-token
 CLAUDE_OAUTH_TOKEN=
 
+# Anthropic models. Use plain aliases (no date suffix) so they don't get retired
+# out from under you. ANTHROPIC_MODEL is the general default; the three per-task
+# vars below override it for specific jobs and fall back to it when unset:
+#   word translation    → high volume, single words — Haiku is cheap & fast
+#   phrase / in-context  → wants more nuance — Sonnet, or Opus if results need it
+#   chat (LLM tutor)     → Sonnet, or Opus for richer explanations
+# Per-task models are Anthropic-only for now; other providers use their single model.
+ANTHROPIC_MODEL=claude-sonnet-4-6
+# ANTHROPIC_WORD_MODEL=claude-haiku-4-5
+# ANTHROPIC_PHRASE_MODEL=claude-sonnet-4-6
+# ANTHROPIC_CHAT_MODEL=claude-sonnet-4-6
+
 # Google Cloud API key for TTS (optional)
 GOOGLE_CLOUD_API_KEY=
 

--- a/api/src/lib/llm/anthropic.test.ts
+++ b/api/src/lib/llm/anthropic.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { AnthropicProvider } from './anthropic';
+
+const ENV_KEYS = [
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_WORD_MODEL',
+  'ANTHROPIC_PHRASE_MODEL',
+  'ANTHROPIC_CHAT_MODEL',
+] as const;
+
+describe('AnthropicProvider model selection', () => {
+  let saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Snapshot then clear so each test starts from a known, env-free baseline.
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test('defaults every task to claude-sonnet-4-6 when nothing is configured', () => {
+    const p = new AnthropicProvider({ apiKey: 'test' });
+    expect(p.modelForTask()).toBe('claude-sonnet-4-6');
+    expect(p.modelForTask('word-translation')).toBe('claude-sonnet-4-6');
+    expect(p.modelForTask('phrase-translation')).toBe('claude-sonnet-4-6');
+    expect(p.modelForTask('chat')).toBe('claude-sonnet-4-6');
+  });
+
+  test('constructor options select the per-task model', () => {
+    const p = new AnthropicProvider({
+      apiKey: 'test',
+      model: 'claude-sonnet-4-6',
+      wordModel: 'claude-haiku-4-5',
+      phraseModel: 'claude-opus-4-8',
+      chatModel: 'claude-opus-4-8',
+    });
+    expect(p.modelForTask('word-translation')).toBe('claude-haiku-4-5');
+    expect(p.modelForTask('phrase-translation')).toBe('claude-opus-4-8');
+    expect(p.modelForTask('chat')).toBe('claude-opus-4-8');
+    expect(p.modelForTask()).toBe('claude-sonnet-4-6');
+  });
+
+  test('per-task env vars override the general default; unset tasks fall back', () => {
+    process.env.ANTHROPIC_MODEL = 'claude-sonnet-4-6';
+    process.env.ANTHROPIC_WORD_MODEL = 'claude-haiku-4-5';
+    const p = new AnthropicProvider({ apiKey: 'test' });
+    expect(p.modelForTask('word-translation')).toBe('claude-haiku-4-5');
+    expect(p.modelForTask('phrase-translation')).toBe('claude-sonnet-4-6');
+    expect(p.modelForTask('chat')).toBe('claude-sonnet-4-6');
+  });
+
+  test('explicit options beat env vars', () => {
+    process.env.ANTHROPIC_WORD_MODEL = 'from-env';
+    const p = new AnthropicProvider({ apiKey: 'test', wordModel: 'from-option' });
+    expect(p.modelForTask('word-translation')).toBe('from-option');
+  });
+
+  test('an unknown task falls back to the general default', () => {
+    const p = new AnthropicProvider({ apiKey: 'test', model: 'claude-sonnet-4-6' });
+    // @ts-expect-error — deliberately exercising the default branch
+    expect(p.modelForTask('something-else')).toBe('claude-sonnet-4-6');
+  });
+});

--- a/api/src/lib/llm/anthropic.ts
+++ b/api/src/lib/llm/anthropic.ts
@@ -1,16 +1,32 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { query } from '@anthropic-ai/claude-agent-sdk';
-import type { LLMProvider, CompletionOptions } from './types';
+import type { LLMProvider, CompletionOptions, LLMTask } from './types';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+// General-purpose default. Use a plain alias (no date suffix) so it doesn't get
+// retired out from under us the way a pinned snapshot does — that's exactly what
+// happened to the old `claude-sonnet-4-20250514`, which started 404-ing.
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+
+export interface AnthropicProviderOptions {
+  apiKey?: string;
+  oauthToken?: string;
+  /** General default model, used for any task without a more specific override. */
+  model?: string;
+  /** Single-word translation — high volume, cheap (e.g. claude-haiku-4-5). */
+  wordModel?: string;
+  /** Phrase / in-context translation — wants more nuance (e.g. sonnet/opus). */
+  phraseModel?: string;
+  /** LLM tutor chat. */
+  chatModel?: string;
+}
 
 export class AnthropicProvider implements LLMProvider {
   name = 'anthropic';
   private client: Anthropic | null = null;
-  private model: string;
+  private models: { default: string; word: string; phrase: string; chat: string };
   private useAgentSdk: boolean;
 
-  constructor(options?: { apiKey?: string; oauthToken?: string; model?: string }) {
+  constructor(options?: AnthropicProviderOptions) {
     const oauthToken =
       options?.oauthToken ||
       process.env.CLAUDE_CODE_OAUTH_TOKEN ||
@@ -32,19 +48,45 @@ export class AnthropicProvider implements LLMProvider {
       this.useAgentSdk = false;
       this.client = new Anthropic();
     }
-    this.model = options?.model || process.env.ANTHROPIC_MODEL || DEFAULT_MODEL;
+
+    // Per-task models fall back to the general default when their env var /
+    // option is unset, so the app works out of the box and you opt into a
+    // cheaper/smarter tier per task. TODO(backlog): surface these in the
+    // Settings UI and support per-task models for all providers, not just Anthropic.
+    const base = options?.model || process.env.ANTHROPIC_MODEL || DEFAULT_MODEL;
+    this.models = {
+      default: base,
+      word: options?.wordModel || process.env.ANTHROPIC_WORD_MODEL || base,
+      phrase: options?.phraseModel || process.env.ANTHROPIC_PHRASE_MODEL || base,
+      chat: options?.chatModel || process.env.ANTHROPIC_CHAT_MODEL || base,
+    };
+  }
+
+  /** Resolve which model to use for a given task (see CompletionOptions.task). */
+  modelForTask(task?: LLMTask): string {
+    switch (task) {
+      case 'word-translation':
+        return this.models.word;
+      case 'phrase-translation':
+        return this.models.phrase;
+      case 'chat':
+        return this.models.chat;
+      default:
+        return this.models.default;
+    }
   }
 
   async complete(options: CompletionOptions): Promise<string> {
+    const model = this.modelForTask(options.task);
     if (this.useAgentSdk) {
-      return this.completeViaAgentSdk(options);
+      return this.completeViaAgentSdk(options, model);
     }
-    return this.completeViaApi(options);
+    return this.completeViaApi(options, model);
   }
 
-  private async completeViaApi(options: CompletionOptions): Promise<string> {
+  private async completeViaApi(options: CompletionOptions, model: string): Promise<string> {
     const message = await this.client!.messages.create({
-      model: this.model,
+      model,
       max_tokens: options.maxTokens,
       messages: options.messages.map((m) => ({
         role: m.role as 'user' | 'assistant',
@@ -60,7 +102,7 @@ export class AnthropicProvider implements LLMProvider {
     return content.text;
   }
 
-  private async completeViaAgentSdk(options: CompletionOptions): Promise<string> {
+  private async completeViaAgentSdk(options: CompletionOptions, model: string): Promise<string> {
     // Build a single prompt from the messages
     const prompt = options.messages
       .map((m) => m.content)
@@ -71,7 +113,7 @@ export class AnthropicProvider implements LLMProvider {
     for await (const message of query({
       prompt,
       options: {
-        model: this.model,
+        model,
         maxTurns: 1,
         systemPrompt: options.messages.find(m => m.role === 'system')?.content || undefined,
         allowedTools: [],

--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -30,6 +30,9 @@ export function getProvider(): LLMProvider {
       const storedOauthToken = getSetting('claudeOauthToken') || undefined;
       const authMode = getSetting('anthropicAuthMode') as string | null;
       const model = process.env.ANTHROPIC_MODEL || undefined;
+      const wordModel = process.env.ANTHROPIC_WORD_MODEL || undefined;
+      const phraseModel = process.env.ANTHROPIC_PHRASE_MODEL || undefined;
+      const chatModel = process.env.ANTHROPIC_CHAT_MODEL || undefined;
 
       // Respect explicit auth mode; fall back to whichever credential is set
       let apiKey: string | undefined;
@@ -44,9 +47,9 @@ export function getProvider(): LLMProvider {
       }
 
       const effectiveMode = apiKey ? 'key' : oauthToken ? 'oauth' : 'env';
-      cacheKey = `anthropic:${effectiveMode}:${model || 'default'}`;
+      cacheKey = `anthropic:${effectiveMode}:${model || 'default'}:${wordModel || 'd'}:${phraseModel || 'd'}:${chatModel || 'd'}`;
       if (cachedProvider && cachedProviderKey === cacheKey) return cachedProvider;
-      cachedProvider = new AnthropicProvider({ apiKey, oauthToken, model });
+      cachedProvider = new AnthropicProvider({ apiKey, oauthToken, model, wordModel, phraseModel, chatModel });
       break;
     }
     case 'apfel': {
@@ -90,6 +93,9 @@ export function getAllProviders(): Record<string, LLMProvider> {
   const apiKey = getSetting('anthropicApiKey') || undefined;
   const oauthToken = getSetting('claudeOauthToken') || undefined;
   const anthropicModel = process.env.ANTHROPIC_MODEL || undefined;
+  const anthropicWordModel = process.env.ANTHROPIC_WORD_MODEL || undefined;
+  const anthropicPhraseModel = process.env.ANTHROPIC_PHRASE_MODEL || undefined;
+  const anthropicChatModel = process.env.ANTHROPIC_CHAT_MODEL || undefined;
 
   const apfelModel = getSetting('apfelModel') || process.env.APFEL_MODEL || undefined;
   const apfelUrl = getSetting('apfelUrl') || process.env.APFEL_URL || undefined;
@@ -101,7 +107,14 @@ export function getAllProviders(): Record<string, LLMProvider> {
   const lmstudioApiKey = getSetting('lmstudioApiKey') || process.env.LMSTUDIO_API_KEY || undefined;
 
   return {
-    claude: new AnthropicProvider({ apiKey, oauthToken, model: anthropicModel }),
+    claude: new AnthropicProvider({
+      apiKey,
+      oauthToken,
+      model: anthropicModel,
+      wordModel: anthropicWordModel,
+      phraseModel: anthropicPhraseModel,
+      chatModel: anthropicChatModel,
+    }),
     apfel: new ApfelProvider(apfelUrl, apfelModel),
     ollama: new OllamaProvider(undefined, ollamaModel),
     lmstudio: new LMStudioProvider({ baseUrl: lmstudioUrl, model: lmstudioModel, apiKey: lmstudioApiKey }),

--- a/api/src/lib/llm/types.ts
+++ b/api/src/lib/llm/types.ts
@@ -3,9 +3,19 @@ export interface ChatMessage {
   content: string;
 }
 
+/**
+ * What a completion is for, so a provider can pick a task-appropriate model.
+ * Only AnthropicProvider acts on this today (per-task model config); other
+ * providers ignore it and use their single configured model.
+ * TODO(backlog): generalise per-task model selection to all providers.
+ */
+export type LLMTask = 'word-translation' | 'phrase-translation' | 'chat';
+
 export interface CompletionOptions {
   messages: ChatMessage[];
   maxTokens: number;
+  /** Optional task hint for per-task model selection (Anthropic only for now). */
+  task?: LLMTask;
 }
 
 export interface LLMProvider {

--- a/api/src/routes/chat.ts
+++ b/api/src/routes/chat.ts
@@ -128,6 +128,7 @@ app.post('/', async (c) => {
       responseText = await provider.complete({
         messages: chatHistory,
         maxTokens: 1024,
+        task: 'chat',
       });
     }
 
@@ -189,7 +190,7 @@ async function runStatelessFallback(
     return { role: m.role as 'user' | 'assistant', content: m.content };
   });
 
-  return provider.complete({ messages: chatHistory, maxTokens: 1024 });
+  return provider.complete({ messages: chatHistory, maxTokens: 1024, task: 'chat' });
 }
 
 export default app;

--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -68,6 +68,7 @@ Be specific and concrete in idiomaticMeaning and usageNotes — avoid vague phra
       const text = await provider.complete({
         messages: [{ role: 'user', content: prompt }],
         maxTokens: 800,
+        task: 'phrase-translation',
       });
 
       return c.json(JSON.parse(text));
@@ -107,6 +108,7 @@ Backwards-compat fields the server adds (do NOT include these yourself — serve
       const text = await provider.complete({
         messages: [{ role: 'user', content: prompt }],
         maxTokens: 800,
+        task: 'word-translation',
       });
 
       const entry = JSON.parse(text);


### PR DESCRIPTION
## What

- **Fixes a hard 404.** The Anthropic provider's default model was the retired snapshot `claude-sonnet-4-20250514`. Switched to the **`claude-sonnet-4-6`** alias (no date suffix, so it won't be retired out from under us again).
- **Adds per-task model selection for Anthropic.** Different translation jobs can now use different model tiers, configured by env var:

| Env var | Used for | Default |
|---|---|---|
| `ANTHROPIC_MODEL` | general / fallback | `claude-sonnet-4-6` |
| `ANTHROPIC_WORD_MODEL` | single-word translation | → `ANTHROPIC_MODEL` |
| `ANTHROPIC_PHRASE_MODEL` | phrase / in-context translation | → `ANTHROPIC_MODEL` |
| `ANTHROPIC_CHAT_MODEL` | LLM tutor chat | → `ANTHROPIC_MODEL` |

Each per-task var falls back to `ANTHROPIC_MODEL` when unset, so **behaviour is unchanged unless you configure it** — the only default change is fixing the dead model. e.g. set `ANTHROPIC_WORD_MODEL=claude-haiku-4-5` to route single words through Haiku (cheap, high volume), and leave phrase/chat on Sonnet (or bump to Opus).

## How

- `CompletionOptions` gains an optional `task` hint (`'word-translation' | 'phrase-translation' | 'chat'`). `translate.ts` tags word vs. phrase lookups; `chat.ts` tags `chat`.
- Only `AnthropicProvider` acts on `task` (resolves it to the configured model via `modelForTask`); Ollama / Apfel / LMStudio ignore it and use their single model.
- Models resolve as `option → per-task env var → ANTHROPIC_MODEL → claude-sonnet-4-6`.

## Anthropic-only for now

Per-task routing is wired for Anthropic only, as requested. **Backlog** (marked `TODO(backlog)` in `types.ts` / `anthropic.ts`): surface these in the Settings UI and support per-task models for all providers.

## Testing

- New unit tests for model selection — `api/src/lib/llm/anthropic.test.ts` (defaults, per-task env overrides, option precedence, unknown-task fallback): **5/5 pass**.
- Full LLM provider suite green (35/35); `tsc` clean on all changed files.

## Test Plan

- [x] Retired model removed — default resolves to `claude-sonnet-4-6` (no more `claude-sonnet-4-20250514` 404) — [proof](https://github.com/heuwels/lector/pull/155#issuecomment-4726501071)
- [x] Per-task routing — `word` / `phrase` / `chat` resolve to their configured models — [proof](https://github.com/heuwels/lector/pull/155#issuecomment-4726501071)
- [x] Fallback — unset per-task vars fall back to `ANTHROPIC_MODEL`, then to the default — [proof](https://github.com/heuwels/lector/pull/155#issuecomment-4726501071)
- [x] Wiring — routes tag the correct `task`; resolved model is passed to the Anthropic call (API-key + Agent-SDK paths) — [proof](https://github.com/heuwels/lector/pull/155#issuecomment-4726501071)
- [x] Unit tests 5/5, LLM suite 35/35, `tsc` clean on changed files — [proof](https://github.com/heuwels/lector/pull/155#issuecomment-4726501071)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
