### PR TITLE
fix(practice): keep trailing punctuation outside the answer-reveal highlight

### DIFF
--- a/src/app/practice/components/Feedback/index.tsx
+++ b/src/app/practice/components/Feedback/index.tsx
@@ -88,17 +88,28 @@ export default function Feedback({
               <span key={i}>
                 {i > 0 && ' '}
                 {i === current.sentence.clozeIndex ? (
-                  <span
-                    data-testid="cloze-word"
-                    onClick={() => onWordClicked(word)}
-                    className={`cursor-pointer rounded px-1 font-bold ${
-                      feedbackData.isCorrect
-                        ? 'border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
-                        : 'border border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
-                    }`}
-                  >
-                    {word}
-                  </span>
+                  // Keep trailing punctuation outside the highlighted chip so a
+                  // sentence-final answer ("vriende.") doesn't show the period
+                  // inside the coloured box — matching the question screen.
+                  (() => {
+                    const [base, punct] = splitTrailingPunctuation(word);
+                    return (
+                      <>
+                        <span
+                          data-testid="cloze-word"
+                          onClick={() => onWordClicked(base)}
+                          className={`cursor-pointer rounded px-1 font-bold ${
+                            feedbackData.isCorrect
+                              ? 'border border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary'
+                              : 'border border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive'
+                          }`}
+                        >
+                          {base}
+                        </span>
+                        {punct}
+                      </>
+                    );
+                  })()
                 ) : (
                   <span
                     data-testid="cloze-word"


### PR DESCRIPTION
## Summary

On the cloze **answer-reveal** screen, the answer was re-rendered as the whole sentence token, so a sentence-final blank showed its trailing punctuation **inside** the coloured highlight chip — e.g. `[vriende.]` instead of `[vriende].`. The question screen never had this because it renders the punctuation outside the blank.

This splits the trailing punctuation off the highlighted answer in `Feedback/index.tsx` and renders it just after the chip, mirroring the question screen. Affects any sentence-final blank (`vriende.`, `wag?`, …), not just older cards.

## Before / after

```
before:  Ek en Sheila is ou [ vriende. ]
after:   Ek en Sheila is ou [ vriende ].
```

## Notes

- **Base is `various-fixes`, not `master`** — the `Feedback/index.tsx` component this touches was introduced on `various-fixes` (commit `6f1a8fa`) and doesn't exist on `master` yet, so this PR stacks on top of #154. Retarget to `master` once #154 lands.
- Matching/known-word logic is unaffected — this is purely how the answer is rendered. The visible punctuation still comes from the sentence, so nothing about stored `clozeWord` changes.
- No unit tests for the `Feedback` component (React-only; covered by the e2e suite). Lint and `tsc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
