### PR TITLE
Match curly apostrophes in word tokenizer (Afrikaans 'n)

### DIFF
--- a/src/components/MarkdownReader/utils.test.ts
+++ b/src/components/MarkdownReader/utils.test.ts
@@ -21,14 +21,13 @@ describe('splitWords', () => {
         expect(words('more is donker en moeilik')).toEqual(['more', 'is', 'donker', 'en', 'moeilik']);
     });
 
-    it('treats the Afrikaans n-article as one word (for the apostrophes the pattern supports)', () => {
-        // The shared pattern matches straight (U+0027) and modifier (U+02BC)
-        // apostrophes, not the curly U+2019 the importer often emits — that gap
-        // is a separate, intentionally-untouched follow-up.
-        const straight = String.fromCharCode(0x27);
-        const modifier = String.fromCharCode(0x02bc);
-        expect(words(`${straight}n hond`)).toEqual([`${straight}n`, 'hond']);
-        expect(words(`${modifier}n kat`)).toEqual([`${modifier}n`, 'kat']);
+    it('treats the Afrikaans n-article as one word across apostrophe variants', () => {
+        // straight ', curly (U+2018 / U+2019 — what the EPUB/HTML importer emits),
+        // and modifier (U+02BC) all count as the n-article's apostrophe.
+        for (const code of [0x27, 0x2018, 0x2019, 0x02bc]) {
+            const apos = String.fromCharCode(code);
+            expect(words(`${apos}n hond`)).toEqual([`${apos}n`, 'hond']);
+        }
     });
 });
 

--- a/src/components/MarkdownReader/utils.ts
+++ b/src/components/MarkdownReader/utils.ts
@@ -8,7 +8,7 @@ export function snapToWordBoundaries(selection: Selection): string {
     if (startContainer.nodeType === Node.TEXT_NODE) {
         const text = startContainer.textContent || '';
         let start = range.startOffset;
-        while (start > 0 && /[\wêëéèôöûüîïáà''ʼ`\-]/.test(text[start - 1])) {
+        while (start > 0 && /[\wêëéèôöûüîïáà'‘’ʼ`\-]/.test(text[start - 1])) {
             start--;
         }
         range.setStart(startContainer, start);
@@ -18,7 +18,7 @@ export function snapToWordBoundaries(selection: Selection): string {
     if (endContainer.nodeType === Node.TEXT_NODE) {
         const text = endContainer.textContent || '';
         let end = range.endOffset;
-        while (end < text.length && /[\wêëéèôöûüîïáà''ʼ`\-]/.test(text[end])) {
+        while (end < text.length && /[\wêëéèôöûüîïáà'‘’ʼ`\-]/.test(text[end])) {
             end++;
         }
         range.setEnd(endContainer, end);
@@ -30,7 +30,7 @@ export function snapToWordBoundaries(selection: Selection): string {
 // Matches a vocab "word": the Afrikaans 'n article, or a (possibly hyphenated)
 // run of letters including accented chars. Shared by the reader's tokenizer so
 // word indices line up between collection and rendering.
-export const WORD_PATTERN = /['''ʼ`]n\b|[\wêëéèôöûüîïáà]+(?:-[\wêëéèôöûüîïáà]+)*/gi;
+export const WORD_PATTERN = /['‘’ʼ`]n\b|[\wêëéèôöûüîïáà]+(?:-[\wêëéèôöûüîïáà]+)*/gi;
 
 export interface TextPart {
     text: string;


### PR DESCRIPTION
## What

Follow-up to #159. The reader's word tokenizer only matched **straight** (`'`, U+0027) and **modifier** (`ʼ`, U+02BC) apostrophes — but the EPUB/HTML importer emits **curly** quotes (U+2018 / U+2019). So a curly-apostrophe **`'n`** (the ubiquitous Afrikaans indefinite article) mis-tokenized: the apostrophe split off and only the bare `n` became a clickable, state-coloured word.

Added U+2018 + U+2019 to **both** apostrophe classes in `MarkdownReader/utils.ts`:
- `WORD_PATTERN` — so `'n` is a single word (one chip, click-to-translate the whole article).
- `snapToWordBoundaries` — so phrase selection snaps around `'n` correctly.

## Tests

- Unit (`utils.test.ts`): the n-article test now asserts **all four** apostrophe variants (straight, U+2018, U+2019, modifier) tokenize `'n` as one word. **10/10**, `tsc` clean.
- CI e2e (`reader-*` specs) exercises the tokenizer + phrase selection.

## Context

Follow-up to #159 (now merged), which extracted `WORD_PATTERN` into `utils.ts`. Targets `master`; the diff is just the apostrophe change (2 files).

## Test Plan

- [x] Curly `'n` (U+2019) renders as a single word chip, not `'` + bare `n` (before/after) — [proof](https://github.com/heuwels/lector/pull/163#issuecomment-4737070999)
- [x] All four apostrophe variants (straight / U+2018 / U+2019 / modifier) tokenize `'n` as one word — unit 10/10 — [proof](https://github.com/heuwels/lector/pull/163#issuecomment-4737070999)
- [x] CI green incl. e2e — no regression to straight-apostrophe reader specs — [proof](https://github.com/heuwels/lector/pull/163#issuecomment-4737070999)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
