### PR TITLE
feat(i18n): drive TTS, dictionary, Tatoeba & UI copy off the active language

### DIFF
--- a/api/src/routes/cloze.test.ts
+++ b/api/src/routes/cloze.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { db } from '../db';
+
+// The bundled sentence bank is Afrikaans content. Mock it down to a tiny
+// fixture so the test doesn't seed the full ~thousand-row bank.
+const FIXTURE_IDS = [9001, 9002];
+
+mock.module('../lib/sentence-bank.json', () => ({
+  default: [
+    {
+      id: 9001,
+      text: 'Die kat sit op die mat.',
+      translation: 'The cat sits on the mat.',
+      clozeWord: 'kat',
+      clozeIndex: 1,
+      wordRank: 50,
+      collection: 'top500',
+    },
+    {
+      id: 9002,
+      text: 'Ek drink water.',
+      translation: 'I drink water.',
+      clozeWord: 'water',
+      clozeIndex: 2,
+      wordRank: 120,
+      collection: 'top500',
+    },
+  ],
+}));
+
+const { default: app } = await import('../routes/cloze');
+
+function setActiveLanguage(code: string) {
+  db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)').run(
+    'targetLanguage',
+    JSON.stringify(code),
+  );
+}
+
+function reset() {
+  db.prepare(
+    `DELETE FROM clozeSentences WHERE tatoebaSentenceId IN (${FIXTURE_IDS.join(',')})`,
+  ).run();
+  db.prepare("DELETE FROM settings WHERE key = 'targetLanguage'").run();
+}
+
+describe('POST /api/cloze/seed — bank language', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test('labels seeded sentences as Afrikaans even when another language is active', async () => {
+    // Regression guard: seeding used to stamp rows with the active language,
+    // so seeding under German filled the German deck with Afrikaans sentences.
+    setActiveLanguage('de');
+
+    const res = await app.request('/seed', { method: 'POST' });
+    expect(res.status).toBe(200);
+
+    const rows = db
+      .prepare(
+        `SELECT language FROM clozeSentences WHERE tatoebaSentenceId IN (${FIXTURE_IDS.join(',')})`,
+      )
+      .all() as { language: string }[];
+    expect(rows.length).toBe(2);
+    expect(rows.every((r) => r.language === 'af')).toBe(true);
+  });
+});

--- a/api/src/routes/cloze.ts
+++ b/api/src/routes/cloze.ts
@@ -14,6 +14,10 @@ type BankEntry = {
   collection: string;
 };
 
+// The bundled sentence bank is Afrikaans content — always store its rows as
+// 'af' so seeding under another active language can't mislabel them.
+const SENTENCE_BANK_LANGUAGE = 'af';
+
 const app = new Hono();
 
 // GET /api/cloze
@@ -196,7 +200,7 @@ app.post('/seed', (c) => {
       insertStmt.run(
         randomUUID(), s.text, s.clozeWord, s.clozeIndex, s.translation,
         'tatoeba', s.collection, s.wordRank, s.id,
-        0, new Date().toISOString(), 0, 0, 0, resolveLanguage(c.req.query('language'))
+        0, new Date().toISOString(), 0, 0, 0, SENTENCE_BANK_LANGUAGE
       );
     }
     for (const s of toUpdate) {
@@ -210,8 +214,8 @@ app.post('/seed', (c) => {
 // GET /api/cloze/seed
 app.get('/seed', (c) => {
   const count = db.prepare(
-    'SELECT COUNT(*) as count FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL)'
-  ).get() as { count: number };
+    'SELECT COUNT(*) as count FROM clozeSentences WHERE language = ? AND (blacklisted = 0 OR blacklisted IS NULL)'
+  ).get(SENTENCE_BANK_LANGUAGE) as { count: number };
 
   return c.json({
     dbCount: count.count,

--- a/docs/multi-language-readiness.md
+++ b/docs/multi-language-readiness.md
@@ -1,0 +1,127 @@
+# Multi-language readiness audit
+
+_Scan for hardcoded Afrikaans assumptions that bypass the active-language abstraction._
+
+> **Status (this branch):** the **code de-hardcoding** items below are implemented —
+> browser TTS, Tatoeba, and the dictionary path/lookup are now driven off the active
+> language; the sentence-bank seeding mislabel bug is fixed; and the hardcoded
+> "Afrikaans" UI copy now uses the active language name. Still open (deliberately out
+> of scope here): the data-partitioning items (`dailyStats` Next routes, `collection_groups`)
+> and all non-Afrikaans **content** (de/es dictionaries, per-language sentence banks).
+
+## Verdict
+
+**The data/wiring path is genuinely multi-language ready; the gaps are concentrated in (a) a handful of code paths that still hardcode `af`/`afr`/`af-ZA`, and (b) the absence of content for any language other than Afrikaans.**
+
+Switching language already works end-to-end: `LanguageSelector` writes both the SQLite `targetLanguage` setting and the `lector-target-language` localStorage key, `SetupGuard` reconciles them on boot, `data-layer.ts` threads `?language=`/`language:` into nearly every request, and every Bun API route resolves it via `resolveLanguage()`. Cloze, vocab, known-words, journal and collections rows are all tagged with the language at write time, so the **core data model partitions by language**. (Two tables are exceptions — daily-activity stats and collection groups; see Known issues.)
+
+**Single biggest blocker:** there is no content for de/es. The curated dictionary is a hardcoded `dictionary-af.db`, and the cloze **sentence bank is Afrikaans-only with no language field** — yet the seeder stamps each sentence with the *active* language, so seeding under German would fill the German deck with Afrikaans sentences mislabeled `de`. De-hardcoding the strings is the easy half; producing per-language dictionaries and sentence banks is the real work.
+
+---
+
+## Already done (the abstraction exists and is used)
+
+| Area | Evidence |
+|---|---|
+| Language registry (af/de/es) with tts/tatoeba codes, avoid-words, test phrase | `src/lib/languages.ts`, `api/src/lib/languages.ts` |
+| Active-language resolution (setting + per-request override) | `api/src/lib/active-language.ts`, `src/lib/server/active-language.ts` (`resolveLanguage`, `getActiveLanguageCode`) |
+| Language switch persists to **both** stores | `LanguageSelector/index.tsx:37-38`, `setup/page.tsx:22-23` |
+| Boot reconciliation (server setting → localStorage) | `SetupGuard/index.tsx:26-35` |
+| Request threading (`?language=` / body `language`) | `data-layer.ts` `langParam()` (line 16-18), used on ~all calls |
+| Bun routes all resolve language | `explain/cloze/stats/collections/chat/journal-correct/vocab/translate.ts` |
+| LLM prompts use `${langName}`, spelreels gated by language | `api/src/routes/translate.ts:39-79` (`lang === 'af' ? getSpelreelsContext() : ''`) |
+| Translate caller passes language explicitly | `src/lib/claude.ts:38,62` |
+| Google/server TTS passes language | `src/lib/tts.ts:179` |
+
+> Next.js `src/app/api/*` LLM routes (translate, explain, …) are **thin proxies** to the Bun server and forward the body verbatim — they don't need their own `resolveLanguage`, so their absence from the abstraction is expected, not a gap.
+
+---
+
+## Blockers — code (hardcoded `af` despite active language)
+
+### 1. Browser TTS is Afrikaans-only
+`src/lib/tts.ts` — the **Google/server TTS mode is language-aware** (passes `language` at line 179), but the **browser fallback mode is fully hardcoded**:
+- `const AFRIKAANS_LANG = 'af-ZA'` (line 9), `FALLBACK_LANGS = ['af','nl-NL','nl']` (line 12)
+- `scoreVoice` (line 85-86), `getAfrikaansVoice()`, candidate `allLangs` (line 123) all assume af/Dutch
+- **Fix:** drive voice selection from `LANGUAGES[activeLang].ttsCode` + `.fallbackTts` (both already exist in the registry).
+
+### 2. Tatoeba sentence fetch is hardcoded to Afrikaans
+`src/app/api/tatoeba/route.ts:63` — `from: 'afr'`; the route never reads a language param.
+- **Fix:** read `language`, use `LANGUAGES[lang].tatoebaCode` (registry already has `afr`/`deu`/`spa`).
+
+### 3. Curated dictionary path is hardcoded
+`src/lib/server/dictionary-db.ts:22` — `return path.join(dir, 'dictionary-af.db')`.
+- **Fix:** `dictionary-${activeLang}.db`. (This is also a content blocker — see below.)
+
+---
+
+## Blockers — content (code can be made ready, but de/es content is missing)
+
+### 4. No dictionary for de/es
+Only `dictionary-af.db` exists; built by `scripts/build-dictionary.ts`. Needs `dictionary-de.db` / `dictionary-es.db`, plus the path fix (#3).
+
+### 5. Sentence bank is Afrikaans-only and mislabels on seed ⚠️
+`src/lib/sentence-bank.json` (656 KB, symlinked to `api/src/lib/sentence-bank.json`) is a **flat list with no `language` field** — all Afrikaans.
+- `cloze/seed/route.ts:55` (and the Bun `cloze.ts` seeder) insert every entry with `resolveLanguage()` = the *currently active* language. Seeding while German is active → Afrikaans sentences stored as `language='de'`.
+- The `needsSeed` check (`seed/route.ts:69-78`) counts all cloze rows regardless of language.
+- **Fix:** per-language banks (e.g. `sentence-bank-<code>.json`) or a `language` field per entry, and seed only the active language's entries.
+
+### 6. Spelling rules (spelreels) are Afrikaans-only — *graceful, not blocking*
+`api/src/lib/afrikaans-spelreels/` is af-specific and **already correctly gated** (`lang === 'af'`), so de/es simply get no spelling-rule context. A parity gap to fill eventually, not a blocker.
+
+---
+
+## Cosmetic — UI copy hardcodes "Afrikaans" (wrong, but non-breaking)
+
+| File | What |
+|---|---|
+| `src/app/journal/page.tsx:163` | Placeholder is literally Afrikaans: _"Skryf vandag se joernaal inskrywing in Afrikaans…"_ |
+| `src/components/ChatWidget/index.tsx:310` | _"Ask about Afrikaans…"_ |
+| `src/components/ChatWidget/constants.ts:8` | Suggested prompt _"How do diminutives work in Afrikaans?"_ |
+| `src/components/PasteImportModal/index.tsx:150` | _"Paste your Afrikaans text here…"_ |
+| `src/components/WebImportModal/components/UrlInputStep/index.tsx:74` | _"…Afrikaans news article…"_ |
+| `src/app/vocab/page.tsx:38-39,85-87` | Anki deck defaults `'Afrikaans'` / `'Afrikaans::Cloze'` + auto-detect `'afrikaans'` |
+| `src/app/practice/constants.ts:4` | `DEFAULT_ANKI_CLOZE_DECK = 'Afrikaans::Cloze'` |
+| `src/app/settings/components/Export/index.tsx:22,33,45` | Export filenames `afrikaans-vocab.csv` etc. |
+| `src/components/ClozeFeedback/index.tsx:42` | Fallback `|| 'af'` (minor — prefer the registry default) |
+
+**Fix pattern:** pull the display name from `useActiveLanguage().native` and namespace Anki decks/filenames by the active language.
+
+---
+
+## Known issues — tables not partitioned by language
+
+### A. Library groups (confirmed — the gap you flagged)
+The `collection_groups` table has **no `language` column**; `groups/route.ts` GET/POST and `data-layer` `getAllGroups`/`createGroup` are language-blind. Collections themselves carry a language, but their parent groups are global — so groups (and any collection-to-group assignment) leak across languages.
+
+### B. Daily-activity stats — half-applied migration ⚠️
+`dailyStats` **was migrated** to a composite key `PRIMARY KEY (date, language)` (`database.ts:541-563`, backfilling existing rows as `'af'`), and the **Bun** stats routes honor it via `resolveLanguage()`. But the **live path is the Next.js routes**, and they were never updated to match:
+- `recordStudyPing()` (`translate/route.ts:9-13`) and `stats/today` PUT/GET (`stats/today/route.ts`) `INSERT INTO dailyStats (date, …)` **without `language`** → every study ping lands under the default `'af'`, regardless of active language, and reads use `WHERE date = ?` alone.
+- `stats/streak` (`stats/streak/route.ts`) aggregates **all** languages — this one is *intentional* (CLAUDE.md: "one streak definition app-wide"), so leave it, but note streak/heatmap are deliberately cross-language.
+
+So today's counters, date-range stats and the heatmap are effectively pinned to `'af'` on the live path. **Two decisions:** (1) make the Next.js write/read paths language-aware to match the schema + Bun routes, and (2) confirm whether streak/heatmap *should* stay global (currently yes) or go per-language.
+
+---
+
+## Maintenance / watch-list (not blockers)
+
+- **Registry duplication:** `src/lib/languages.ts` and `api/src/lib/languages.ts` are two full copies of `LANGUAGES` that must be kept in sync (same mirroring rule as `dates`/`streak` in CLAUDE.md). `src/constants/languages.ts` is just a 3-line `DEFAULT_LANGUAGE` re-export; `src/types/language.ts` holds the canonical types.
+- **Tokenization assumptions:** `src/lib/words.ts:13`, `src/lib/definition-links.ts:46`, `src/components/MarkdownReader/utils.ts:30` special-case the Afrikaans `'n` article and Latin diacritics. The `'n` handling is harmless for other languages; verify the diacritic char-class covers German `ß` and Spanish `ñ`/`¿`/`¡` before relying on it.
+
+---
+
+## Benign — leave alone (correct as-is)
+
+- One-time migrations: DB filename `afrikaans.db → lector.db` (`database.ts:9,23`, `api/db.ts:10,22`); localStorage keys `afrikaans-reader-* → lector-*` (`layout.tsx:40`).
+- Anki backward-compat tag `tag:afrikaans-reader` OR-clause (`anki.ts:261,264`).
+- Registry entries `name: 'Afrikaans'` (correct), comments, and `*.test.ts` fixtures.
+
+---
+
+## Suggested order of work
+
+1. **Registry-drive the three code blockers** (TTS browser mode, Tatoeba code, dictionary path) — small, mechanical, unblocks the engine.
+2. **Fix the sentence-bank seeding** (#5) — it's a latent data-corruption bug the moment anyone seeds under a non-af language, independent of whether content exists yet.
+3. **Finish the per-language data partitioning:** make the Next.js `dailyStats` read/write paths language-aware (the schema + Bun routes already are), and add `language` to `collection_groups`.
+4. **Sweep the cosmetic copy** via `useActiveLanguage().native`.
+5. **Produce content** (dictionaries, per-language sentence banks, optional spelling rules) — the long pole.

--- a/e2e/journal.spec.ts
+++ b/e2e/journal.spec.ts
@@ -95,7 +95,7 @@ test.describe("Journal", () => {
 
     await page.getByRole("button", { name: "New Entry" }).click();
 
-    await expect(page.getByPlaceholder(/skryf vandag/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/journal entry in/i)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Save Draft" })
     ).toBeVisible();
@@ -110,7 +110,7 @@ test.describe("Journal", () => {
 
     await page.getByRole("button", { name: "New Entry" }).click();
 
-    const textarea = page.getByPlaceholder(/skryf vandag/i);
+    const textarea = page.getByPlaceholder(/journal entry in/i);
     await textarea.fill("Ek het vandag geoefen.");
     await page.getByRole("button", { name: "Save Draft" }).click();
 
@@ -153,7 +153,7 @@ test.describe("Journal", () => {
 
     // Clicking a draft should open the editor
     await page.getByText("Gister ek het na die stoor gaan.").first().click();
-    await expect(page.getByPlaceholder(/skryf vandag/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/journal entry in/i)).toBeVisible();
 
     await page.request.delete(`/api/journal/${id}`);
   });
@@ -192,7 +192,7 @@ test.describe("Journal", () => {
     await page.getByRole("button", { name: "New Entry" }).click();
 
     await page
-      .getByPlaceholder(/skryf vandag/i)
+      .getByPlaceholder(/journal entry in/i)
       .fill("Gister ek het na die stoor gaan. Ek het koop baie dinge.");
 
     // 2. Save as draft
@@ -212,7 +212,7 @@ test.describe("Journal", () => {
 
     // 5. Click draft to edit
     await page.getByText("Gister ek het na die stoor gaan.").first().click();
-    await expect(page.getByPlaceholder(/skryf vandag/i)).toHaveValue(
+    await expect(page.getByPlaceholder(/journal entry in/i)).toHaveValue(
       "Gister ek het na die stoor gaan. Ek het koop baie dinge."
     );
 

--- a/src/app/api/cloze/seed/route.ts
+++ b/src/app/api/cloze/seed/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/server/database';
-import { resolveLanguage } from '@/lib/server/active-language';
 import { randomUUID } from 'crypto';
 import sentenceBank from '@/lib/sentence-bank.json';
+
+// The bundled sentence bank is Afrikaans content, so its rows are always
+// stored as 'af' — regardless of the active language. Seeding while another
+// language is active must not mislabel these sentences as that language.
+const SENTENCE_BANK_LANGUAGE = 'af';
 
 type BankEntry = {
   id: number;
@@ -52,7 +56,7 @@ export async function POST() {
       insertStmt.run(
         randomUUID(), s.text, s.clozeWord, s.clozeIndex, s.translation,
         'tatoeba', s.collection, s.wordRank, s.id,
-        0, new Date().toISOString(), 0, 0, 0, resolveLanguage()
+        0, new Date().toISOString(), 0, 0, 0, SENTENCE_BANK_LANGUAGE
       );
     }
     for (const s of toUpdate) {
@@ -68,8 +72,8 @@ export async function POST() {
 // GET /api/cloze/seed - Check if seeding is needed
 export async function GET() {
   const count = db.prepare(
-    'SELECT COUNT(*) as count FROM clozeSentences WHERE (blacklisted = 0 OR blacklisted IS NULL)'
-  ).get() as { count: number };
+    'SELECT COUNT(*) as count FROM clozeSentences WHERE language = ? AND (blacklisted = 0 OR blacklisted IS NULL)'
+  ).get(SENTENCE_BANK_LANGUAGE) as { count: number };
 
   return NextResponse.json({
     dbCount: count.count,

--- a/src/app/api/dictionary/lookup/route.ts
+++ b/src/app/api/dictionary/lookup/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/server/database';
 import { lookupWord } from '@/lib/server/dictionary-db';
+import { resolveLanguage } from '@/lib/server/active-language';
 
 /**
  * GET /api/dictionary/lookup?word=<word>
@@ -36,7 +37,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Word is required' }, { status: 400 });
     }
 
-    const entry = lookupWord(word.trim());
+    const lang = resolveLanguage(request.nextUrl.searchParams.get('language'));
+    const entry = lookupWord(word.trim(), lang);
     if (entry) recordStudyPing();
 
     return NextResponse.json({ entry: entry ?? null });

--- a/src/app/api/tatoeba/route.ts
+++ b/src/app/api/tatoeba/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import https from 'node:https';
+import { LANGUAGES } from '@/lib/languages';
+import { resolveLanguage } from '@/lib/server/active-language';
 
 interface TatoebaApiSentence {
   id: number;
@@ -58,9 +60,10 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const limit = searchParams.get('limit') || '20';
   const query = searchParams.get('query');
+  const lang = resolveLanguage(searchParams.get('language'));
 
   const params = new URLSearchParams({
-    from: 'afr',
+    from: LANGUAGES[lang].tatoebaCode,
     to: 'eng',
     sort: query ? 'relevance' : 'random',
     limit: Math.min(parseInt(limit), 100).toString(),

--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -15,8 +15,10 @@ import HistoryCard from './components/HistoryCard';
 import { formatDate } from './utils';
 import { Button } from '@/components/ui/button';
 import PageHeader from '@/components/PageHeader';
+import { useActiveLanguage } from '@/utils/hooks';
 
 export default function JournalPage() {
+  const activeLang = useActiveLanguage();
   const [bodyText, setBodyText] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -160,7 +162,7 @@ export default function JournalPage() {
             <textarea
               value={bodyText}
               onChange={(e) => handleBodyChange(e.target.value)}
-              placeholder="Skryf vandag se joernaal inskrywing in Afrikaans..."
+              placeholder={`Write today's journal entry in ${activeLang.native}...`}
               className="min-h-[160px] w-full resize-y rounded-lg border border-input bg-background p-4 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
               disabled={isSubmitting}
               autoFocus

--- a/src/app/practice/components/Feedback/index.tsx
+++ b/src/app/practice/components/Feedback/index.tsx
@@ -6,9 +6,10 @@ import { Button } from '@/components/ui/button';
 import ClozeFeedback from '@/components/ClozeFeedback';
 import { splitTrailingPunctuation } from '@/lib/words';
 import { addClozeCard } from '@/lib/anki';
-import { ANKI_CLOZE_DECK_SETTING_KEY, DEFAULT_ANKI_CLOZE_DECK } from '../../constants';
+import { ANKI_CLOZE_DECK_SETTING_KEY } from '../../constants';
 import { CurrentSentence, IFeedbackData } from '../../types';
 import { isTTSAvailable, speak } from '@/lib/tts';
+import { useActiveLanguage } from '@/utils/hooks';
 
 export default function Feedback({
   feedbackData,
@@ -21,6 +22,7 @@ export default function Feedback({
   onWordClicked: (word: string) => void;
   onNext: () => void;
 }) {
+  const activeLang = useActiveLanguage();
   const [isAddingToAnki, setIsAddingToAnki] = useState(false);
   const [ankiAdded, setAnkiAdded] = useState(false);
 
@@ -37,7 +39,8 @@ export default function Feedback({
 
     setIsAddingToAnki(true);
     try {
-      const deckName = localStorage.getItem(ANKI_CLOZE_DECK_SETTING_KEY) || DEFAULT_ANKI_CLOZE_DECK;
+      const deckName =
+        localStorage.getItem(ANKI_CLOZE_DECK_SETTING_KEY) || `${activeLang.native}::Cloze`;
 
       const cleanWord = splitTrailingPunctuation(current.sentence.clozeWord)[0];
       await addClozeCard(

--- a/src/app/practice/constants.ts
+++ b/src/app/practice/constants.ts
@@ -1,7 +1,6 @@
 import { ClozeCollection } from "@/types";
 
 export const ANKI_CLOZE_DECK_SETTING_KEY = 'lector-anki-cloze-deck';
-export const DEFAULT_ANKI_CLOZE_DECK = 'Afrikaans::Cloze';
 export const ROUND_SIZES = [10, 20, 30, 40, 50] as const;
 
 

--- a/src/app/settings/components/Export/index.tsx
+++ b/src/app/settings/components/Export/index.tsx
@@ -1,9 +1,14 @@
 import { Button } from '@/components/ui/button';
 import { getAllKnownWords, getAllVocab } from '@/lib/data-layer';
 import { downloadFile } from '@/utils/browser';
+import { useActiveLanguage } from '@/utils/hooks';
 import { toast } from 'sonner';
 
 export default function Export() {
+  const activeLang = useActiveLanguage();
+  // ASCII slug for filenames, e.g. "afrikaans" / "german" / "spanish".
+  const slug = activeLang.name.toLowerCase();
+
   const notifyError = (error: Error | unknown) => {
     toast.error(`Export failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
   };
@@ -19,7 +24,7 @@ export default function Export() {
         ),
       ].join('\n');
 
-      downloadFile(csv, 'afrikaans-vocab.csv', 'text/csv');
+      downloadFile(csv, `${slug}-vocab.csv`, 'text/csv');
       toast.success('Vocab exported as CSV.');
     } catch (error) {
       notifyError(error);
@@ -30,7 +35,7 @@ export default function Export() {
     try {
       const vocab = await getAllVocab();
       const json = JSON.stringify(vocab, null, 2);
-      downloadFile(json, 'afrikaans-vocab.json', 'application/json');
+      downloadFile(json, `${slug}-vocab.json`, 'application/json');
       toast.success('Vocab exported as JSON.');
     } catch (error) {
       notifyError(error);
@@ -42,7 +47,7 @@ export default function Export() {
       const knownWords = await getAllKnownWords();
       const words = knownWords.filter((w) => w.state === 'known').map((w) => w.word);
       const text = words.join('\n');
-      downloadFile(text, 'afrikaans-known-words.txt', 'text/plain');
+      downloadFile(text, `${slug}-known-words.txt`, 'text/plain');
       toast.success(`Exported ${words.length} known words.`);
     } catch (error) {
       notifyError(error);

--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -24,8 +24,10 @@ import VocabStats from './components/VocabStats';
 import VocabDetailModal from './components/VocabDetailModal';
 import { toast } from 'sonner';
 import PageHeader from '@/components/PageHeader';
+import { useActiveLanguage } from '@/utils/hooks';
 
 export default function VocabPage() {
+  const activeLang = useActiveLanguage();
   const [entries, setEntries] = useState<VocabEntry[]>([]);
   const [collections, setCollections] = useState<Collection[]>([]);
   const [stats, setStats] = useState<{
@@ -35,8 +37,8 @@ export default function VocabPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [selectedEntry, setSelectedEntry] = useState<VocabEntry | null>(null);
   const [ankiConnected, setAnkiConnected] = useState<boolean | null>(null);
-  const [ankiDeck, setAnkiDeck] = useState('Afrikaans');
-  const [ankiClozeDeck, setAnkiClozeDeck] = useState('Afrikaans::Cloze');
+  const [ankiDeck, setAnkiDeck] = useState(activeLang.native);
+  const [ankiClozeDeck, setAnkiClozeDeck] = useState(`${activeLang.native}::Cloze`);
 
   useEffect(() => {
     loadData();
@@ -82,9 +84,14 @@ export default function VocabPage() {
         // Only auto-select a deck if the user hasn't saved a preference
         const savedDeck = localStorage.getItem('lector-anki-deck');
         if (!savedDeck) {
-          const afrikaansDeck = decks.find((d) => d.toLowerCase().includes('afrikaans'));
-          if (afrikaansDeck) {
-            setAnkiDeck(afrikaansDeck);
+          const langNative = activeLang.native.toLowerCase();
+          const langName = activeLang.name.toLowerCase();
+          const matchedDeck = decks.find((d) => {
+            const dl = d.toLowerCase();
+            return dl.includes(langNative) || dl.includes(langName);
+          });
+          if (matchedDeck) {
+            setAnkiDeck(matchedDeck);
           } else if (decks.length > 0 && decks[0] !== 'Default') {
             setAnkiDeck(decks[0]);
           }

--- a/src/components/ChatWidget/index.tsx
+++ b/src/components/ChatWidget/index.tsx
@@ -307,7 +307,7 @@ export default function ChatWidget() {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
-                placeholder="Ask about Afrikaans..."
+                placeholder={`Ask about ${activeLang.native}...`}
                 rows={1}
                 className="flex-1 rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
                 disabled={loading}

--- a/src/components/ClozeFeedback/index.tsx
+++ b/src/components/ClozeFeedback/index.tsx
@@ -7,6 +7,7 @@ import { Kbd } from '@/components/ui/kbd';
 import { ClozeFeedbackProps } from './types';
 import { toast } from 'sonner';
 import Markdown from 'react-markdown';
+import { getActiveLanguage } from '@/lib/data-layer';
 
 export default function ClozeFeedback({
   isCorrect,
@@ -39,7 +40,7 @@ export default function ClozeFeedback({
           sentence,
           translation,
           clozeWord: correctWord,
-          language: localStorage.getItem('lector-target-language') || 'af',
+          language: getActiveLanguage(),
         }),
       });
       if (!res.ok) throw new Error();

--- a/src/components/PasteImportModal/index.tsx
+++ b/src/components/PasteImportModal/index.tsx
@@ -4,9 +4,11 @@ import { X } from 'lucide-react';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
+import { useActiveLanguage } from '@/utils/hooks';
 import type { PasteImportModalProps } from './types';
 
 export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImportModalProps) {
+  const activeLang = useActiveLanguage();
   const modalRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLInputElement>(null);
   const [title, setTitle] = useState('');
@@ -147,7 +149,7 @@ export default function PasteImportModal({ isOpen, onClose, onSave }: PasteImpor
               value={content}
               onChange={(e) => setContent(e.target.value)}
               disabled={isSaving}
-              placeholder="Paste your Afrikaans text here..."
+              placeholder={`Paste your ${activeLang.native} text here...`}
               rows={12}
               className="w-full resize-none rounded-lg border border-input bg-background px-4 py-3 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none disabled:opacity-50"
             />

--- a/src/components/WebImportModal/components/UrlInputStep/index.tsx
+++ b/src/components/WebImportModal/components/UrlInputStep/index.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, Ref } from 'react';
 import { Button } from '@/components/ui/button';
+import { useActiveLanguage } from '@/utils/hooks';
 
 export default function UrlInputStep({
   url,
@@ -20,6 +21,7 @@ export default function UrlInputStep({
   onRetry: () => void;
   inputRef: Ref<HTMLInputElement>;
 }) {
+  const activeLang = useActiveLanguage();
   return (
     <div className="space-y-4">
       <div>
@@ -71,8 +73,8 @@ export default function UrlInputStep({
       )}
 
       <p className="text-sm text-muted-foreground">
-        Paste a URL to an Afrikaans news article or blog post. The article content will be extracted
-        and added to your library.
+        Paste a URL to a news article or blog post in {activeLang.native}. The article content will be
+        extracted and added to your library.
       </p>
     </div>
   );

--- a/src/lib/__tests__/dictionary-db.test.ts
+++ b/src/lib/__tests__/dictionary-db.test.ts
@@ -31,7 +31,7 @@ describe('dictionary-db', () => {
 
   describe('exact match', () => {
     test('finds a top-frequency root word', () => {
-      const entry = lookupWord('die');
+      const entry = lookupWord('die', 'af');
       expect(entry).toBeDefined();
       expect(entry!.word).toBe('die');
       expect(entry!.lemmaInfo).toBeUndefined();
@@ -41,13 +41,13 @@ describe('dictionary-db', () => {
     });
 
     test('case-insensitive', () => {
-      const entry = lookupWord('Die');
+      const entry = lookupWord('Die', 'af');
       expect(entry).toBeDefined();
       expect(entry!.word).toBe('die');
     });
 
     test('curated frequency rank survives kaikki merge', () => {
-      const entry = lookupWord('en');
+      const entry = lookupWord('en', 'af');
       expect(entry).toBeDefined();
       // "en" is rank 2 in dictionary-roots.json — must not be overwritten by kaikki
       expect(entry!.rank).toBe(2);
@@ -58,7 +58,7 @@ describe('dictionary-db', () => {
     test('bedink found via be- prefix on dink (lemmaInfo populated)', () => {
       // "bedink" (to consider) is not a kaikki entry on its own — it's reached
       // by stripping the be- prefix and finding "dink" (to think) as the stem.
-      const entry = lookupWord('bedink');
+      const entry = lookupWord('bedink', 'af');
       expect(entry).toBeDefined();
       expect(entry!.lemmaInfo).toBeDefined();
       expect(entry!.lemmaInfo!.stem).toBe('dink');
@@ -71,7 +71,7 @@ describe('dictionary-db', () => {
       // Worth pinning: in the legacy JSON dict "verstaan" was reached via the
       // ver- prefix on "staan". Kaikki has "verstaan" as a standalone entry,
       // so we now serve it directly — no lemmaInfo, and we get multiple senses.
-      const entry = lookupWord('verstaan');
+      const entry = lookupWord('verstaan', 'af');
       expect(entry).toBeDefined();
       expect(entry!.lemmaInfo).toBeUndefined();
       expect(entry!.senses.length).toBeGreaterThan(1);
@@ -80,7 +80,7 @@ describe('dictionary-db', () => {
 
   describe('suffix derivation', () => {
     test('katte resolves to the kat lemma', () => {
-      const entry = lookupWord('katte');
+      const entry = lookupWord('katte', 'af');
       expect(entry).toBeDefined();
       // kaikki has a dedicated "katte" page whose only gloss is "plural of kat".
       // Either way the lookup must reach an entry that points back at "kat".
@@ -92,7 +92,7 @@ describe('dictionary-db', () => {
     test('manne (plural of man) found via inflections table only', () => {
       // "manne" is in the inflections table but NOT in entries — so this test
       // pins the inflections-table lookup path (step 2).
-      const entry = lookupWord('manne');
+      const entry = lookupWord('manne', 'af');
       expect(entry).toBeDefined();
       expect(entry!.lemmaInfo).toBeDefined();
       expect(entry!.lemmaInfo!.stem).toBe('man');
@@ -104,17 +104,17 @@ describe('dictionary-db', () => {
 
   describe('miss', () => {
     test('returns undefined for nonsense', () => {
-      expect(lookupWord('xyzzyx')).toBeUndefined();
+      expect(lookupWord('xyzzyx', 'af')).toBeUndefined();
     });
 
     test('returns undefined for a word that does not appear anywhere', () => {
-      expect(lookupWord('blargleblarg')).toBeUndefined();
+      expect(lookupWord('blargleblarg', 'af')).toBeUndefined();
     });
   });
 
   describe('multi-sense words', () => {
     test('pond exposes multiple senses (currency, weight)', () => {
-      const entry = lookupWord('pond');
+      const entry = lookupWord('pond', 'af');
       expect(entry).toBeDefined();
       expect(entry!.senses.length).toBeGreaterThanOrEqual(2);
       const currency = entry!.senses.some((s) => /currency|pound/i.test(s.gloss));
@@ -124,7 +124,7 @@ describe('dictionary-db', () => {
     });
 
     test('word (to become) has more than one sense', () => {
-      const entry = lookupWord('word');
+      const entry = lookupWord('word', 'af');
       expect(entry).toBeDefined();
       expect(entry!.senses.length).toBeGreaterThanOrEqual(2);
     });
@@ -132,7 +132,7 @@ describe('dictionary-db', () => {
 
   describe('schema fields', () => {
     test('exposes partOfSpeech on each sense', () => {
-      const entry = lookupWord('staan');
+      const entry = lookupWord('staan', 'af');
       expect(entry).toBeDefined();
       for (const s of entry!.senses) {
         expect(typeof s.partOfSpeech).toBe('string');
@@ -143,10 +143,18 @@ describe('dictionary-db', () => {
 
     test('returns ipa for words that have one in kaikki', () => {
       // "word" carries /vɔrt/ in the dump — we picked the first IPA value.
-      const entry = lookupWord('word');
+      const entry = lookupWord('word', 'af');
       expect(entry).toBeDefined();
       expect(entry!.ipa).toBeDefined();
       expect(entry!.ipa).toMatch(/[\[\/]/);
+    });
+  });
+
+  describe('language selection', () => {
+    test('does not serve Afrikaans entries for a language with no dictionary', () => {
+      // Only dictionary-af.db ships here. A German lookup of an Afrikaans word
+      // must miss (→ undefined) rather than fall through to the Afrikaans data.
+      expect(lookupWord('die', 'de')).toBeUndefined();
     });
   });
 });

--- a/src/lib/dictionary-client.ts
+++ b/src/lib/dictionary-client.ts
@@ -21,9 +21,10 @@ export interface ExpandedDictionaryEntry {
 }
 
 /**
- * In-memory session cache. Map of lowercase word → entry (or null for misses).
- * Cleared on page reload — there's no persistence so memory pressure is bounded
- * by how many distinct words the user looks up in one session (typically <500).
+ * In-memory session cache. Map of `${language}:${lowercase word}` → entry (or
+ * null for misses) — keyed by language so the same word in different target
+ * languages doesn't collide. Cleared on page reload, so memory is bounded by
+ * how many distinct words the user looks up in one session (typically <500).
  */
 const sessionCache = new Map<string, ExpandedDictionaryEntry | null>();
 
@@ -46,10 +47,17 @@ export async function lookupWordRemote(word: string): Promise<ExpandedDictionary
   return entry;
 }
 
-/** Drop a single cached entry (call after editing the dict to force a re-fetch). */
+/** Drop a single cached entry (call after editing the dict to force a re-fetch).
+ *  Keys are `${language}:${word}`, so invalidate the word across every language. */
 export function invalidateLookupCache(word?: string): void {
-  if (word === undefined) sessionCache.clear();
-  else sessionCache.delete(word.toLowerCase());
+  if (word === undefined) {
+    sessionCache.clear();
+    return;
+  }
+  const suffix = `:${word.toLowerCase()}`;
+  for (const key of sessionCache.keys()) {
+    if (key.endsWith(suffix)) sessionCache.delete(key);
+  }
 }
 
 export interface CacheAcceptedTranslationInput {

--- a/src/lib/dictionary-client.ts
+++ b/src/lib/dictionary-client.ts
@@ -1,10 +1,12 @@
 /**
  * Client-side dictionary lookup. Calls /api/dictionary/lookup, which queries
- * the SQLite Afrikaans dictionary built by scripts/build-dictionary.ts.
+ * the SQLite dictionary for the active language (built by
+ * scripts/build-dictionary.ts).
  *
  * Returns the rich entry shape on a hit, or null on a miss — callers should
  * fall back to the AI translate API when null.
  */
+import { getActiveLanguage } from './data-layer';
 
 export interface ExpandedDictionaryEntry {
   word: string;
@@ -26,12 +28,13 @@ export interface ExpandedDictionaryEntry {
 const sessionCache = new Map<string, ExpandedDictionaryEntry | null>();
 
 export async function lookupWordRemote(word: string): Promise<ExpandedDictionaryEntry | null> {
-  const key = word.toLowerCase();
+  const language = getActiveLanguage();
+  const key = `${language}:${word.toLowerCase()}`;
   if (sessionCache.has(key)) {
     return sessionCache.get(key) ?? null;
   }
 
-  const url = `/api/dictionary/lookup?word=${encodeURIComponent(word)}`;
+  const url = `/api/dictionary/lookup?word=${encodeURIComponent(word)}&language=${language}`;
   const res = await fetch(url);
   if (!res.ok) {
     // Don't cache transport errors — let the next click retry.

--- a/src/lib/server/dictionary-db.ts
+++ b/src/lib/server/dictionary-db.ts
@@ -2,24 +2,26 @@ import Database, { Database as DatabaseType } from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { db as userDb } from './database';
+import { getActiveLanguageCode } from './active-language';
 
 /**
- * Read-only SQLite-backed Afrikaans dictionary.
+ * Read-only SQLite-backed bilingual dictionary, selected by the active language.
  *
  * Built by `scripts/build-dictionary.ts` from the kaikki.org Wiktionary dump
  * (merged with the hand-curated ranks in `src/lib/dictionary-roots.json`).
  * This module mirrors the lookup algorithm in `src/lib/dictionary.ts` —
  * exact → inflections → prefix derivation → suffix derivation → affix-strip
  * fallback — but exposes the richer multi-sense schema available from kaikki.
+ * The affix-strip heuristics are Afrikaans-specific and only run for `af`.
  */
 
 // The dictionary is read-only application data shipped with the image.
 // Prefer DICT_DIR so it stays put when the user mounts a volume on DATA_DIR
 // for their (mutable) collections/vocab data. Fall back to DATA_DIR for local
 // dev (where the build script writes here) and finally to ./data.
-function getDbPath(): string {
+function getDbPath(language: string): string {
   const dir = process.env.DICT_DIR || process.env.DATA_DIR || './data';
-  return path.join(dir, 'dictionary-af.db');
+  return path.join(dir, `dictionary-${language}.db`);
 }
 
 // ---------------------------------------------------------------------------
@@ -44,28 +46,39 @@ export interface ExpandedDictionaryEntry {
 // Lazy connection (mirrors src/lib/server/database.ts pattern)
 // ---------------------------------------------------------------------------
 
-let _db: DatabaseType | null = null;
+// Connections are cached per language so switching the active language opens
+// the right dictionary (the Next.js server process is long-lived). A cached
+// `null` records "no dict file for this language" so we don't re-stat on every
+// lookup.
+const _dbs = new Map<string, DatabaseType | null>();
 
-function getDb(): DatabaseType | null {
-  if (_db) return _db;
-  if (!fs.existsSync(getDbPath())) {
+function getDb(language: string): DatabaseType | null {
+  const cached = _dbs.get(language);
+  if (cached !== undefined) return cached;
+
+  const dbPath = getDbPath(language);
+  if (!fs.existsSync(dbPath)) {
     // The dictionary DB is optional at runtime — callers fall back to the
     // legacy JSON dict + the AI translate API when this file isn't present.
+    _dbs.set(language, null);
     return null;
   }
-  _db = new Database(getDbPath(), { readonly: true, fileMustExist: true });
-  _db.pragma('journal_mode = WAL');
-  return _db;
+  const conn = new Database(dbPath, { readonly: true, fileMustExist: true });
+  conn.pragma('journal_mode = WAL');
+  _dbs.set(language, conn);
+  return conn;
 }
 
-// Exposed as a proxy so consumers can `import { dictDb }` and the DB opens
-// lazily on first access — same shape as `db` in src/lib/server/database.ts.
+// Exposed as a proxy so consumers can `import { dictDb }` and the active
+// language's DB opens lazily on first access — same shape as `db` in
+// src/lib/server/database.ts.
 export const dictDb = new Proxy({} as DatabaseType, {
   get(_target, prop) {
-    const real = getDb();
+    const language = getActiveLanguageCode();
+    const real = getDb(language);
     if (!real) {
       throw new Error(
-        `Dictionary database not found at ${getDbPath()}. ` +
+        `Dictionary database not found at ${getDbPath(language)}. ` +
           `Run \`npx tsx scripts/build-dictionary.ts\` to build it.`,
       );
     }
@@ -124,19 +137,21 @@ type Stmts = {
   selectInflectionLemma: ReturnType<DatabaseType['prepare']>;
 };
 
-let _stmts: Stmts | null = null;
+const _stmtsByLang = new Map<string, Stmts>();
 
-function getStmts(): Stmts | null {
-  if (_stmts) return _stmts;
-  const db = getDb();
+function getStmts(language: string): Stmts | null {
+  const cached = _stmtsByLang.get(language);
+  if (cached) return cached;
+  const db = getDb(language);
   if (!db) return null;
-  _stmts = {
+  const stmts: Stmts = {
     selectEntry: db.prepare('SELECT word, rank, ipa, etymology FROM entries WHERE word = ?'),
     selectSenses: db.prepare('SELECT pos, gloss FROM senses WHERE word = ? ORDER BY sort_order'),
     selectRelated: db.prepare('SELECT related_word, relation FROM related_forms WHERE word = ?'),
     selectInflectionLemma: db.prepare('SELECT lemma, type FROM inflections WHERE inflected_form = ? LIMIT 1'),
   };
-  return _stmts;
+  _stmtsByLang.set(language, stmts);
+  return stmts;
 }
 
 interface EntryRow {
@@ -196,10 +211,13 @@ interface CachedEntryRow {
   etymology: string | null;
 }
 
-function lookupCached(word: string): ExpandedDictionaryEntry | undefined {
+function lookupCached(word: string, language: string): ExpandedDictionaryEntry | undefined {
+  // Filter by language so a cached entry learned in one language isn't served
+  // for another. (cached_entries.word is the PK, so only one language's entry
+  // per word is retained — a stricter per-language cache needs a schema change.)
   const row = userDb
-    .prepare('SELECT word, ipa, etymology FROM cached_entries WHERE word = ?')
-    .get(word) as CachedEntryRow | undefined;
+    .prepare('SELECT word, ipa, etymology FROM cached_entries WHERE word = ? AND language = ?')
+    .get(word, language) as CachedEntryRow | undefined;
   if (!row) return undefined;
 
   const senses = userDb
@@ -291,11 +309,14 @@ export function cacheAcceptedEntry(input: CacheAcceptedInput): string | null {
 // lookupWord — exact → inflections → prefix → suffix → affix-strip fallback
 // ---------------------------------------------------------------------------
 
-export function lookupWord(word: string): ExpandedDictionaryEntry | undefined {
+export function lookupWord(
+  word: string,
+  language: string = getActiveLanguageCode(),
+): ExpandedDictionaryEntry | undefined {
   const lower = word.toLowerCase();
-  const stmts = getStmts();
+  const stmts = getStmts(language);
 
-  // Curated kaikki dict — only available if data/dictionary-af.db is present.
+  // Curated kaikki dict — only available if data/dictionary-<lang>.db is present.
   if (stmts) {
     // 1. Exact match
     const exact = stmts.selectEntry.get(lower) as EntryRow | undefined;
@@ -311,33 +332,38 @@ export function lookupWord(word: string): ExpandedDictionaryEntry | undefined {
       }
     }
 
-    // 3. Known prefix → exact stem
-    for (const prefix of PREFIXES) {
-      if (!lower.startsWith(prefix)) continue;
-      const stem = lower.slice(prefix.length);
-      if (stem.length < MIN_STEM) continue;
-      const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
-      if (stemRow) {
-        return buildEntry(stemRow, stmts, lower, { stem, label: PREFIX_LABELS[prefix] });
-      }
-    }
-
-    // 4. Known suffix → exact stem (with consonant undoubling)
-    for (const suffix of SUFFIXES) {
-      if (!lower.endsWith(suffix)) continue;
-      const stem = lower.slice(0, -suffix.length);
-      if (stem.length < MIN_STEM) continue;
-
-      const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
-      if (stemRow) {
-        return buildEntry(stemRow, stmts, lower, { stem, label: SUFFIX_LABELS[suffix] });
+    // Steps 3-4 use Afrikaans-specific affix morphology (PREFIXES / SUFFIXES /
+    // consonant undoubling). Only apply them for Afrikaans — running them
+    // against another language's dictionary would mis-derive stems.
+    if (language === 'af') {
+      // 3. Known prefix → exact stem
+      for (const prefix of PREFIXES) {
+        if (!lower.startsWith(prefix)) continue;
+        const stem = lower.slice(prefix.length);
+        if (stem.length < MIN_STEM) continue;
+        const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
+        if (stemRow) {
+          return buildEntry(stemRow, stmts, lower, { stem, label: PREFIX_LABELS[prefix] });
+        }
       }
 
-      const undoubled = undoubleConsonant(stem);
-      if (undoubled && undoubled.length >= MIN_STEM) {
-        const uRow = stmts.selectEntry.get(undoubled) as EntryRow | undefined;
-        if (uRow) {
-          return buildEntry(uRow, stmts, lower, { stem: undoubled, label: SUFFIX_LABELS[suffix] });
+      // 4. Known suffix → exact stem (with consonant undoubling)
+      for (const suffix of SUFFIXES) {
+        if (!lower.endsWith(suffix)) continue;
+        const stem = lower.slice(0, -suffix.length);
+        if (stem.length < MIN_STEM) continue;
+
+        const stemRow = stmts.selectEntry.get(stem) as EntryRow | undefined;
+        if (stemRow) {
+          return buildEntry(stemRow, stmts, lower, { stem, label: SUFFIX_LABELS[suffix] });
+        }
+
+        const undoubled = undoubleConsonant(stem);
+        if (undoubled && undoubled.length >= MIN_STEM) {
+          const uRow = stmts.selectEntry.get(undoubled) as EntryRow | undefined;
+          if (uRow) {
+            return buildEntry(uRow, stmts, lower, { stem: undoubled, label: SUFFIX_LABELS[suffix] });
+          }
         }
       }
     }
@@ -347,7 +373,7 @@ export function lookupWord(word: string): ExpandedDictionaryEntry | undefined {
   //    Lives behind the curated dict so the kaikki entry always wins, but in
   //    front of the AI translate fallback so previously-seen words don't pay
   //    for the LLM round-trip again.
-  const cached = lookupCached(lower);
+  const cached = lookupCached(lower, language);
   if (cached) return cached;
 
   return undefined;

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -1,15 +1,24 @@
 // Text-to-Speech wrapper
 // Uses Google Cloud TTS when available, falls back to browser TTS
 import { getActiveLanguage } from './data-layer';
+import { LANGUAGES, DEFAULT_LANGUAGE, type LanguageCode } from './languages';
 
 // Default speech rate (1.0 is normal speed)
 const DEFAULT_RATE = 0.9;
 
-// Afrikaans language code
-const AFRIKAANS_LANG = 'af-ZA';
+// Resolve the active language's TTS config. Browser-TTS voice selection is
+// driven entirely off this, so switching the target language picks an
+// appropriate voice instead of always assuming Afrikaans.
+function activeLangConfig() {
+  return LANGUAGES[getActiveLanguage() as LanguageCode] ?? LANGUAGES[DEFAULT_LANGUAGE];
+}
 
-// Fallback languages if Afrikaans is not available
-const FALLBACK_LANGS = ['af', 'nl-NL', 'nl']; // Dutch is somewhat similar
+// Accepted langs for the active language, most-specific first — e.g.
+// af → ['af-ZA', 'af', 'nl-NL', 'nl']; de → ['de-DE', 'de'].
+function candidateLangs(): string[] {
+  const config = activeLangConfig();
+  return [config.ttsCode, config.code, ...config.fallbackTts];
+}
 
 // Preferred voice name patterns (higher quality voices)
 const PREFERRED_VOICE_PATTERNS = [/google/i, /premium/i, /enhanced/i, /natural/i, /neural/i];
@@ -81,19 +90,20 @@ function scoreVoice(voice: SpeechSynthesisVoice): number {
     }
   }
 
-  // Prefer exact language match
-  if (voice.lang === AFRIKAANS_LANG) score += 3;
-  if (voice.lang.startsWith('af')) score += 2;
+  // Prefer exact language match for the active language
+  const primaryLang = activeLangConfig().ttsCode;
+  if (voice.lang === primaryLang) score += 3;
+  if (voice.lang.startsWith(primaryLang.split('-')[0])) score += 2;
 
   return score;
 }
 
 /**
- * Get the best available voice for Afrikaans (browser TTS)
- * Caches the result for consistent voice selection
+ * Get the best available voice for the active language (browser TTS).
+ * Caches the result for consistent voice selection.
  * @returns The voice to use, or undefined if none found
  */
-function getAfrikaansVoice(): SpeechSynthesisVoice | undefined {
+function getActiveLanguageVoice(): SpeechSynthesisVoice | undefined {
   if (!isTTSAvailable()) {
     return undefined;
   }
@@ -108,22 +118,25 @@ function getAfrikaansVoice(): SpeechSynthesisVoice | undefined {
     return undefined;
   }
 
-  // Check for user's saved preference
+  const allLangs = candidateLangs();
+  const matchesActiveLang = (v: SpeechSynthesisVoice) =>
+    allLangs.some((lang) => v.lang === lang || v.lang.startsWith(lang.split('-')[0]));
+
+  // Check for user's saved preference — but only reuse it if it still matches
+  // the active language. The saved name is global, so an Afrikaans voice must
+  // not be reused after the user switches the target language to German.
   const savedVoiceName = localStorage.getItem(VOICE_PREF_KEY);
   if (savedVoiceName) {
     const savedVoice = voices.find((v) => v.name === savedVoiceName);
-    if (savedVoice) {
+    if (savedVoice && matchesActiveLang(savedVoice)) {
       cachedVoice = savedVoice;
       voiceInitialized = true;
       return cachedVoice;
     }
   }
 
-  // Find all candidate voices (Afrikaans or Dutch)
-  const allLangs = [AFRIKAANS_LANG, 'af', ...FALLBACK_LANGS];
-  const candidateVoices = voices.filter((v) =>
-    allLangs.some((lang) => v.lang === lang || v.lang.startsWith(lang.split('-')[0])),
-  );
+  // Find all candidate voices for the active language (+ fallbacks)
+  const candidateVoices = voices.filter(matchesActiveLang);
 
   if (candidateVoices.length === 0) {
     voiceInitialized = true;
@@ -216,14 +229,14 @@ function speakWithBrowser(text: string, rate: number): void {
 
   const utterance = new SpeechSynthesisUtterance(text);
 
-  // Set the voice (try Afrikaans, fall back to Dutch)
-  const voice = getAfrikaansVoice();
+  // Set the voice for the active language (falls back per the registry)
+  const voice = getActiveLanguageVoice();
   if (voice) {
     utterance.voice = voice;
     utterance.lang = voice.lang;
   } else {
     // Set language even without a specific voice
-    utterance.lang = AFRIKAANS_LANG;
+    utterance.lang = activeLangConfig().ttsCode;
   }
 
   // Set speech parameters
@@ -270,8 +283,8 @@ export function stopSpeaking(): void {
 }
 
 /**
- * Get available voices for Afrikaans or Dutch (browser TTS)
- * Useful for debugging or letting users choose a voice
+ * Get available voices for the active language (+ fallbacks) for browser TTS.
+ * Useful for debugging or letting users choose a voice.
  * @returns Array of available voices
  */
 export function getAvailableVoices(): SpeechSynthesisVoice[] {
@@ -280,7 +293,7 @@ export function getAvailableVoices(): SpeechSynthesisVoice[] {
   }
 
   const voices = window.speechSynthesis.getVoices();
-  const relevantLangs = [AFRIKAANS_LANG, ...FALLBACK_LANGS];
+  const relevantLangs = candidateLangs();
 
   return voices.filter((v) =>
     relevantLangs.some((lang) => v.lang === lang || v.lang.startsWith(lang.split('-')[0])),
@@ -303,7 +316,7 @@ export function waitForVoices(): Promise<SpeechSynthesisVoice[]> {
       const voices = window.speechSynthesis.getVoices();
       // Pre-initialize the voice cache
       if (voices.length > 0 && !voiceInitialized) {
-        getAfrikaansVoice();
+        getActiveLanguageVoice();
       }
       resolve(voices);
     };


### PR DESCRIPTION
## What & why

Removes hardcoded Afrikaans assumptions that bypassed the active-language abstraction, so adding German/Spanish becomes a matter of **content** rather than **code**. Scope is the code de-hardcoding + the one seeding bug; data-partitioning and de/es content are deliberately out of scope (see #173).

Motivated by the readiness audit added here as `docs/multi-language-readiness.md`.

## Changes

**Code (hardcoded `af`/`afr`/`af-ZA` → active language)**
- **Browser TTS** (`src/lib/tts.ts`): voices selected from the active language's `ttsCode`/`fallbackTts` (registry) instead of hardcoded `af-ZA`/Dutch. Also: a saved voice preference is only reused when it matches the active language (an Afrikaans voice is no longer reused after switching to German). Google/server TTS was already language-aware.
- **Dictionary** (`src/lib/server/dictionary-db.ts`, `dictionary/lookup` route, `dictionary-client.ts`): `dictionary-${lang}.db` path; connections + prepared statements cached **per language** (long-lived server process); language threaded through the route and client; Afrikaans-specific affix heuristics gated to `af`; on-device AI-cache lookup filtered by language.
- **Tatoeba** (`tatoeba/route.ts`): uses the registry `tatoebaCode` instead of `'afr'`.

**Bug fix — sentence-bank seeding**
- The bundled sentence bank is Afrikaans content, but seeding stamped each row with the *active* language — so seeding under German filled the German cloze deck with Afrikaans sentences mislabeled `de`. Now always labels rows `'af'`, in **both** the Next and Bun seed routes.

**UI copy (8 spots)**
- Journal / chat / import placeholders, Anki deck defaults + auto-detect, and export filenames now use the active language's name instead of "Afrikaans".

## Tests

- **Bun** (`api/src/routes/cloze.test.ts`): regression test — seeded rows stay `'af'` even when German is the active language.
- **vitest** (`src/lib/__tests__/dictionary-db.test.ts`): language-isolation test — a `de` lookup does not serve Afrikaans entries; existing calls made explicit (`'af'`).

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors |
| `npm test` (vitest) | 139 pass¹ |
| `bun run test` (api) | 53 pass |
| `npm run build` | compiled successfully |

¹ The pre-existing `dictionary-db > bedink` test fails only against a **locally-built** dict (`data/` is gitignored; `bedink` is now a direct entry, so step-1 returns before the prefix heuristic — behaviorally identical with/without this PR's `af` gate). CI fetches the pinned dict.

## Test plan

Verified against the running app (Next :3456 + Bun api :3457); proof in PR comments.

- [x] UI copy (journal + chat placeholders) follows the active language, dynamically across de/es — [proof](https://github.com/heuwels/lector/pull/174#issuecomment-4751141937)
- [x] Dictionary lookup is per-language (`af` hits, `es` gracefully misses — no Afrikaans leakage) — [proof](https://github.com/heuwels/lector/pull/174#issuecomment-4751143708)
- [x] Sentence-bank seeding always labels rows `'af'` under any active language — Bun regression test `api/src/routes/cloze.test.ts`
- [ ] Browser TTS voice selection (registry-driven) — not browser-provable headlessly (no system voices); covered by the `tts.ts` refactor + code review

## Safety note

The new `lookupCached` language filter is safe for existing users: the `cached_entries.language` column is `NOT NULL DEFAULT 'af'` (SQLite backfills on `ADD COLUMN`), verified 0 NULL/empty rows on a real `lector.db`.

## Follow-up

- #173 — finish data partitioning (`dailyStats` Next routes + `collection_groups`) and the streak/heatmap global-vs-per-language decision.
- de/es dictionary + sentence-bank **content** (no code blockers remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

