### PR TITLE
fix(llm): drop response_format so JSON works on LM Studio

### DIFF
--- a/api/src/lib/llm/index.ts
+++ b/api/src/lib/llm/index.ts
@@ -4,6 +4,7 @@ import { OpenAICompatibleProvider } from './openai-compatible';
 import { db } from '../../db';
 
 export type { LLMProvider, ChatMessage, CompletionOptions } from './types';
+export { parseLooseJson } from './parse-json';
 
 let cachedProvider: LLMProvider | null = null;
 let cachedProviderKey: string | null = null;

--- a/api/src/lib/llm/openai-compatible.test.ts
+++ b/api/src/lib/llm/openai-compatible.test.ts
@@ -71,7 +71,7 @@ describe('OpenAICompatibleProvider', () => {
       expect(result).toBe('hello back');
     });
 
-    test('does NOT send response_format unless responseFormat is "json"', async () => {
+    test('never sends response_format in text mode', async () => {
       globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
         const body = JSON.parse(init?.body as string);
         expect(body.response_format).toBeUndefined();
@@ -82,10 +82,13 @@ describe('OpenAICompatibleProvider', () => {
       await provider.complete({ messages: [{ role: 'user', content: 'Hi' }], maxTokens: 10 });
     });
 
-    test('requests JSON mode when responseFormat is "json"', async () => {
+    // JSON is prompt-driven, not enforced via response_format: no value works
+    // across all backends (LM Studio 400s on json_object; Ollama ignores
+    // json_schema), so we never send it and read the text back with parseLooseJson.
+    test('does NOT send response_format even when responseFormat is "json"', async () => {
       globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
         const body = JSON.parse(init?.body as string);
-        expect(body.response_format).toEqual({ type: 'json_object' });
+        expect(body.response_format).toBeUndefined();
         return new Response(JSON.stringify({ choices: [{ message: { content: '{"ok":true}' } }] }), { status: 200 });
       }) as unknown as typeof fetch;
 

--- a/api/src/lib/llm/openai-compatible.ts
+++ b/api/src/lib/llm/openai-compatible.ts
@@ -53,11 +53,14 @@ export class OpenAICompatibleProvider implements LLMProvider {
       messages: options.messages,
       max_tokens: options.maxTokens,
     };
-    // Only constrain the output when the caller will JSON.parse it. Verified that
-    // Ollama, LM Studio, and Apfel all honor OpenAI JSON mode on /v1.
-    if (options.responseFormat === 'json') {
-      body.response_format = { type: 'json_object' };
-    }
+    // We deliberately do NOT set response_format. No value works across every
+    // OpenAI-compatible backend: LM Studio 400s on `json_object` (it wants
+    // `json_schema` or `text`), while Ollama silently ignores `json_schema` and
+    // only does structured output via its own native `format` field. The only
+    // universally-safe path is prompt-driven JSON — callers that need it instruct
+    // "ONLY a JSON object, no markdown" and parse with parseLooseJson(). This
+    // mirrors AnthropicProvider, which also relies on the prompt. So
+    // options.responseFormat is intentionally not acted on here.
 
     const response = await this.fetchWithTimeout(`${this.baseUrl}/v1/chat/completions`, {
       method: 'POST',

--- a/api/src/lib/llm/parse-json.test.ts
+++ b/api/src/lib/llm/parse-json.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test';
+import { parseLooseJson } from './parse-json';
+
+describe('parseLooseJson', () => {
+  test('parses plain JSON', () => {
+    expect(parseLooseJson<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  test('parses with surrounding whitespace', () => {
+    expect(parseLooseJson<{ a: number }>('  \n {"a":1}\n ')).toEqual({ a: 1 });
+  });
+
+  test('strips a ```json fence', () => {
+    expect(parseLooseJson<{ a: number }>('```json\n{"a":1}\n```')).toEqual({ a: 1 });
+  });
+
+  test('strips a bare ``` fence', () => {
+    expect(parseLooseJson<{ a: number }>('```\n{"a":1}\n```')).toEqual({ a: 1 });
+  });
+
+  test('extracts an object from surrounding prose', () => {
+    expect(parseLooseJson<{ a: number }>('Sure! Here you go: {"a":1} Hope that helps.')).toEqual({ a: 1 });
+  });
+
+  test('keeps nested objects intact via the outermost span', () => {
+    expect(parseLooseJson<{ a: { b: number } }>('prefix {"a":{"b":2}} suffix')).toEqual({ a: { b: 2 } });
+  });
+
+  test('parses a top-level array', () => {
+    expect(parseLooseJson<number[]>('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  test('strips a <think> reasoning block before the JSON', () => {
+    // The think block contains braces on purpose — naive span extraction would
+    // slice from inside it and fail.
+    const raw = '<think>The user wants {a:1}; I will return {"a":1}</think>\n{"a":1}';
+    expect(parseLooseJson<{ a: number }>(raw)).toEqual({ a: 1 });
+  });
+
+  test('strips a <think> block even before a fenced payload', () => {
+    const raw = '<think>hmm { } braces</think>\n```json\n{"a":1}\n```';
+    expect(parseLooseJson<{ a: number }>(raw)).toEqual({ a: 1 });
+  });
+
+  test('handles a realistic fenced translation payload', () => {
+    const raw = '```json\n{"word":"loop","senses":[{"partOfSpeech":"noun","gloss":"walk"}]}\n```';
+    expect(parseLooseJson<{ word: string; senses: Array<{ partOfSpeech: string; gloss: string }> }>(raw)).toEqual({
+      word: 'loop',
+      senses: [{ partOfSpeech: 'noun', gloss: 'walk' }],
+    });
+  });
+
+  test('throws a clear error on non-JSON', () => {
+    expect(() => parseLooseJson('not json at all')).toThrow('Model did not return valid JSON');
+  });
+
+  test('throws a clear error on empty string', () => {
+    expect(() => parseLooseJson('')).toThrow('Model did not return valid JSON');
+  });
+
+  test('throws when the brace span is not valid JSON', () => {
+    expect(() => parseLooseJson('text { not: valid } more')).toThrow('Model did not return valid JSON');
+  });
+});

--- a/api/src/lib/llm/parse-json.ts
+++ b/api/src/lib/llm/parse-json.ts
@@ -1,0 +1,42 @@
+/**
+ * Parse JSON returned by an LLM.
+ *
+ * We can't rely on server-side JSON mode: no `response_format` value works
+ * across every OpenAI-compatible backend (LM Studio 400s on `json_object` and
+ * wants `json_schema`; Ollama silently ignores `json_schema` and only does
+ * structured output via its native `format` field). So every JSON caller asks
+ * for JSON in the prompt instead — and real models add wrappers around it:
+ *   - reasoning models (DeepSeek-R1 distills, Qwen3, common in LM Studio) emit a
+ *     <think>…</think> block first, usually containing braces;
+ *   - chat-tuned models wrap output in a ```json fence or a sentence of preamble.
+ * This strips those before parsing, then falls back to extracting the outermost
+ * {...} or [...] span.
+ */
+export function parseLooseJson<T = unknown>(text: string): T {
+  // 1. Drop reasoning <think>…</think> blocks first — their braces would
+  //    otherwise derail the span extraction in step 3.
+  const thinkless = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+  // 2. Strip a surrounding ```json … ``` (or bare ``` … ```) fence.
+  const fence = thinkless.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/i);
+  const unfenced = (fence ? fence[1] : thinkless).trim();
+
+  // 3. Try parsing the cleaned text as-is.
+  try {
+    return JSON.parse(unfenced) as T;
+  } catch {
+    // 4. Fall back to the outermost object/array span, dropping any prose the
+    //    model added on either side.
+    const first = unfenced.search(/[[{]/);
+    const last = Math.max(unfenced.lastIndexOf('}'), unfenced.lastIndexOf(']'));
+    if (first !== -1 && last > first) {
+      try {
+        return JSON.parse(unfenced.slice(first, last + 1)) as T;
+      } catch {
+        // fall through to the shared error below
+      }
+    }
+    const preview = text.length > 120 ? `${text.slice(0, 120)}…` : text;
+    throw new Error(`Model did not return valid JSON. Got: ${JSON.stringify(preview)}`);
+  }
+}

--- a/api/src/lib/llm/types.ts
+++ b/api/src/lib/llm/types.ts
@@ -17,10 +17,13 @@ export interface CompletionOptions {
   /** Optional task hint for per-task model selection (Anthropic only for now). */
   task?: LLMTask;
   /**
-   * Whether the caller needs a structured JSON object back. Routes that
-   * `JSON.parse()` the result (translate, journal-correct) pass 'json' so the
-   * provider requests OpenAI JSON mode; prose callers (explain, chat) leave it
-   * 'text'. Defaults to 'text' — providers only constrain the format on demand.
+   * Hint that the caller will JSON.parse() the result (translate and
+   * journal-correct pass 'json'; prose callers like explain/chat leave it
+   * 'text'). Providers do NOT turn this into a server-side JSON-mode flag: no
+   * response_format value works across all backends (LM Studio rejects
+   * json_object, Ollama ignores json_schema), so JSON is enforced by the prompt
+   * and read back with parseLooseJson(). Kept as a hint for possible future
+   * per-provider handling.
    */
   responseFormat?: 'json' | 'text';
 }

--- a/api/src/routes/journal-correct.ts
+++ b/api/src/routes/journal-correct.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { getProvider } from '../lib/llm';
+import { getProvider, parseLooseJson } from '../lib/llm';
 import { resolveLanguage } from '../lib/active-language';
 import { getLanguageConfig } from '../lib/languages';
 
@@ -43,7 +43,7 @@ Keep explanations concise (1-2 sentences) and educational.`,
       responseFormat: 'json',
     });
 
-    const result = JSON.parse(text);
+    const result = parseLooseJson<Record<string, unknown>>(text);
     return c.json(result);
   } catch (error) {
     console.error('Journal correction error:', error);

--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { getProvider } from '../lib/llm';
+import { getProvider, parseLooseJson } from '../lib/llm';
 import { getSpelreelsContext } from '../lib/spelreels';
 import { resolveLanguage } from '../lib/active-language';
 import { getLanguageConfig } from '../lib/languages';
@@ -72,7 +72,7 @@ Be specific and concrete in idiomaticMeaning and usageNotes — avoid vague phra
         responseFormat: 'json',
       });
 
-      return c.json(JSON.parse(text));
+      return c.json(parseLooseJson<Record<string, unknown>>(text));
     } else {
       const prompt = `You are a ${langName} to English translator with deep knowledge of ${langName} orthography, morphology, and etymology.
 
@@ -113,7 +113,13 @@ Backwards-compat fields the server adds (do NOT include these yourself — serve
         responseFormat: 'json',
       });
 
-      const entry = JSON.parse(text);
+      const entry = parseLooseJson(text) as {
+        word?: string;
+        senses?: Array<{ partOfSpeech: string; gloss: string }>;
+        ipa?: string;
+        etymology?: string;
+        relatedForms?: Array<{ form: string; relation: string }>;
+      };
 
       // Stitch legacy fields so existing call sites that only read translation +
       // partOfSpeech don't have to change.


### PR DESCRIPTION
## Problem

Translating against a hosted **LM Studio** backend fails with:

```
LLM provider error: {"error":"'response_format.type' must be 'json_schema' or 'text'"}
```

`OpenAICompatibleProvider` sends `response_format: { type: 'json_object' }` for JSON tasks (translate, journal-correct). LM Studio rejects `json_object` at the HTTP level (400) — it only accepts `json_schema` or `text`. Networking is fine; the request *shape* is rejected.

## Why prompt-driven JSON (not `json_schema`)

There is **no single `response_format` value** that works across every OpenAI-compatible backend:

| Backend | `json_object` | `json_schema` |
|---|:--:|:--:|
| OpenAI | ✓ | ✓ |
| LM Studio | ✗ 400 | ✓ |
| Ollama | ✓ | ✗ ignored ([#10001](https://github.com/ollama/ollama/issues/10001)) |

`json_object` breaks LM Studio; `json_schema` is silently ignored by Ollama (it only does structured output via its native `format` field) and also conflicts with these prompts, which deliberately omit optional fields. The only universally-safe option is **prompt-driven JSON** — which is exactly what `AnthropicProvider` already does.

## Changes

- **`openai-compatible.ts`** — stop sending `response_format`; rely on the prompt (which already says "ONLY a JSON object, no markdown").
- **`parse-json.ts`** (new) — `parseLooseJson()`: strips `<think>…</think>` reasoning blocks (DeepSeek-R1 / Qwen3, common in LM Studio), strips ```` ```json ```` fences, extracts the outermost `{…}`, and throws a clear error with a content preview otherwise.
- **`translate.ts`** (word + phrase) and **`journal-correct.ts`** parse via `parseLooseJson`.
- Tests: new `parse-json.test.ts` (incl. reasoning-model cases); updated `openai-compatible.test.ts`.

## Test plan

- [x] `cd api && bun test` → **66 pass / 0 fail** — [proof](https://github.com/heuwels/lector/pull/175#issuecomment-4751675628)
- [x] `tsc --noEmit` — **0 errors in changed files** (pre-existing unrelated api errors aside) — [proof](https://github.com/heuwels/lector/pull/175#issuecomment-4751675628)
- [ ] E2E in CI on this PR; live LM Studio verification after the hosted image redeploys

## Deploy note

After merge, `docker.yml` rebuilds `ghcr.io/heuwels/lector:latest`; on the server `docker compose pull && docker compose up -d` picks it up.

## Heads-up

Prompt-driven JSON means a reasoning model with a low `max_tokens` (or very verbose output) can truncate the JSON — that now surfaces as `Model did not return valid JSON. Got: …` rather than the old 400 (model-side, not a regression; raise max-tokens or use a non-reasoning model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
