### PR TITLE
chore(dict): bump to dict-2026-06-19 + unify the pin into dict.env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
     branches: [master]
 
-# Dictionary release pinned to the same version the Dockerfile uses. Bump
-# together when a new dict release is published via scripts/release-dict.sh.
-env:
-  DICT_VERSION: dict-2026-06-06
-  DICT_SHA256: 652df8d15e0678ead3b25ce0a021776d428256673df15b16e3e04cfe9b284a78
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -42,6 +36,8 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Load dictionary pin
+        run: grep -v '^#' dict.env >> "$GITHUB_ENV"
       - name: Fetch on-device dictionary
         # dictionary-db.test.ts is an integration test over the real (gitignored)
         # dictionary — without this the whole vitest run fails in beforeAll.
@@ -87,6 +83,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: npm ci
       - run: cd api && bun install
+      - name: Load dictionary pin
+        run: grep -v '^#' dict.env >> "$GITHUB_ENV"
       - name: Fetch on-device dictionary
         # The dictionary is gitignored — it ships in the Docker image. For CI
         # the dev server needs a copy at data/dictionary-af.db so e2e tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     needs: [build]
-    # Pinned to the same release the Dockerfile + ci.yml use. Bump together
-    # when a new dict release is published via scripts/release-dict.sh.
-    env:
-      DICT_VERSION: dict-2026-06-06
-      DICT_SHA256: 652df8d15e0678ead3b25ce0a021776d428256673df15b16e3e04cfe9b284a78
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -56,6 +51,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: npm ci
       - run: cd api && bun install
+      - name: Load dictionary pin
+        run: grep -v '^#' dict.env >> "$GITHUB_ENV"
       - name: Fetch on-device dictionary
         run: |
           mkdir -p data

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,34 +12,34 @@ COPY . .
 RUN npm run build
 
 # ── Dictionary fetch stage ──────────────────────────────────────────────────
-# The Afrikaans dictionary is read-only application data. Default source is the
-# `heuwels/lector` GitHub Release artifact; both URL and expected SHA-256 are
-# overridable, so anyone running their own deployment can substitute a tuned
-# DB by passing --build-arg DICT_URL=... --build-arg DICT_SHA256=...
+# The Afrikaans dictionary is read-only application data. The pinned release is
+# defined once in dict.env (single source of truth, shared with the CI
+# workflows) and baked into the image here. Override for a custom DB by passing
+# --build-arg DICT_URL=... --build-arg DICT_SHA256=... (both default to the pin
+# in dict.env when left empty).
 #
 # Examples:
-#   # Default (heuwels/lector latest dict release)
-#   docker build .
-#
-#   # Custom DB hosted on your CDN
+#   docker build .                                   # pinned dict from dict.env
 #   docker build \
 #     --build-arg DICT_URL=https://cdn.example.com/lector/my-dict.db \
 #     --build-arg DICT_SHA256=$(sha256sum my-dict.db | awk '{print $1}') .
-#
-#   # Skip integrity check (NOT recommended for production)
-#   docker build --build-arg DICT_SHA256= .
 FROM alpine:3 AS dict
-ARG DICT_VERSION=dict-2026-06-06
-ARG DICT_URL=https://github.com/heuwels/lector/releases/download/${DICT_VERSION}/dictionary-af.db
-ARG DICT_SHA256=652df8d15e0678ead3b25ce0a021776d428256673df15b16e3e04cfe9b284a78
+ARG DICT_URL=
+ARG DICT_SHA256=
 RUN apk add --no-cache curl
-RUN mkdir -p /dict \
- && echo "Fetching dictionary from: ${DICT_URL}" \
- && curl -fL --retry 3 "${DICT_URL}" -o /dict/dictionary-af.db \
- && if [ -n "${DICT_SHA256}" ]; then \
-      echo "${DICT_SHA256}  /dict/dictionary-af.db" | sha256sum -c -; \
+COPY dict.env /tmp/dict.env
+RUN set -e; \
+    OVERRIDE_URL="${DICT_URL}"; OVERRIDE_SHA="${DICT_SHA256}"; \
+    . /tmp/dict.env; \
+    URL="${OVERRIDE_URL:-https://github.com/heuwels/lector/releases/download/${DICT_VERSION}/dictionary-af.db}"; \
+    SHA="${OVERRIDE_SHA:-${DICT_SHA256}}"; \
+    mkdir -p /dict; \
+    echo "Fetching dictionary from: ${URL}"; \
+    curl -fL --retry 3 "${URL}" -o /dict/dictionary-af.db; \
+    if [ -n "${SHA}" ]; then \
+      echo "${SHA}  /dict/dictionary-af.db" | sha256sum -c -; \
     else \
-      echo "WARNING: DICT_SHA256 is empty — skipping integrity check"; \
+      echo "WARNING: no SHA-256 to verify against — skipping integrity check"; \
     fi
 
 # ── Bun API build stage ──

--- a/dict.env
+++ b/dict.env
@@ -1,0 +1,5 @@
+# Pinned on-device dictionary release — single source of truth.
+# Read by the Dockerfile (sourced) and the CI workflows (loaded into $GITHUB_ENV).
+# Regenerate with scripts/release-dict.sh.
+DICT_VERSION=dict-2026-06-19
+DICT_SHA256=d8620401a3696f0f547b9c8af5a507b3c83d9d0971af35db79a9e4e9491854cb

--- a/scripts/release-dict.sh
+++ b/scripts/release-dict.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # Build data/dictionary-af.db from kaikki.org + the curated roots, then upload
-# it as a GitHub Release asset. Prints the values to paste into the Dockerfile
-# (DICT_VERSION + DICT_SHA256) so subsequent docker builds pull this exact file.
+# it as a GitHub Release asset, then writes the pin (DICT_VERSION + DICT_SHA256)
+# to dict.env so subsequent docker builds and CI pull this exact file.
 #
 # Usage:
 #   scripts/release-dict.sh            # auto-generate tag (dict-YYYY-MM-DD)
@@ -43,7 +43,7 @@ Built from kaikki.org Afrikaans Wiktionary dump + curated roots in \`src/lib/dic
 - Size: ${SIZE_MB} MB
 - SHA-256: \`${SHA}\`
 
-Pulled into the Docker image at build time — see Dockerfile \`DICT_VERSION\` ARG.
+Pulled into the Docker image at build time — pinned in \`dict.env\`.
 EOF
 )
 
@@ -58,15 +58,24 @@ else
     --latest=false
 fi
 
+echo ">> Writing pin to dict.env"
+cat > dict.env <<EOF
+# Pinned on-device dictionary release — single source of truth.
+# Read by the Dockerfile (sourced) and the CI workflows (loaded into \$GITHUB_ENV).
+# Regenerate with scripts/release-dict.sh.
+DICT_VERSION=${TAG}
+DICT_SHA256=${SHA}
+EOF
+
 cat <<EOF
 
 ============================================================
-Release published.
+Release published and dict.env updated:
 
-To pin this build into the Docker image, update Dockerfile:
+  DICT_VERSION=${TAG}
+  DICT_SHA256=${SHA}
 
-  ARG DICT_VERSION=${TAG}
-  ARG DICT_SHA256=${SHA}
+Commit dict.env to pin this dictionary into the image + CI, then open a PR.
 
 Verify the download manually with:
 

--- a/src/lib/__tests__/dictionary-db.test.ts
+++ b/src/lib/__tests__/dictionary-db.test.ts
@@ -55,13 +55,17 @@ describe('dictionary-db', () => {
   });
 
   describe('prefix derivation', () => {
-    test('bedink found via be- prefix on dink (lemmaInfo populated)', () => {
-      // "bedink" (to consider) is not a kaikki entry on its own — it's reached
-      // by stripping the be- prefix and finding "dink" (to think) as the stem.
-      const entry = lookupWord('bedink', 'af');
+    test('verleer found via ver- prefix on leer (lemmaInfo populated)', () => {
+      // "verleer" (to unlearn) isn't a first-class entry — it's reached by
+      // stripping the ver- prefix and finding "leer" (to learn) as the stem.
+      // NOTE: these prefix fixtures are churn-prone — as the dictionary grows,
+      // derived words get promoted to first-class entries (see the verstaan note
+      // below; the former "bedink" fixture was promoted by the woordeboek import).
+      // If this starts failing, swap in another still-derived ver-/be-/ont- word.
+      const entry = lookupWord('verleer', 'af');
       expect(entry).toBeDefined();
       expect(entry!.lemmaInfo).toBeDefined();
-      expect(entry!.lemmaInfo!.stem).toBe('dink');
+      expect(entry!.lemmaInfo!.stem).toBe('leer');
       expect(entry!.lemmaInfo!.label).toBe('derived from');
       // Senses come from the stem
       expect(entry!.senses.length).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Bumps the on-device dictionary to **dict-2026-06-19** and **unifies the version/sha pin into a single `dict.env`**.

## Why

The dict version + sha-256 were duplicated across three files — `Dockerfile`, `ci.yml`, `release.yml` — each carrying a *"bump together when a new dict release is published"* comment. That's exactly the kind of triplication that drifts (the CI pin had in fact fallen behind the published dict). One source of truth removes the footgun.

## How

- **`dict.env`** (new) — the single source: `DICT_VERSION` + `DICT_SHA256`.
- **`Dockerfile`** — the `dict` stage now `COPY`s and `source`s `dict.env`. `--build-arg DICT_URL=… / DICT_SHA256=…` still override it for custom-DB builds (captured *before* sourcing, so the override wins).
- **`ci.yml` / `release.yml`** — each dict-fetching job loads the pin with `grep -v '^#' dict.env >> "$GITHUB_ENV"` before fetching; the static `env:` blocks are gone. (`e2e-docker` already gets the dict via the image build, so it needs no change.)
- **`release-dict.sh`** — now writes `dict.env` directly (it previously printed Dockerfile `ARG` lines to paste by hand).

## Pin change

| | before | after |
|---|---|---|
| `DICT_VERSION` | `dict-2026-06-06` | **`dict-2026-06-19`** |
| `DICT_SHA256` | `652df8d1…` | **`d8620401…`** |

## Test plan

- [ ] CI on this PR — `unit-tests` + `e2e-tests` fetch `dict-2026-06-19` via the new `dict.env` load and verify the sha; **`e2e-docker` builds the production image**, exercising the Dockerfile `COPY dict.env` + source path.
- The sha was supplied for the published `dict-2026-06-19` asset; CI's `sha256sum -c` is the authoritative validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
