### PR TITLE
ci: shared registry build cache (reuse PR build on master)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
   e2e-docker:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -118,9 +121,19 @@ jobs:
           node-version: 22
           cache: npm
       - uses: docker/setup-buildx-action@v3
+      # Registry build cache is shared across branches (unlike type=gha, which is
+      # branch-isolated), so this PR build populates the cache that docker.yml's
+      # publish build on master then reuses — no second from-scratch image build.
+      # Fork PRs can't push to ghcr: skip the login; cache-to then fails soft
+      # (ignore-error) and cache-from simply misses.
+      - name: Log in to ghcr (build cache)
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build production image
-        # Same cache scope as docker.yml's amd64 build, so PR builds reuse
-        # master's layer cache (the dictionary is baked in by the Dockerfile).
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -128,8 +141,8 @@ jobs:
           push: false
           tags: lector:e2e
           platforms: linux/amd64
-          cache-from: type=gha,scope=amd64
-          cache-to: type=gha,mode=max,scope=amd64
+          cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64,mode=max,ignore-error=true
       - name: Start container
         # No volume mount: /app/data starts empty, matching the fresh DB the
         # dev-mode webServer guarantees. Container :3000 maps to host :3456,

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,8 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-amd64
           platforms: linux/amd64
-          cache-from: type=gha,scope=amd64
-          cache-to: type=gha,mode=max,scope=amd64
+          cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64,mode=max,ignore-error=true
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
@@ -47,8 +47,8 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-arm64
           platforms: linux/arm64
-          cache-from: type=gha,scope=arm64
-          cache-to: type=gha,mode=max,scope=arm64
+          cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64,mode=max,ignore-error=true
 
   merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-amd64
           platforms: linux/amd64
-          cache-from: type=gha,scope=amd64
-          cache-to: type=gha,mode=max,scope=amd64
+          cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64,mode=max,ignore-error=true
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
@@ -112,8 +112,8 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-arm64
           platforms: linux/arm64
-          cache-from: type=gha,scope=arm64
-          cache-to: type=gha,mode=max,scope=arm64
+          cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64,mode=max,ignore-error=true
 
   merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`type=gha` build cache is **branch-isolated** — a run can only read caches from its own branch, the PR base, and the default branch. So:

- A PR's `e2e-docker` build writes its cache to the **PR-branch** scope.
- On merge, `docker.yml` runs on `master` and can't see that cache → it **re-runs the expensive `npm run build` (Next.js) from scratch**.
- `mode=max` × {amd64, arm64} × every active PR branch also competes for the repo's **10 GB Actions-cache budget** → LRU eviction → more misses.

Net: every merged PR effectively builds the image twice, and the second build can't reuse the first.

## Fix

Switch all five build sites to a **registry-backed cache** in ghcr:

```
cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64
cache-to:   type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64,mode=max,ignore-error=true
```

(`-arm64` for the arm builds.) A registry cache **isn't branch-isolated** — every build reads/writes the same ref — so the PR's `e2e-docker` build populates the cache that `docker.yml` / `release.yml` reuse on master. The publish build becomes mostly cache hits instead of a second full build, and it's no longer capped by the 10 GB Actions limit.

## Changes

- **`ci.yml` → `e2e-docker`**: registry cache + `packages: write` + a ghcr login step, **fork-guarded** (`if: head.repo == github.repository`) since fork tokens can't push.
- **`docker.yml`** `build-amd64` / `build-arm64`: registry cache.
- **`release.yml`** `build-amd64` / `build-arm64`: registry cache.
- `cache-to` uses `ignore-error=true` everywhere, so a cache-push hiccup (or a fork PR with no push token) never fails the build.

## Notes / test plan

- [ ] This PR's own `e2e-docker` exercises the new config — it logs in, builds amd64, and pushes `buildcache-amd64`. The first run is a cold miss (the cache tag doesn't exist yet); the payoff shows on subsequent builds and the next master publish.
- Creates two cache tags on the existing `lector` package (`buildcache-amd64`, `buildcache-arm64`) — kept on the repo-linked package so `GITHUB_TOKEN` has write access (avoids the separate-package linking 403). They can be pruned periodically.
- Independent of #175 / #176 (already merged) — no app/runtime code touched.
- Secondary, **not** in this PR: `builder`'s `COPY . .` pulls in `dict.env` / `.github/` (not in `.dockerignore`), so a dict bump or workflow tweak still invalidates the Next build layer — a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
