### PR TITLE
Clarify the CEFR fluency meter + align the language-badge word count

### DIFF
--- a/api/src/lib/cefr.ts
+++ b/api/src/lib/cefr.ts
@@ -1,0 +1,63 @@
+// CEFR-style vocabulary levels and progress derivation.
+//
+// The progress bar measures progress *through the current band* (it resets to
+// 0% on entering a level and fills to 100% as you approach the next), rather
+// than total words as a fraction of the next threshold. Banded is deliberate:
+// a cumulative `known / nextThreshold` would show a near-beginner as e.g. "10%
+// to C2", which is meaningless. Each level is a fresh, winnable 0→100.
+//
+// Mirror: src/lib/cefr.ts — keep both copies in sync (the Next.js and Hono
+// servers share the SQLite file but not source).
+
+export interface CefrLevelInfo {
+  code: string;
+  label: string;
+  min: number;
+  /** Upper bound of the band, or null for the open-ended top level (C2). */
+  max: number | null;
+}
+
+export interface CefrProgress {
+  estimatedLevel: CefrLevelInfo;
+  /** The level above the current one, or null at the top level. */
+  nextLevel: { code: string; label: string } | null;
+  /** 0..100, progress through the current band. */
+  progressToNextLevel: number;
+  /** Words still needed to reach the next level, or null at the top level. */
+  wordsToNextLevel: number | null;
+}
+
+const CEFR_LEVELS = [
+  { min: 0, max: 500, code: 'A1', label: 'Beginner' },
+  { min: 500, max: 1500, code: 'A2', label: 'Elementary' },
+  { min: 1500, max: 3000, code: 'B1', label: 'Intermediate' },
+  { min: 3000, max: 5000, code: 'B2', label: 'Upper Intermediate' },
+  { min: 5000, max: 8000, code: 'C1', label: 'Advanced' },
+  { min: 8000, max: Infinity, code: 'C2', label: 'Proficiency' },
+] as const;
+
+export function deriveCefrProgress(totalKnownWords: number): CefrProgress {
+  const idx = CEFR_LEVELS.findIndex((l) => totalKnownWords >= l.min && totalKnownWords < l.max);
+  const currentIndex = idx === -1 ? CEFR_LEVELS.length - 1 : idx;
+  const current = CEFR_LEVELS[currentIndex];
+  const next = CEFR_LEVELS[currentIndex + 1] ?? null;
+  const isTopLevel = current.max === Infinity;
+
+  const progressToNextLevel = isTopLevel
+    ? 100
+    : Math.round(((totalKnownWords - current.min) / (current.max - current.min)) * 100);
+
+  const wordsToNextLevel = isTopLevel ? null : Math.max(0, current.max - totalKnownWords);
+
+  return {
+    estimatedLevel: {
+      code: current.code,
+      label: current.label,
+      min: current.min,
+      max: isTopLevel ? null : current.max,
+    },
+    nextLevel: next ? { code: next.code, label: next.label } : null,
+    progressToNextLevel,
+    wordsToNextLevel,
+  };
+}

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -3,6 +3,7 @@ import { db, DailyStatsRow } from '../db';
 import { resolveLanguage } from '../lib/active-language';
 import { getTodayDate, addDaysToDateString } from '../lib/dates';
 import { activeDateSet, computeStreaks } from '../lib/streak';
+import { deriveCefrProgress } from '../lib/cefr';
 
 const app = new Hono();
 
@@ -36,15 +37,21 @@ app.get('/', (c) => {
 app.get('/today', (c) => {
   const lang = resolveLanguage(c.req.query('language'));
   const today = getTodayDate();
-  let stats = db.prepare('SELECT * FROM dailyStats WHERE date = ? AND language = ?').get(today, lang) as DailyStatsRow | undefined;
+  let stats = db
+    .prepare('SELECT * FROM dailyStats WHERE date = ? AND language = ?')
+    .get(today, lang) as DailyStatsRow | undefined;
 
   if (!stats) {
-    db.prepare(`
+    db.prepare(
+      `
       INSERT INTO dailyStats (date, language, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
       VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0)
-    `).run(today, lang);
+    `,
+    ).run(today, lang);
 
-    stats = db.prepare('SELECT * FROM dailyStats WHERE date = ? AND language = ?').get(today, lang) as DailyStatsRow;
+    stats = db
+      .prepare('SELECT * FROM dailyStats WHERE date = ? AND language = ?')
+      .get(today, lang) as DailyStatsRow;
   }
 
   return c.json(stats);
@@ -56,20 +63,35 @@ app.put('/today', async (c) => {
   const today = getTodayDate();
   const body = await c.req.json();
 
-  db.prepare(`
+  db.prepare(
+    `
     INSERT OR IGNORE INTO dailyStats (date, language, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
     VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0)
-  `).run(today, lang);
+  `,
+  ).run(today, lang);
 
   const field = body.field as string;
   const amount = body.amount ?? 1;
 
-  const allowedFields = ['wordsRead', 'newWordsSaved', 'wordsMarkedKnown', 'minutesRead', 'clozePracticed', 'points', 'dictionaryLookups', 'ankiReviews'];
+  const allowedFields = [
+    'wordsRead',
+    'newWordsSaved',
+    'wordsMarkedKnown',
+    'minutesRead',
+    'clozePracticed',
+    'points',
+    'dictionaryLookups',
+    'ankiReviews',
+  ];
   if (!allowedFields.includes(field)) {
     return c.json({ error: 'Invalid field' }, 400);
   }
 
-  db.prepare(`UPDATE dailyStats SET ${field} = ${field} + ? WHERE date = ? AND language = ?`).run(amount, today, lang);
+  db.prepare(`UPDATE dailyStats SET ${field} = ${field} + ? WHERE date = ? AND language = ?`).run(
+    amount,
+    today,
+    lang,
+  );
 
   return c.json({ success: true });
 });
@@ -79,9 +101,9 @@ app.get('/fluency', (c) => {
   const lang = resolveLanguage(c.req.query('language'));
 
   // Count words by state from knownWords table
-  const stateCounts = db.prepare(
-    'SELECT state, COUNT(*) as count FROM knownWords WHERE language = ? GROUP BY state'
-  ).all(lang) as { state: string; count: number }[];
+  const stateCounts = db
+    .prepare('SELECT state, COUNT(*) as count FROM knownWords WHERE language = ? GROUP BY state')
+    .all(lang) as { state: string; count: number }[];
 
   const countMap: Record<string, number> = {};
   for (const row of stateCounts) {
@@ -99,32 +121,12 @@ app.get('/fluency', (c) => {
   };
 
   const totalKnownWords = byState.known;
-  const totalLearning =
-    byState.level1 + byState.level2 + byState.level3 + byState.level4;
+  const totalLearning = byState.level1 + byState.level2 + byState.level3 + byState.level4;
   const totalNew = byState.new;
 
-  // Determine CEFR-style level
-  const levels = [
-    { min: 0, max: 500, code: 'A1', label: 'Beginner' },
-    { min: 500, max: 1500, code: 'A2', label: 'Elementary' },
-    { min: 1500, max: 3000, code: 'B1', label: 'Intermediate' },
-    { min: 3000, max: 5000, code: 'B2', label: 'Upper Intermediate' },
-    { min: 5000, max: 8000, code: 'C1', label: 'Advanced' },
-    { min: 8000, max: Infinity, code: 'C2', label: 'Proficiency' },
-  ];
-
-  const currentLevel = levels.find(
-    (l) => totalKnownWords >= l.min && totalKnownWords < l.max
-  ) || levels[levels.length - 1];
-
-  const progressToNextLevel =
-    currentLevel.max === Infinity
-      ? 100
-      : Math.round(
-          ((totalKnownWords - currentLevel.min) /
-            (currentLevel.max - currentLevel.min)) *
-            100
-        );
+  // Determine CEFR-style level + progress through the current band.
+  const { estimatedLevel, nextLevel, progressToNextLevel, wordsToNextLevel } =
+    deriveCefrProgress(totalKnownWords);
 
   // Weekly growth: words marked known in last 7 days vs previous 7 days
   const today = getTodayDate();
@@ -132,24 +134,27 @@ app.get('/fluency', (c) => {
   const prevWeekStart = addDaysToDateString(today, -13);
   const prevWeekEnd = addDaysToDateString(today, -7);
 
-  const thisWeekRow = db.prepare(
-    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?'
-  ).get(weekStart, today, lang) as { total: number };
+  const thisWeekRow = db
+    .prepare(
+      'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?',
+    )
+    .get(weekStart, today, lang) as { total: number };
 
-  const prevWeekRow = db.prepare(
-    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?'
-  ).get(prevWeekStart, prevWeekEnd, lang) as { total: number };
+  const prevWeekRow = db
+    .prepare(
+      'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?',
+    )
+    .get(prevWeekStart, prevWeekEnd, lang) as { total: number };
 
   return c.json({
     totalKnownWords,
     totalLearning,
     totalNew,
     byState,
-    estimatedLevel: {
-      code: currentLevel.code,
-      label: currentLevel.label,
-    },
+    estimatedLevel,
+    nextLevel,
     progressToNextLevel,
+    wordsToNextLevel,
     weeklyGrowth: {
       thisWeek: thisWeekRow.total,
       lastWeek: prevWeekRow.total,
@@ -166,9 +171,11 @@ app.get('/streak', (c) => {
   const lang = resolveLanguage(c.req.query('language'));
   const today = getTodayDate();
 
-  const rows = db.prepare(
-    'SELECT date, dictionaryLookups, clozePracticed, minutesRead, ankiReviews FROM dailyStats WHERE language = ?'
-  ).all(lang) as Pick<
+  const rows = db
+    .prepare(
+      'SELECT date, dictionaryLookups, clozePracticed, minutesRead, ankiReviews FROM dailyStats WHERE language = ?',
+    )
+    .all(lang) as Pick<
     DailyStatsRow,
     'date' | 'dictionaryLookups' | 'clozePracticed' | 'minutesRead' | 'ankiReviews'
   >[];

--- a/e2e/fluency.spec.ts
+++ b/e2e/fluency.spec.ts
@@ -1,15 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-test.describe("Fluency Benchmarks", () => {
+test.describe('Fluency Benchmarks', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
   });
 
-  test("should display fluency section on stats page with level badge", async ({
-    page,
-  }) => {
-    await page.goto("/stats");
-    await page.waitForLoadState("networkidle");
+  test('should display fluency section on stats page with level badge', async ({ page }) => {
+    await page.goto('/stats');
+    await page.waitForLoadState('networkidle');
 
     // Fluency section should be visible
     const section = page.locator('[data-testid="fluency-section"]');
@@ -18,14 +16,20 @@ test.describe("Fluency Benchmarks", () => {
     // Level badge should show A1 (low word count from test data)
     const badge = page.locator('[data-testid="fluency-level-badge"]');
     await expect(badge).toBeVisible();
-    await expect(badge).toHaveText("A1");
+    await expect(badge).toHaveText('A1');
 
     // Should display the level description
-    await expect(section.getByText("Beginner")).toBeVisible();
+    await expect(section.getByText('Beginner')).toBeVisible();
 
     // Progress bar should exist
     const progressBar = page.locator('[data-testid="fluency-progress-bar"]');
     await expect(progressBar).toBeVisible();
+
+    // The bar names the target level and shows a words-to-go countdown
+    // (A1 band → next level A2), instead of a bare percentage.
+    const wordsToNext = page.locator('[data-testid="fluency-words-to-next"]');
+    await expect(wordsToNext).toBeVisible();
+    await expect(wordsToNext).toHaveText(/words to A2/);
 
     // Known and learning counts should be visible (values may vary
     // depending on data left by other tests, so just check they render)
@@ -38,9 +42,9 @@ test.describe("Fluency Benchmarks", () => {
     await expect(learningCount).toHaveText(/^\d+$/);
   });
 
-  test("should show CEFR level label with description", async ({ page }) => {
-    await page.goto("/stats");
-    await page.waitForLoadState("networkidle");
+  test('should show CEFR level label with description', async ({ page }) => {
+    await page.goto('/stats');
+    await page.waitForLoadState('networkidle');
 
     const section = page.locator('[data-testid="fluency-section"]');
     await expect(section).toBeVisible({ timeout: 10000 });
@@ -49,38 +53,44 @@ test.describe("Fluency Benchmarks", () => {
     await expect(section.getByText(/A1\s*—\s*Beginner/)).toBeVisible();
 
     // Should show "Estimated CEFR Level" subtitle
-    await expect(section.getByText("Estimated CEFR Level")).toBeVisible();
+    await expect(section.getByText('Estimated CEFR Level')).toBeVisible();
   });
 
-  test("fluency API endpoint should return valid data", async ({ page }) => {
-    const response = await page.request.get("/api/stats/fluency");
+  test('fluency API endpoint should return valid data', async ({ page }) => {
+    const response = await page.request.get('/api/stats/fluency');
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
-    expect(data).toHaveProperty("totalKnownWords");
-    expect(data).toHaveProperty("totalLearning");
-    expect(data).toHaveProperty("totalNew");
-    expect(data).toHaveProperty("byState");
+    expect(data).toHaveProperty('totalKnownWords');
+    expect(data).toHaveProperty('totalLearning');
+    expect(data).toHaveProperty('totalNew');
+    expect(data).toHaveProperty('byState');
     // The totals must be derived from byState — one calculation app-wide
     expect(data.totalKnownWords).toBe(data.byState.known);
     expect(data.totalLearning).toBe(
-      data.byState.level1 +
-        data.byState.level2 +
-        data.byState.level3 +
-        data.byState.level4
+      data.byState.level1 + data.byState.level2 + data.byState.level3 + data.byState.level4,
     );
-    expect(data).toHaveProperty("estimatedLevel");
-    expect(data.estimatedLevel).toHaveProperty("code");
-    expect(data.estimatedLevel).toHaveProperty("label");
-    expect(data).toHaveProperty("progressToNextLevel");
-    expect(data).toHaveProperty("weeklyGrowth");
-    expect(data.weeklyGrowth).toHaveProperty("thisWeek");
-    expect(data.weeklyGrowth).toHaveProperty("lastWeek");
-    expect(data.weeklyGrowth).toHaveProperty("delta");
+    expect(data).toHaveProperty('estimatedLevel');
+    expect(data.estimatedLevel).toHaveProperty('code');
+    expect(data.estimatedLevel).toHaveProperty('label');
+    expect(data.estimatedLevel).toHaveProperty('min');
+    expect(data.estimatedLevel).toHaveProperty('max');
+    expect(data).toHaveProperty('nextLevel');
+    expect(data).toHaveProperty('progressToNextLevel');
+    expect(data).toHaveProperty('wordsToNextLevel');
+    expect(data).toHaveProperty('weeklyGrowth');
+    expect(data.weeklyGrowth).toHaveProperty('thisWeek');
+    expect(data.weeklyGrowth).toHaveProperty('lastWeek');
+    expect(data.weeklyGrowth).toHaveProperty('delta');
 
-    // With empty DB, should be A1
-    expect(data.estimatedLevel.code).toBe("A1");
+    // With empty DB (0 known words) → A1, at the start of a fresh band:
+    // next level is A2, the full 500-word band away.
+    expect(data.estimatedLevel.code).toBe('A1');
     expect(data.totalKnownWords).toBe(0);
-    expect(typeof data.progressToNextLevel).toBe("number");
+    expect(typeof data.progressToNextLevel).toBe('number');
+    expect(data.estimatedLevel.min).toBe(0);
+    expect(data.estimatedLevel.max).toBe(500);
+    expect(data.nextLevel.code).toBe('A2');
+    expect(data.wordsToNextLevel).toBe(500);
   });
 });

--- a/src/app/api/stats/fluency/route.ts
+++ b/src/app/api/stats/fluency/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/server/database';
 import { resolveLanguage } from '@/lib/server/active-language';
 import { getTodayDate } from '@/lib/server/dates';
 import { addDaysToDateString } from '@/lib/dates';
+import { deriveCefrProgress } from '@/lib/cefr';
 
 // GET /api/stats/fluency - Get fluency benchmarks (word counts, CEFR level, growth)
 export async function GET(request: NextRequest) {
@@ -10,9 +11,9 @@ export async function GET(request: NextRequest) {
   const lang = resolveLanguage(searchParams.get('language'));
 
   // Count words by state from knownWords table
-  const stateCounts = db.prepare(
-    'SELECT state, COUNT(*) as count FROM knownWords WHERE language = ? GROUP BY state'
-  ).all(lang) as { state: string; count: number }[];
+  const stateCounts = db
+    .prepare('SELECT state, COUNT(*) as count FROM knownWords WHERE language = ? GROUP BY state')
+    .all(lang) as { state: string; count: number }[];
 
   const countMap: Record<string, number> = {};
   for (const row of stateCounts) {
@@ -30,32 +31,12 @@ export async function GET(request: NextRequest) {
   };
 
   const totalKnownWords = byState.known;
-  const totalLearning =
-    byState.level1 + byState.level2 + byState.level3 + byState.level4;
+  const totalLearning = byState.level1 + byState.level2 + byState.level3 + byState.level4;
   const totalNew = byState.new;
 
-  // Determine CEFR-style level
-  const levels = [
-    { min: 0, max: 500, code: 'A1', label: 'Beginner' },
-    { min: 500, max: 1500, code: 'A2', label: 'Elementary' },
-    { min: 1500, max: 3000, code: 'B1', label: 'Intermediate' },
-    { min: 3000, max: 5000, code: 'B2', label: 'Upper Intermediate' },
-    { min: 5000, max: 8000, code: 'C1', label: 'Advanced' },
-    { min: 8000, max: Infinity, code: 'C2', label: 'Proficiency' },
-  ];
-
-  const currentLevel = levels.find(
-    (l) => totalKnownWords >= l.min && totalKnownWords < l.max
-  ) || levels[levels.length - 1];
-
-  const progressToNextLevel =
-    currentLevel.max === Infinity
-      ? 100
-      : Math.round(
-          ((totalKnownWords - currentLevel.min) /
-            (currentLevel.max - currentLevel.min)) *
-            100
-        );
+  // Determine CEFR-style level + progress through the current band.
+  const { estimatedLevel, nextLevel, progressToNextLevel, wordsToNextLevel } =
+    deriveCefrProgress(totalKnownWords);
 
   // Weekly growth: words marked known in last 7 days vs previous 7 days
   const today = getTodayDate();
@@ -63,24 +44,27 @@ export async function GET(request: NextRequest) {
   const prevWeekStart = addDaysToDateString(today, -13);
   const prevWeekEnd = addDaysToDateString(today, -7);
 
-  const thisWeekRow = db.prepare(
-    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?'
-  ).get(weekStart, today, lang) as { total: number };
+  const thisWeekRow = db
+    .prepare(
+      'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?',
+    )
+    .get(weekStart, today, lang) as { total: number };
 
-  const prevWeekRow = db.prepare(
-    'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?'
-  ).get(prevWeekStart, prevWeekEnd, lang) as { total: number };
+  const prevWeekRow = db
+    .prepare(
+      'SELECT COALESCE(SUM(wordsMarkedKnown), 0) as total FROM dailyStats WHERE date BETWEEN ? AND ? AND language = ?',
+    )
+    .get(prevWeekStart, prevWeekEnd, lang) as { total: number };
 
   return NextResponse.json({
     totalKnownWords,
     totalLearning,
     totalNew,
     byState,
-    estimatedLevel: {
-      code: currentLevel.code,
-      label: currentLevel.label,
-    },
+    estimatedLevel,
+    nextLevel,
     progressToNextLevel,
+    wordsToNextLevel,
     weeklyGrowth: {
       thisWeek: thisWeekRow.total,
       lastWeek: prevWeekRow.total,

--- a/src/app/stats/components.tsx
+++ b/src/app/stats/components.tsx
@@ -129,9 +129,7 @@ export function WordStateBreakdown({ byState }: { byState: Record<WordState, num
 
   return (
     <div className="panel p-6">
-      <h3 className="mb-4 text-lg font-semibold text-foreground">
-        Words by State
-      </h3>
+      <h3 className="mb-4 text-lg font-semibold text-foreground">Words by State</h3>
       <div className="space-y-3">
         {states.map(({ key, label, color, bgColor }) => {
           const count = byState[key] || 0;
@@ -172,9 +170,7 @@ export function ClozeStats({
 
   return (
     <div className="panel p-6">
-      <h3 className="mb-4 text-lg font-semibold text-foreground">
-        Cloze Practice
-      </h3>
+      <h3 className="mb-4 text-lg font-semibold text-foreground">Cloze Practice</h3>
       <div className="grid grid-cols-2 gap-4">
         <div className="rounded-lg bg-muted p-4 text-center">
           <div className="text-3xl font-bold text-[var(--chart-3)]">
@@ -183,9 +179,7 @@ export function ClozeStats({
           <div className="mt-1 text-sm text-muted-foreground">Sentences Practiced</div>
         </div>
         <div className="rounded-lg bg-muted p-4 text-center">
-          <div className="text-3xl font-bold text-primary">
-            {accuracy.toFixed(1)}%
-          </div>
+          <div className="text-3xl font-bold text-primary">{accuracy.toFixed(1)}%</div>
           <div className="mt-1 text-sm text-muted-foreground">Accuracy</div>
         </div>
         <div className="col-span-2 rounded-lg bg-muted p-4 text-center">
@@ -278,15 +272,19 @@ export function SentenceMastery({
 
 // Fluency badge component
 export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
-  const { estimatedLevel, progressToNextLevel, totalKnownWords, totalLearning, weeklyGrowth } =
-    fluency;
+  const {
+    estimatedLevel,
+    nextLevel,
+    progressToNextLevel,
+    wordsToNextLevel,
+    totalKnownWords,
+    totalLearning,
+    weeklyGrowth,
+  } = fluency;
   const growthDelta = weeklyGrowth.delta;
 
   return (
-    <div
-      data-testid="fluency-section"
-      className="mb-8 panel p-6"
-    >
+    <div data-testid="fluency-section" className="panel mb-8 p-6">
       <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
           <span
@@ -307,9 +305,7 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
             <span
               data-testid="fluency-weekly-growth"
               className={`inline-flex items-center gap-1 text-sm font-medium ${
-                growthDelta > 0
-                  ? 'text-primary'
-                  : 'text-destructive'
+                growthDelta > 0 ? 'text-primary' : 'text-destructive'
               }`}
             >
               {growthDelta > 0 ? (
@@ -331,7 +327,9 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
       {/* Progress bar toward next level */}
       <div className="mb-4">
         <div className="mb-1 flex justify-between text-sm">
-          <span className="text-muted-foreground">Progress to next level</span>
+          <span className="text-muted-foreground">
+            {nextLevel ? `Progress to ${nextLevel.code}` : 'Top level reached'}
+          </span>
           <span className="text-muted-foreground">{progressToNextLevel}%</span>
         </div>
         <div
@@ -343,15 +341,21 @@ export function FluencyBadge({ fluency }: { fluency: FluencyStats }) {
             style={{ width: `${progressToNextLevel}%` }}
           />
         </div>
+        {nextLevel && (
+          <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+            <span>{estimatedLevel.min.toLocaleString()}</span>
+            <span data-testid="fluency-words-to-next" className="font-medium text-foreground">
+              {wordsToNextLevel?.toLocaleString()} words to {nextLevel.code}
+            </span>
+            <span>{estimatedLevel.max?.toLocaleString()}</span>
+          </div>
+        )}
       </div>
 
       {/* Known / Learning counts */}
       <div className="grid grid-cols-2 gap-4">
         <div className="rounded-lg bg-muted p-3 text-center">
-          <div
-            data-testid="fluency-known-count"
-            className="text-2xl font-bold text-primary"
-          >
+          <div data-testid="fluency-known-count" className="text-2xl font-bold text-primary">
             {totalKnownWords.toLocaleString()}
           </div>
           <div className="text-sm text-muted-foreground">Known</div>
@@ -376,9 +380,7 @@ export function SkeletonBlock({ className = '' }: { className?: string }) {
 
 export function SkeletonCard({ className = '' }: { className?: string }) {
   return (
-    <div
-      className={`panel p-6 ${className}`}
-    >
+    <div className={`panel p-6 ${className}`}>
       <SkeletonBlock className="mb-3 h-4 w-24" />
       <SkeletonBlock className="mb-2 h-10 w-32" />
       <SkeletonBlock className="h-3 w-20" />
@@ -392,7 +394,7 @@ export function StatsSkeleton() {
       <SkeletonBlock className="mb-6 h-4 w-56" />
 
       {/* Fluency badge skeleton */}
-      <div className="mb-8 panel p-6">
+      <div className="panel mb-8 p-6">
         <div className="mb-4 flex items-center gap-4">
           <SkeletonBlock className="h-10 w-16" />
           <div className="flex-1">

--- a/src/components/LanguageSelector/index.tsx
+++ b/src/components/LanguageSelector/index.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { getVocabStats, setSetting } from '@/lib/data-layer';
+import { getFluencyStats, setSetting } from '@/lib/data-layer';
 import { LANGUAGES } from '@/lib/languages';
 import { LanguageCode } from '@/types/language';
 import { useActiveLanguage } from '@/utils/hooks';
@@ -21,10 +21,9 @@ export default function LanguageSelector({ compact = false }: { compact?: boolea
   useEffect(() => {
     const init = async () => {
       try {
-        const vocabStats = await getVocabStats();
-        const knownCount =
-          vocabStats.byState.level3 + vocabStats.byState.level4 + vocabStats.byState.known;
-        setKnownWordsCount(knownCount);
+        const fluency = await getFluencyStats();
+
+        setKnownWordsCount(fluency.totalKnownWords);
       } catch (error) {
         console.error('Error loading data:', error);
       }
@@ -67,7 +66,7 @@ export default function LanguageSelector({ compact = false }: { compact?: boolea
         <DropdownMenuTrigger
           data-testid="language-selector"
           aria-label={`Language: ${activeLang.native}`}
-          className="flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted  "
+          className="flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted"
         >
           <span>{activeLang.flag}</span>
           <span>{activeLang.code.toUpperCase()}</span>
@@ -87,7 +86,7 @@ export default function LanguageSelector({ compact = false }: { compact?: boolea
         <DropdownMenuTrigger
           data-testid="language-selector"
           aria-label={`Language: ${activeLang.native}`}
-          className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent  "
+          className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
         >
           <span className="text-lg">{activeLang.flag}</span>
           <span className="flex-1 text-left">{activeLang.native}</span>

--- a/src/lib/cefr.test.ts
+++ b/src/lib/cefr.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { deriveCefrProgress } from './cefr';
+
+describe('deriveCefrProgress', () => {
+  it('places 0 words at the start of A1', () => {
+    const p = deriveCefrProgress(0);
+    expect(p.estimatedLevel.code).toBe('A1');
+    expect(p.progressToNextLevel).toBe(0);
+    expect(p.nextLevel?.code).toBe('A2');
+    expect(p.wordsToNextLevel).toBe(500);
+  });
+
+  it('measures progress THROUGH the current band, not as a fraction of the next threshold', () => {
+    // 709 known in A2 (500–1500): (709-500)/(1500-500) = 20.9% → 21%, NOT 709/1500 = 47%.
+    const p = deriveCefrProgress(709);
+    expect(p.estimatedLevel.code).toBe('A2');
+    expect(p.estimatedLevel.min).toBe(500);
+    expect(p.estimatedLevel.max).toBe(1500);
+    expect(p.progressToNextLevel).toBe(21);
+    expect(p.nextLevel?.code).toBe('B1');
+    expect(p.wordsToNextLevel).toBe(791);
+  });
+
+  it('resets to 0% on entering a new level', () => {
+    // Exactly at a boundary: 1500 is the floor of B1, so progress restarts.
+    const p = deriveCefrProgress(1500);
+    expect(p.estimatedLevel.code).toBe('B1');
+    expect(p.progressToNextLevel).toBe(0);
+    expect(p.nextLevel?.code).toBe('B2');
+    expect(p.wordsToNextLevel).toBe(1500);
+  });
+
+  it('caps the top level (C2) at 100% with no next level', () => {
+    const p = deriveCefrProgress(9000);
+    expect(p.estimatedLevel.code).toBe('C2');
+    expect(p.estimatedLevel.max).toBeNull();
+    expect(p.progressToNextLevel).toBe(100);
+    expect(p.nextLevel).toBeNull();
+    expect(p.wordsToNextLevel).toBeNull();
+  });
+});

--- a/src/lib/cefr.ts
+++ b/src/lib/cefr.ts
@@ -1,0 +1,63 @@
+// CEFR-style vocabulary levels and progress derivation.
+//
+// The progress bar measures progress *through the current band* (it resets to
+// 0% on entering a level and fills to 100% as you approach the next), rather
+// than total words as a fraction of the next threshold. Banded is deliberate:
+// a cumulative `known / nextThreshold` would show a near-beginner as e.g. "10%
+// to C2", which is meaningless. Each level is a fresh, winnable 0→100.
+//
+// Mirror: api/src/lib/cefr.ts — keep both copies in sync (the Next.js and Hono
+// servers share the SQLite file but not source).
+
+export interface CefrLevelInfo {
+  code: string;
+  label: string;
+  min: number;
+  /** Upper bound of the band, or null for the open-ended top level (C2). */
+  max: number | null;
+}
+
+export interface CefrProgress {
+  estimatedLevel: CefrLevelInfo;
+  /** The level above the current one, or null at the top level. */
+  nextLevel: { code: string; label: string } | null;
+  /** 0..100, progress through the current band. */
+  progressToNextLevel: number;
+  /** Words still needed to reach the next level, or null at the top level. */
+  wordsToNextLevel: number | null;
+}
+
+const CEFR_LEVELS = [
+  { min: 0, max: 500, code: 'A1', label: 'Beginner' },
+  { min: 500, max: 1500, code: 'A2', label: 'Elementary' },
+  { min: 1500, max: 3000, code: 'B1', label: 'Intermediate' },
+  { min: 3000, max: 5000, code: 'B2', label: 'Upper Intermediate' },
+  { min: 5000, max: 8000, code: 'C1', label: 'Advanced' },
+  { min: 8000, max: Infinity, code: 'C2', label: 'Proficiency' },
+] as const;
+
+export function deriveCefrProgress(totalKnownWords: number): CefrProgress {
+  const idx = CEFR_LEVELS.findIndex((l) => totalKnownWords >= l.min && totalKnownWords < l.max);
+  const currentIndex = idx === -1 ? CEFR_LEVELS.length - 1 : idx;
+  const current = CEFR_LEVELS[currentIndex];
+  const next = CEFR_LEVELS[currentIndex + 1] ?? null;
+  const isTopLevel = current.max === Infinity;
+
+  const progressToNextLevel = isTopLevel
+    ? 100
+    : Math.round(((totalKnownWords - current.min) / (current.max - current.min)) * 100);
+
+  const wordsToNextLevel = isTopLevel ? null : Math.max(0, current.max - totalKnownWords);
+
+  return {
+    estimatedLevel: {
+      code: current.code,
+      label: current.label,
+      min: current.min,
+      max: isTopLevel ? null : current.max,
+    },
+    nextLevel: next ? { code: next.code, label: next.label } : null,
+    progressToNextLevel,
+    wordsToNextLevel,
+  };
+}

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -568,8 +568,12 @@ export interface FluencyStats {
   estimatedLevel: {
     code: string;
     label: string;
+    min: number;
+    max: number | null;
   };
+  nextLevel: { code: string; label: string } | null;
   progressToNextLevel: number;
+  wordsToNextLevel: number | null;
   weeklyGrowth: {
     thisWeek: number;
     lastWeek: number;


### PR DESCRIPTION
## What

The CEFR "Progress to next level" meter showed a bare percentage that invited the wrong mental math — e.g. with **709** known words in A2 (500–1500) you'd compute 709/1500 ≈ 47%, but the bar reads **21%**. The 21% is actually *correct*: it measures progress **through the current band** — `(709 − 500) / (1500 − 500)` — which resets to 0% at each new level. That's the right model (a cumulative `known / ceiling` would show a near-beginner as "10% to C2"). The bar just didn't *communicate* it.

This makes the meter self-explanatory and aligns the language-badge count with the stats page. **No formula change** — `progressToNextLevel` semantics are unchanged; this is presentation + new response fields.

## Changes

**Meter clarity** — `src/app/stats/components.tsx`
- Names the target level: **"Progress to B1"** instead of the generic "next level".
- Anchors the span under the bar — `floor … ceiling` with an **"N words to B1"** countdown — so it's obvious the bar starts at the band floor (500), not 0.

**Shared, tested derivation**
- Extracted the CEFR level table + math into `deriveCefrProgress()` (`src/lib/cefr.ts`, mirrored to `api/src/lib/cefr.ts` per the existing src/api mirror convention), with unit tests pinning the banded semantics — the 709→21% case, the boundary reset, and the C2 cap.
- Both the Next.js (`src/app/api/stats/fluency/route.ts`) and Hono (`api/src/routes/stats.ts`) fluency routes now return `estimatedLevel.{min,max}`, `nextLevel`, and `wordsToNextLevel`.

**Badge ↔ stats alignment** — `src/components/LanguageSelector/index.tsx`
- The dropdown badge now counts `getFluencyStats().totalKnownWords` (= `byState.known`), matching the stats page's "Known". It previously summed `level3+level4+known`, so the two disagreed. (Also drops the now-unused `getVocabStats` import.)

## Tests
- New `src/lib/cefr.test.ts` (4 cases).
- Extended `e2e/fluency.spec.ts`: asserts the new API fields and that the words-to-next countdown renders.
- Local: `vitest run` (144 ✓), `cd api && bun test` (66 ✓), eslint + prettier clean, `tsc --noEmit` clean for the touched files. Relying on CI for the full Playwright e2e suite (port 3456 was occupied locally).

## Screenshot
Before: `Progress to next level … 21%`  →  After: `Progress to B1 … 21%` with `500 · 791 words to B1 · 1,500` beneath the bar.
