### PR TITLE
fix(reader): stop double word-highlighting in markdown lists

### DIFF
--- a/src/components/MarkdownReader/index.tsx
+++ b/src/components/MarkdownReader/index.tsx
@@ -130,7 +130,7 @@ export default function MarkdownReader({
     ): ReactNode => {
         if (typeof children === 'string') {
             return splitWords(children).map((part, k) => {
-                if (!part.isWord) return <span key={`${keyPrefix}-${k}`}>{part.text}</span>;
+                if (!part.isWord) return <span key={`${keyPrefix}-${k}`} data-leaf="">{part.text}</span>;
                 const currentWordIndex = ctx.i++;
                 const state = getWordState(part.text);
                 const colorClass = state ? stateClasses[state] : stateClasses.new;
@@ -138,6 +138,7 @@ export default function MarkdownReader({
                 return (
                     <span
                         key={`${keyPrefix}-${k}`}
+                        data-leaf=""
                         onClick={(e) => {
                             clearPhraseHighlight();
                             const sentence = findSentence(e.currentTarget);
@@ -159,6 +160,14 @@ export default function MarkdownReader({
         }
         if (isValidElement(children)) {
             const el = children as ReactElement<{ children?: ReactNode }>;
+            // Already a leaf span we emitted — return as-is. A loose markdown list
+            // renders each item as <li><p>…</p></li>, and both the `li` and `p`
+            // components run renderBlock(); without this guard the inner pass would
+            // re-wrap the words the outer pass already wrapped, producing nested
+            // duplicate (double-highlighted) word spans.
+            if ((el.props as Record<string, unknown>)['data-leaf'] !== undefined) {
+                return el;
+            }
             return cloneElement(el, {}, renderChildren(el.props.children, ctx, keyPrefix));
         }
         return children;


### PR DESCRIPTION
## Summary

Words in markdown **lists** were highlighted twice in the reader — visibly doubled padding/background and two click targets per word — but only in `<ul>`/`<ol>`, and only for some lists.

## Root cause

A **loose** markdown list (blank lines between items) renders each item as `<li><p>…</p></li>`. `MarkdownReader`'s `li` and `p` components **both** call `renderBlock()`, so the outer (`li`) pass wraps each word in a clickable span and then the inner (`p`) pass re-wraps those spans → nested, double-highlighted word spans. **Tight** lists (no blank lines) put text directly in `<li>` with no inner `<p>`, so they render once — which is why it looked formatting-dependent.

## Fix

Make word-wrapping **idempotent**: tag each leaf span `renderChildren` emits with `data-leaf`, and return an already-tagged span unchanged instead of re-wrapping it. The inner pass becomes a no-op. Tight lists and inline formatting (`**bold**`/`*italic*` inside items) still wrap exactly once.

10 lines, one file (`src/components/MarkdownReader/index.tsx`).

## Test plan

- [ ] Open a lesson with a loose bullet list — list words highlight once, single click target, single padding.
- [ ] Inline formatting inside a list item (`- **bold** word`) still highlights each word once.
- [ ] Tight lists and normal paragraphs unchanged.

> Note: there's no jsdom/testing-library harness for components in this repo yet, so no unit test is added; verified by tracing all cases (loose list, tight list, inline-in-list) and in the running app. Happy to add a component-test setup separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
