### PR TITLE
feat(translate): two-tier streamed gloss + enrich (+ fix dict-bypass speed bug)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,14 @@ CLAUDE_OAUTH_TOKEN=
 # Anthropic models. Use plain aliases (no date suffix) so they don't get retired
 # out from under you. ANTHROPIC_MODEL is the general default; the three per-task
 # vars below override it for specific jobs and fall back to it when unset:
-#   word translation    → high volume, single words — Haiku is cheap & fast
+#   word translation    → high volume, single words — Haiku is cheap & fast.
+#                          Also drives the streamed /translate/gloss fast path,
+#                          so keeping it on Haiku is the biggest latency win.
 #   phrase / in-context  → wants more nuance — Sonnet, or Opus if results need it
 #   chat (LLM tutor)     → Sonnet, or Opus for richer explanations
 # Per-task models are Anthropic-only for now; other providers use their single model.
 ANTHROPIC_MODEL=claude-sonnet-4-6
-# ANTHROPIC_WORD_MODEL=claude-haiku-4-5
+ANTHROPIC_WORD_MODEL=claude-haiku-4-5
 # ANTHROPIC_PHRASE_MODEL=claude-sonnet-4-6
 # ANTHROPIC_CHAT_MODEL=claude-sonnet-4-6
 

--- a/api/src/lib/dictionary-db.ts
+++ b/api/src/lib/dictionary-db.ts
@@ -16,9 +16,13 @@ import { getActiveLanguageCode } from './active-language';
 
 // The dictionary is read-only application data shipped with the image. Prefer
 // DICT_DIR so it stays put when the user mounts a volume on DATA_DIR for their
-// (mutable) data; fall back to DATA_DIR for local dev, then ./data.
+// (mutable) data; fall back to DATA_DIR, then '../data'. The default mirrors
+// db.ts (which also defaults to '../data') because the API runs from ./api in
+// local dev (`cd api && bun run …`) — a bare './data' resolved to the
+// nonexistent ./api/data, so every dictionary lookup silently missed and every
+// word fell through to the (slow) AI path.
 function getDbPath(language: string): string {
-  const dir = process.env.DICT_DIR || process.env.DATA_DIR || './data';
+  const dir = process.env.DICT_DIR || process.env.DATA_DIR || '../data';
   return path.join(dir, `dictionary-${language}.db`);
 }
 

--- a/api/src/lib/llm/anthropic.ts
+++ b/api/src/lib/llm/anthropic.ts
@@ -89,6 +89,34 @@ export class AnthropicProvider implements LLMProvider {
     return this.completeViaApi(options, model);
   }
 
+  async *stream(options: CompletionOptions): AsyncGenerator<string> {
+    const model = this.modelForTask(options.task);
+    // The Agent SDK (OAuth path) doesn't expose a clean token stream here, so
+    // buffer the whole result and yield it once. The contract only requires the
+    // concatenation to equal complete()'s output — pin auth to an API key to get
+    // real token-by-token streaming on the latency-critical gloss path.
+    if (this.useAgentSdk) {
+      const text = await this.completeViaAgentSdk(options, model);
+      if (text) yield text;
+      return;
+    }
+
+    const stream = this.client!.messages.stream({
+      model,
+      max_tokens: options.maxTokens,
+      messages: options.messages.map((m) => ({
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+      })),
+    });
+
+    for await (const event of stream) {
+      if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+        yield event.delta.text;
+      }
+    }
+  }
+
   private async completeViaApi(options: CompletionOptions, model: string): Promise<string> {
     const message = await this.client!.messages.create({
       model,

--- a/api/src/lib/llm/openai-compatible.ts
+++ b/api/src/lib/llm/openai-compatible.ts
@@ -77,6 +77,63 @@ export class OpenAICompatibleProvider implements LLMProvider {
     return data.choices?.[0]?.message?.content || '';
   }
 
+  /**
+   * Stream a completion via `stream: true`. The server sends SSE frames
+   * (`data: {json}\n\n`, terminated by `data: [DONE]`); we parse each line,
+   * pull `choices[0].delta.content`, and yield it. Note fetchWithTimeout only
+   * bounds the time-to-headers — once the response resolves the abort timer is
+   * cleared, so a long stream body isn't cut off mid-generation.
+   */
+  async *stream(options: CompletionOptions): AsyncGenerator<string> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: options.messages,
+      max_tokens: options.maxTokens,
+      stream: true,
+    };
+
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok || !response.body) {
+      const error = response.ok ? 'no response body' : await response.text().catch(() => `HTTP ${response.status}`);
+      throw new Error(`LLM provider error: ${error}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        // SSE frames are newline-delimited; process every complete line and
+        // keep the trailing partial in the buffer for the next chunk.
+        let nl: number;
+        while ((nl = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, nl).trim();
+          buffer = buffer.slice(nl + 1);
+          if (!line.startsWith('data:')) continue; // skip blank lines / comments
+          const data = line.slice(5).trim();
+          if (data === '[DONE]') return;
+          try {
+            const json = JSON.parse(data);
+            const delta = json.choices?.[0]?.delta?.content;
+            if (delta) yield delta as string;
+          } catch {
+            // keep-alive ping or non-JSON line — ignore
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   async healthCheck(): Promise<{ ok: boolean; error?: string }> {
     try {
       const response = await this.fetchWithTimeout(`${this.baseUrl}/v1/models`, {

--- a/api/src/lib/llm/types.ts
+++ b/api/src/lib/llm/types.ts
@@ -33,6 +33,15 @@ export interface LLMProvider {
   /** The configured model identifier, surfaced for status reporting. */
   model?: string;
   complete(options: CompletionOptions): Promise<string>;
+  /**
+   * Stream a completion as incremental text deltas — used by the latency-sensitive
+   * word-gloss path so the reader sees the translation form as it generates rather
+   * than waiting for the whole response. Yields text *fragments* (not cumulative);
+   * callers concatenate. Providers that can't truly stream (e.g. the Anthropic
+   * Agent-SDK/OAuth path) may buffer and yield once — the contract is only that the
+   * concatenation equals what complete() would have returned.
+   */
+  stream(options: CompletionOptions): AsyncIterable<string>;
   /** Check if the provider is reachable and configured */
   healthCheck(): Promise<{ ok: boolean; error?: string }>;
 }

--- a/api/src/lib/translate-prompts.test.ts
+++ b/api/src/lib/translate-prompts.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { buildGlossPrompt, buildWordEntryPrompt, buildPhrasePrompt } from './translate-prompts';
+import { getSpelreelsContext } from './spelreels';
+
+const WORD = 'seemeeu';
+const SENTENCE = 'By die see sien sy n seemeeu wat oor die water vlieg.';
+
+// A fragment that only appears in the injected Afrikaans spelreels block.
+const SPELREELS_MARKER = 'Spelreëls';
+
+describe('buildGlossPrompt (fast path)', () => {
+  const prompt = buildGlossPrompt('Afrikaans', WORD, SENTENCE);
+
+  test('includes the word and sentence', () => {
+    expect(prompt).toContain(WORD);
+    expect(prompt).toContain(SENTENCE);
+  });
+
+  test('asks for plain text, not JSON', () => {
+    expect(prompt).not.toContain('JSON');
+    expect(prompt).not.toContain('"senses"');
+  });
+
+  test('never carries the spelreels ruleset', () => {
+    expect(prompt).not.toContain(SPELREELS_MARKER);
+    expect(prompt).not.toContain(getSpelreelsContext());
+  });
+
+  test('stays short (the whole point of the fast path)', () => {
+    // Generous ceiling: the real prompt is ~400 chars. The old word prompt with
+    // spelreels was ~13k+. This guards against the ruleset sneaking back in.
+    expect(prompt.length).toBeLessThan(1000);
+  });
+});
+
+describe('buildWordEntryPrompt (enrich path)', () => {
+  const prompt = buildWordEntryPrompt('Afrikaans', WORD, SENTENCE);
+
+  test('requests the rich structured schema', () => {
+    expect(prompt).toContain('"senses"');
+    expect(prompt).toContain('"ipa"');
+    expect(prompt).toContain('"etymology"');
+    expect(prompt).toContain('"relatedForms"');
+  });
+
+  test('never carries the spelreels ruleset (the regression we are fixing)', () => {
+    expect(prompt).not.toContain(SPELREELS_MARKER);
+    expect(prompt).not.toContain(getSpelreelsContext());
+  });
+});
+
+describe('buildPhrasePrompt (keeps spelreels for af)', () => {
+  test('embeds the spelreels section when one is provided', () => {
+    const section = `Use the following official spelling rules:\n\n${getSpelreelsContext()}\n\n---\n\n`;
+    const prompt = buildPhrasePrompt('Afrikaans', section, 'die appel van my oog', SENTENCE);
+    expect(prompt).toContain(SPELREELS_MARKER);
+  });
+
+  test('omits it when the section is empty (non-af languages)', () => {
+    const prompt = buildPhrasePrompt('German', '', 'der Apfel', SENTENCE);
+    expect(prompt).not.toContain(SPELREELS_MARKER);
+  });
+});

--- a/api/src/lib/translate-prompts.ts
+++ b/api/src/lib/translate-prompts.ts
@@ -1,0 +1,96 @@
+/**
+ * Prompt builders for the translation routes, kept in their own dependency-free
+ * module (no DB, no provider) so they can be unit-tested as pure functions.
+ *
+ * The load-bearing invariant these encode: the spelreels (Afrikaans orthography
+ * ruleset, ~3.3k tokens) is injected ONLY on the phrase path, never on a
+ * single-word lookup. It used to ride along on every word translation and blew
+ * past small local models' context windows for negligible gain.
+ */
+
+/**
+ * Fast-path word gloss. Deliberately tiny: plain-text output (streamable, no
+ * JSON to wait on), no spelreels, no IPA/etymology/related-forms. This is what
+ * the reader sees the instant they click — the rich dictionary entry is a
+ * separate opt-in "enrich" call.
+ */
+export function buildGlossPrompt(langName: string, word: string, sentence: string): string {
+  return `You are a ${langName} to English translator. A learner clicked the word "${word}" while reading.
+Sentence context: "${sentence || word}"
+
+Reply with ONLY the concise English meaning — the natural translation(s), most common sense first, separated by "; ". No explanation, no quotes, no markdown, no extra words. If the word is an inflected form you may prefix a short tag like "(plural)" or "(past tense)". Keep it under ~12 words.`;
+}
+
+/**
+ * Rich dictionary-quality word entry (senses + IPA + etymology + related forms).
+ * Used by the opt-in "enrich" action and by legacy structured word lookups
+ * (in-context / re-translate). No spelreels — the full orthography ruleset adds
+ * thousands of tokens of latency for negligible gain on a single-word lookup.
+ */
+export function buildWordEntryPrompt(langName: string, word: string, sentence: string): string {
+  return `You are a ${langName} to English translator with deep knowledge of ${langName} orthography, morphology, and etymology.
+
+A learner clicked the following ${langName} word while reading. Produce a dictionary-quality entry — not a single gloss. The output is used both to display the meaning AND to persist into an on-device dictionary, so be thorough and faithful.
+
+Word: "${word}"
+Sentence context: "${sentence || word}"
+
+Respond with ONLY a JSON object in this exact shape (no markdown, no code blocks):
+{
+  "word": "${word}",
+  "senses": [
+    { "partOfSpeech": "noun | verb | adjective | adverb | pronoun | preposition | conjunction | interjection | determiner | numeral | particle", "gloss": "concise English meaning, no period" }
+    /* ...one entry per distinct sense; order most-common first */
+  ],
+  "ipa": "/.../ or [...] — phonetic transcription if you're confident",
+  "etymology": "Brief origin note (e.g. 'From Dutch X, from Middle Dutch Y')",
+  "relatedForms": [
+    { "form": "the related word", "relation": "plural of | diminutive of | past tense of | derived from | etc." }
+  ]
+}
+
+Rules:
+- "word" and "senses" are REQUIRED. senses must be non-empty.
+- CRITICAL — valid JSON only: never put a double-quote character (") inside any string value. To quote a word, gloss, or cognate (common in etymology), use single quotes ('like this') or parentheses. A raw double quote inside a value breaks the JSON and the entry is discarded.
+- Include separate sense entries for genuinely distinct meanings (e.g. trek = pull / move / journey). Don't split shades of the same meaning.
+- Use the sentence to bias sense ORDER, but include all common senses a learner might reasonably encounter.
+- Each gloss is a short English phrase (1-4 words is typical, up to a clause for verbs with idiomatic completions).
+- Omit ipa / etymology / relatedForms entirely if you're not confident — don't guess.
+- Use the same partOfSpeech vocabulary as Wiktionary so cached entries align with the curated dict.
+
+Backwards-compat fields the server adds (do NOT include these yourself — server stitches them from senses): translation, partOfSpeech.`;
+}
+
+/**
+ * Phrase / idiom translation. This path KEEPS the Afrikaans spelreels context
+ * (passed in by the caller, af only) — idioms and fixed expressions genuinely
+ * benefit from the orthography/register rules, and phrases are looked up far
+ * less often than single words, so the extra tokens are an acceptable cost here.
+ */
+export function buildPhrasePrompt(langName: string, spelreelsSection: string, word: string, sentence: string): string {
+  return `You are a ${langName} to English translator with deep knowledge of ${langName} orthography, idiom, and register.
+
+${spelreelsSection}A learner has selected a ${langName} phrase from a text they're reading. Help them understand it the way a native speaker would — not just what the words say, but what the phrase actually means, why it's phrased this way, and when it would be used.
+
+Phrase: "${word}"
+Sentence context: "${sentence || word}"
+
+Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
+{
+  "translation": "the most natural English translation a fluent speaker would use",
+  "literalBreakdown": "word-by-word literal gloss (e.g. 'hand-shoe' for handskoen)",
+  "idiomaticMeaning": "if the phrase is an idiom, fixed expression, or compound: what it actually means and why — e.g. 'This is an idiom which literally means X. It is used when ...'",
+  "usageNotes": "register, tone, formality, or contextual notes a learner should know (e.g. 'informal', 'used by older speakers', 'often sarcastic', 'common in Bible-influenced Afrikaans')",
+  "register": "formal | informal | literary | colloquial | archaic | neutral"
+}
+
+CRITICAL — valid JSON only: never put a double-quote character (") inside any string value. To quote a word or phrase, use single quotes ('like this') or parentheses. A raw double quote inside a value breaks the JSON and the lookup fails.
+
+Required fields: translation. All other fields are optional — only include them when they add real value:
+- Include literalBreakdown if the phrase is more than one word AND the literal gloss differs from the natural translation in an interesting way.
+- Include idiomaticMeaning ALWAYS for idioms, fixed expressions, sayings, proverbs, or compound words whose meaning isn't obvious from the parts. Explain like a teacher would.
+- Include usageNotes when the phrase carries register / tone / cultural baggage the learner couldn't infer from the dictionary.
+- Include register if you're confident; omit if neutral or unclear.
+
+Be specific and concrete in idiomaticMeaning and usageNotes — avoid vague phrases like 'commonly used' or 'has a special meaning'.`;
+}

--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -1,8 +1,10 @@
 import { Hono } from 'hono';
+import { streamText } from 'hono/streaming';
 import { getProvider, parseLooseJson } from '../lib/llm';
 import { getSpelreelsContext } from '../lib/spelreels';
 import { resolveLanguage } from '../lib/active-language';
 import { getLanguageConfig } from '../lib/languages';
+import { buildGlossPrompt, buildWordEntryPrompt, buildPhrasePrompt } from '../lib/translate-prompts';
 
 import { db } from '../db';
 
@@ -19,9 +21,102 @@ function recordStudyPing() {
   `).run(now, today);
 }
 
+// Parse a rich word-entry response and stitch the legacy translation/partOfSpeech
+// fields so existing call sites that only read those don't have to change.
+function stitchWordEntry(text: string, fallbackWord: string) {
+  const entry = parseLooseJson(text) as {
+    word?: string;
+    senses?: Array<{ partOfSpeech: string; gloss: string }>;
+    ipa?: string;
+    etymology?: string;
+    relatedForms?: Array<{ form: string; relation: string }>;
+  };
+
+  const senses: Array<{ partOfSpeech: string; gloss: string }> = Array.isArray(entry.senses) ? entry.senses : [];
+  const stitchedTranslation = senses.map((s) => s.gloss).filter(Boolean).join('; ');
+
+  return {
+    translation: stitchedTranslation,
+    partOfSpeech: senses[0]?.partOfSpeech,
+    word: entry.word || fallbackWord,
+    senses,
+    ipa: entry.ipa,
+    etymology: entry.etymology,
+    relatedForms: Array.isArray(entry.relatedForms) ? entry.relatedForms : undefined,
+  };
+}
+
+// Shared handler for the structured word entry — used by POST / (type=word) and
+// POST /enrich. Throws on provider/JSON failure; callers wrap in try/catch.
+async function buildWordEntryResponse(langName: string, word: string, sentence: string) {
+  const provider = getProvider();
+  const text = await provider.complete({
+    messages: [{ role: 'user', content: buildWordEntryPrompt(langName, word, sentence) }],
+    maxTokens: 1500,
+    task: 'word-translation',
+    responseFormat: 'json',
+  });
+  return stitchWordEntry(text, word);
+}
+
 const app = new Hono();
 
-// POST /api/translate
+// POST /api/translate/gloss — latency-critical fast path (single words only).
+// Streams a plain-text gloss as it generates so the reader sees the meaning
+// form token-by-token instead of waiting for a full structured response.
+app.post('/gloss', async (c) => {
+  const { word, sentence, language } = await c.req.json();
+  if (!word) {
+    return c.json({ error: 'Word is required' }, 400);
+  }
+
+  recordStudyPing();
+
+  const lang = resolveLanguage(language);
+  const langName = getLanguageConfig(lang).name;
+  const prompt = buildGlossPrompt(langName, word, sentence || '');
+  const provider = getProvider();
+
+  // streamText commits a 200 the moment it starts, so a provider failure before
+  // the first delta can't become a non-200. We log and end the stream; the
+  // client treats an empty gloss as a failure and can retry / fall back to
+  // /enrich. (Errors mid-stream are unavoidable over a committed response.)
+  return streamText(c, async (stream) => {
+    try {
+      for await (const delta of provider.stream({
+        messages: [{ role: 'user', content: prompt }],
+        maxTokens: 200,
+        task: 'word-translation',
+      })) {
+        await stream.write(delta);
+      }
+    } catch (err) {
+      console.error('Gloss stream error:', err);
+    }
+  });
+});
+
+// POST /api/translate/enrich — opt-in rich dictionary entry for a word the user
+// already glossed. Off the critical path, so it stays non-streamed JSON. No
+// study ping: the originating /gloss call already counted this lookup.
+app.post('/enrich', async (c) => {
+  try {
+    const { word, sentence, language } = await c.req.json();
+    if (!word) {
+      return c.json({ error: 'Word is required' }, 400);
+    }
+    const lang = resolveLanguage(language);
+    const langName = getLanguageConfig(lang).name;
+    return c.json(await buildWordEntryResponse(langName, word, sentence || ''));
+  } catch (error) {
+    console.error('Enrich error:', error);
+    return c.json({ error: error instanceof Error ? error.message : 'Enrich failed' }, 500);
+  }
+});
+
+// POST /api/translate — original endpoint. Phrases use the spelreels-aware
+// phrase prompt; words return the rich structured entry (now spelreels-free).
+// Kept for in-context / re-translate callers and back-compat.
 app.post('/', async (c) => {
   try {
     const { word, sentence, type = 'word', language } = await c.req.json();
@@ -36,111 +131,24 @@ app.post('/', async (c) => {
     const langConfig = getLanguageConfig(lang);
     const langName = langConfig.name;
 
-    const spelreels = lang === 'af' ? getSpelreelsContext() : '';
-    const spelreelsSection = spelreels ? `Use the following official spelling rules to inform your understanding of the ${langName} input:\n\n${spelreels}\n\n---\n\n` : '';
-
     if (type === 'phrase') {
-      const prompt = `You are a ${langName} to English translator with deep knowledge of ${langName} orthography, idiom, and register.
-
-${spelreelsSection}A learner has selected a ${langName} phrase from a text they're reading. Help them understand it the way a native speaker would — not just what the words say, but what the phrase actually means, why it's phrased this way, and when it would be used.
-
-Phrase: "${word}"
-Sentence context: "${sentence || word}"
-
-Respond with ONLY a JSON object in this exact format (no markdown, no code blocks):
-{
-  "translation": "the most natural English translation a fluent speaker would use",
-  "literalBreakdown": "word-by-word literal gloss (e.g. 'hand-shoe' for handskoen)",
-  "idiomaticMeaning": "if the phrase is an idiom, fixed expression, or compound: what it actually means and why — e.g. 'This is an idiom which literally means X. It is used when ...'",
-  "usageNotes": "register, tone, formality, or contextual notes a learner should know (e.g. 'informal', 'used by older speakers', 'often sarcastic', 'common in Bible-influenced Afrikaans')",
-  "register": "formal | informal | literary | colloquial | archaic | neutral"
-}
-
-CRITICAL — valid JSON only: never put a double-quote character (") inside any string value. To quote a word or phrase, use single quotes ('like this') or parentheses. A raw double quote inside a value breaks the JSON and the lookup fails.
-
-Required fields: translation. All other fields are optional — only include them when they add real value:
-- Include literalBreakdown if the phrase is more than one word AND the literal gloss differs from the natural translation in an interesting way.
-- Include idiomaticMeaning ALWAYS for idioms, fixed expressions, sayings, proverbs, or compound words whose meaning isn't obvious from the parts. Explain like a teacher would.
-- Include usageNotes when the phrase carries register / tone / cultural baggage the learner couldn't infer from the dictionary.
-- Include register if you're confident; omit if neutral or unclear.
-
-Be specific and concrete in idiomaticMeaning and usageNotes — avoid vague phrases like 'commonly used' or 'has a special meaning'.`;
+      const spelreels = lang === 'af' ? getSpelreelsContext() : '';
+      const spelreelsSection = spelreels
+        ? `Use the following official spelling rules to inform your understanding of the ${langName} input:\n\n${spelreels}\n\n---\n\n`
+        : '';
 
       const provider = getProvider();
       const text = await provider.complete({
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: buildPhrasePrompt(langName, spelreelsSection, word, sentence || '') }],
         maxTokens: 1500,
         task: 'phrase-translation',
         responseFormat: 'json',
       });
 
       return c.json(parseLooseJson<Record<string, unknown>>(text));
-    } else {
-      const prompt = `You are a ${langName} to English translator with deep knowledge of ${langName} orthography, morphology, and etymology.
-
-${spelreelsSection}A learner clicked the following ${langName} word while reading. Produce a dictionary-quality entry — not a single gloss. The output is used both to display the meaning AND to persist into an on-device dictionary, so be thorough and faithful.
-
-Word: "${word}"
-Sentence context: "${sentence || word}"
-
-Respond with ONLY a JSON object in this exact shape (no markdown, no code blocks):
-{
-  "word": "${word}",
-  "senses": [
-    { "partOfSpeech": "noun | verb | adjective | adverb | pronoun | preposition | conjunction | interjection | determiner | numeral | particle", "gloss": "concise English meaning, no period" }
-    /* ...one entry per distinct sense; order most-common first */
-  ],
-  "ipa": "/.../ or [...] — phonetic transcription if you're confident",
-  "etymology": "Brief origin note (e.g. 'From Dutch X, from Middle Dutch Y')",
-  "relatedForms": [
-    { "form": "the related word", "relation": "plural of | diminutive of | past tense of | derived from | etc." }
-  ]
-}
-
-Rules:
-- "word" and "senses" are REQUIRED. senses must be non-empty.
-- CRITICAL — valid JSON only: never put a double-quote character (") inside any string value. To quote a word, gloss, or cognate (common in etymology), use single quotes ('like this') or parentheses. A raw double quote inside a value breaks the JSON and the entry is discarded.
-- Include separate sense entries for genuinely distinct meanings (e.g. trek = pull / move / journey). Don't split shades of the same meaning.
-- Use the sentence to bias sense ORDER, but include all common senses a learner might reasonably encounter.
-- Each gloss is a short English phrase (1-4 words is typical, up to a clause for verbs with idiomatic completions).
-- Omit ipa / etymology / relatedForms entirely if you're not confident — don't guess.
-- Use the same partOfSpeech vocabulary as Wiktionary so cached entries align with the curated dict.
-
-Backwards-compat fields the server adds (do NOT include these yourself — server stitches them from senses): translation, partOfSpeech.`;
-
-      const provider = getProvider();
-      const text = await provider.complete({
-        messages: [{ role: 'user', content: prompt }],
-        maxTokens: 1500,
-        task: 'word-translation',
-        responseFormat: 'json',
-      });
-
-      const entry = parseLooseJson(text) as {
-        word?: string;
-        senses?: Array<{ partOfSpeech: string; gloss: string }>;
-        ipa?: string;
-        etymology?: string;
-        relatedForms?: Array<{ form: string; relation: string }>;
-      };
-
-      // Stitch legacy fields so existing call sites that only read translation +
-      // partOfSpeech don't have to change.
-      const senses: Array<{ partOfSpeech: string; gloss: string }> = Array.isArray(entry.senses) ? entry.senses : [];
-      const stitchedTranslation = senses.map((s) => s.gloss).filter(Boolean).join('; ');
-      const firstPos = senses[0]?.partOfSpeech;
-
-      return c.json({
-        translation: stitchedTranslation,
-        partOfSpeech: firstPos,
-        // Pass through the structured fields
-        word: entry.word || word,
-        senses,
-        ipa: entry.ipa,
-        etymology: entry.etymology,
-        relatedForms: Array.isArray(entry.relatedForms) ? entry.relatedForms : undefined,
-      });
     }
+
+    return c.json(await buildWordEntryResponse(langName, word, sentence || ''));
   } catch (error) {
     console.error('Translation error:', error);
     return c.json(

--- a/e2e/nested-definitions.spec.ts
+++ b/e2e/nested-definitions.spec.ts
@@ -73,6 +73,13 @@ test.describe('Nested dictionary definitions (reader)', () => {
       });
     });
 
+    // A dict-miss word (incl. a nested lookup that misses) now streams its gloss
+    // from /translate/gloss as plain text rather than the structured endpoint.
+    await page.route('**/api/translate/gloss', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      await route.fulfill({ status: 200, contentType: 'text/plain', body: `[translated: ${body.word}]` });
+    });
+
     // Remove leftovers from aborted runs
     const res = await page.request.get('/api/collections');
     for (const c of await res.json()) {

--- a/e2e/reader-markdown.spec.ts
+++ b/e2e/reader-markdown.spec.ts
@@ -46,6 +46,12 @@ test.describe('Reader markdown rendering', () => {
       });
     });
 
+    // Word dict-misses stream a plain-text gloss from /translate/gloss.
+    await page.route('**/api/translate/gloss', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      await route.fulfill({ status: 200, contentType: 'text/plain', body: `[translated: ${body.word}]` });
+    });
+
     const res = await page.request.get('/api/collections');
     for (const c of await res.json()) {
       if (c.title === TITLE) await page.request.delete(`/api/collections/${c.id}`);

--- a/e2e/reader-streaming-gloss.spec.ts
+++ b/e2e/reader-streaming-gloss.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Two-tier word translation on the reader (issue: translation latency).
+ *
+ * Clicking a word that misses the on-device dictionary should:
+ *   1. stream a fast plain-text gloss into the drawer (POST /api/translate/gloss)
+ *   2. offer an "Enrich" button that fetches the rich entry — senses, IPA,
+ *      etymology, related forms (POST /api/translate/enrich)
+ *
+ * Both LLM endpoints are mocked so we assert the wiring, not the model. The
+ * dictionary lookup is forced to a miss so the AI path is deterministic.
+ */
+
+const GLOSS = 'seagull';
+const TITLE = 'Streaming Gloss Test';
+
+async function setupMocks(page: Page) {
+  // Force a dictionary miss so the click always falls through to the AI path.
+  await page.route('**/api/dictionary/lookup*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ entry: null }),
+    });
+  });
+
+  // Fast path: plain-text gloss (the client reads it via a stream reader).
+  await page.route('**/api/translate/gloss', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'text/plain', body: GLOSS });
+  });
+
+  // Enrich path: the rich structured entry.
+  await page.route('**/api/translate/enrich', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        translation: GLOSS,
+        partOfSpeech: 'noun',
+        word: 'seemeeu',
+        senses: [{ partOfSpeech: 'noun', gloss: GLOSS }],
+        ipa: '/ˈseː.mɪːu/',
+        etymology: 'From Afrikaans see (sea) plus meeu (gull).',
+        relatedForms: [{ form: 'seemeeue', relation: 'plural of' }],
+      }),
+    });
+  });
+}
+
+async function importLesson(page: Page): Promise<string> {
+  const colRes = await page.request.post('/api/collections', {
+    data: { title: TITLE, language: 'af' },
+  });
+  const { id: collectionId } = await colRes.json();
+
+  await page.request.post(`/api/collections/${collectionId}/lessons`, {
+    data: {
+      title: 'Hoofstuk 1',
+      textContent: 'By die see sien sy n seemeeu wat oor die water vlieg.',
+    },
+  });
+
+  const lessonsRes = await page.request.get(`/api/collections/${collectionId}/lessons`);
+  const lessons = await lessonsRes.json();
+  await page.goto(`/read/${lessons[0].id}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByText('seemeeu')).toBeVisible({ timeout: 10000 });
+  return collectionId;
+}
+
+test.describe('Reader — streamed gloss + enrich', () => {
+  let collectionId: string;
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setupMocks(page);
+
+    // Clean leftovers from a prior run.
+    const res = await page.request.get('/api/collections');
+    for (const c of await res.json()) {
+      if (c.title === TITLE) await page.request.delete(`/api/collections/${c.id}`);
+    }
+    const vocabRes = await page.request.get('/api/vocab?text=seemeeu');
+    for (const v of await vocabRes.json()) {
+      await page.request.delete(`/api/vocab/${v.id}`);
+    }
+
+    collectionId = await importLesson(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (collectionId) await page.request.delete(`/api/collections/${collectionId}`);
+  });
+
+  test('streams a gloss, then enriches to the full entry', async ({ page }) => {
+    const word = page.locator('article span.cursor-pointer', { hasText: 'seemeeu' });
+    await expect(word).toBeVisible();
+    await word.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+
+    // Tier 1: the streamed gloss is shown.
+    await expect(drawer.getByText(GLOSS, { exact: false })).toBeVisible({ timeout: 5000 });
+
+    // It's an AI result, not an on-device dict hit.
+    await expect(drawer.getByText('on-device')).toHaveCount(0);
+
+    // Tier 2: Enrich is offered for the bare gloss.
+    const enrich = drawer.getByRole('button', { name: 'Enrich' });
+    await expect(enrich).toBeVisible();
+    await enrich.click();
+
+    // Rich fields appear after enrichment.
+    await expect(drawer.getByText('Etymology')).toBeVisible({ timeout: 5000 });
+    await expect(drawer.getByText('From Afrikaans see', { exact: false })).toBeVisible();
+    await expect(drawer.getByText('Related forms')).toBeVisible();
+    await expect(drawer.getByText('seemeeue')).toBeVisible();
+
+    // Once enriched, the Enrich affordance is gone.
+    await expect(enrich).toHaveCount(0);
+  });
+
+  test('gloss result is not flagged as an on-device dictionary hit', async ({ page }) => {
+    const word = page.locator('article span.cursor-pointer', { hasText: 'seemeeu' });
+    await word.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+    await expect(drawer.getByText(GLOSS, { exact: false })).toBeVisible({ timeout: 5000 });
+
+    // The "AI" source pill should show, not "on-device" or "learned".
+    await expect(drawer.getByText('on-device')).toHaveCount(0);
+    await expect(drawer.getByText('learned')).toHaveCount(0);
+  });
+});

--- a/e2e/reader-streaming-gloss.spec.ts
+++ b/e2e/reader-streaming-gloss.spec.ts
@@ -135,3 +135,20 @@ test.describe('Reader — streamed gloss + enrich', () => {
     await expect(drawer.getByText('learned')).toHaveCount(0);
   });
 });
+
+/**
+ * Guard against the easy mistake of adding a Hono route without its Next proxy
+ * file (each /api/* path needs its own app/api/.../route.ts — there's no
+ * catch-all). The UI specs above mock these endpoints, so a missing proxy would
+ * pass there but 404 in the real app. Here we hit the REAL proxy → Hono with no
+ * word: a wired route forwards and Hono replies 400; a missing proxy 404s. No
+ * LLM call (rejected at validation), so it's safe in CI.
+ */
+test.describe('translate proxy routes are wired', () => {
+  for (const path of ['/api/translate/gloss', '/api/translate/enrich']) {
+    test(`${path} forwards to Hono (not 404)`, async ({ request }) => {
+      const res = await request.post(path, { data: { language: 'af' } });
+      expect(res.status(), `${path} should reach Hono, not be a missing Next route`).toBe(400);
+    });
+  }
+});

--- a/e2e/reader-word-handling.spec.ts
+++ b/e2e/reader-word-handling.spec.ts
@@ -37,7 +37,7 @@ test.describe('Reader word handling', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
 
-    // Mock translate API
+    // Mock translate API (phrase + legacy structured word path).
     await page.route('**/api/translate', async (route) => {
       const body = JSON.parse(route.request().postData() || '{}');
       await route.fulfill({
@@ -48,6 +48,12 @@ test.describe('Reader word handling', () => {
           partOfSpeech: body.type === 'phrase' ? 'phrase' : 'noun',
         }),
       });
+    });
+
+    // Word dict-misses now stream a plain-text gloss from /translate/gloss.
+    await page.route('**/api/translate/gloss', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      await route.fulfill({ status: 200, contentType: 'text/plain', body: `[translated: ${body.word}]` });
     });
 
     // Clean up any leftover test collections

--- a/e2e/translation-cache.spec.ts
+++ b/e2e/translation-cache.spec.ts
@@ -8,9 +8,10 @@ import { test, expect, Page, Route } from '@playwright/test';
  * Strategy:
  *   1. Import a book with a known nonsense token that's guaranteed to miss
  *      the on-device dict (and isn't a real Afrikaans word).
- *   2. Mock /api/translate to return a deterministic structured response;
- *      assert exactly ONE call across the test.
- *   3. Click the word, mark it Known (an accept action).
+ *   2. Mock /api/translate/gloss (the streamed fast path) with a deterministic
+ *      response; assert exactly ONE call across the test.
+ *   3. Click the word, mark it Known (an accept action) — the gloss is cached
+ *      as a single sense.
  *   4. Re-click the same word — the drawer must show the `learned` source pill
  *      and the AI mock must still report exactly one total invocation.
  */
@@ -39,39 +40,26 @@ test.describe('AI translation cache', () => {
   // dict entry, and so the cache is empty for the first click.
   const NONSENSE = `xqzzaftj${Date.now().toString(36)}`;
   let collectionId: string;
-  let translateCallCount = 0;
+  let glossCallCount = 0;
 
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    translateCallCount = 0;
+    glossCallCount = 0;
 
-    // Mock the AI translate endpoint with a structured payload that the
-    // drawer can render AND the cache can persist.
+    // The read page streams a plain-text gloss for a dict miss; that gloss is
+    // what gets cached (as a single sense) when the user accepts it.
+    await page.route('**/api/translate/gloss', async (route: Route) => {
+      glossCallCount++;
+      await route.fulfill({ status: 200, contentType: 'text/plain', body: 'invented; made-up' });
+    });
+
+    // Phrase + legacy structured word path — not exercised by the bare-gloss
+    // accept flow, but stubbed so a stray call never hits the network.
     await page.route('**/api/translate', async (route: Route) => {
-      const body = JSON.parse(route.request().postData() || '{}');
-      if (body.type === 'phrase') {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ translation: '[ai phrase]', partOfSpeech: 'phrase' }),
-        });
-        return;
-      }
-      translateCallCount++;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          translation: 'invented; made-up',
-          partOfSpeech: 'noun',
-          word: body.word,
-          senses: [
-            { partOfSpeech: 'noun', gloss: 'invented' },
-            { partOfSpeech: 'noun', gloss: 'made-up' },
-          ],
-          ipa: '/test/',
-          etymology: 'From the test suite',
-        }),
+        body: JSON.stringify({ translation: '[ai phrase]', partOfSpeech: 'phrase' }),
       });
     });
 
@@ -106,7 +94,7 @@ test.describe('AI translation cache', () => {
     const drawer = page.getByTestId('translation-drawer');
     await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
     await expect(drawer.getByText('AI', { exact: true })).toBeVisible({ timeout: 5000 });
-    expect(translateCallCount).toBe(1);
+    expect(glossCallCount).toBe(1);
 
     // Accept via "Known" — this should fire-and-forget the cache write.
     await drawer.getByRole('button', { name: /Known/ }).click();
@@ -131,6 +119,6 @@ test.describe('AI translation cache', () => {
     await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
     await expect(drawer.getByText('learned', { exact: true })).toBeVisible({ timeout: 5000 });
     await expect(drawer.locator('ol li').first()).toBeVisible();
-    expect(translateCallCount).toBe(1);
+    expect(glossCallCount).toBe(1);
   });
 });

--- a/src/app/api/translate/enrich/route.ts
+++ b/src/app/api/translate/enrich/route.ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from '@/lib/server/api-proxy';
+
+// POST /api/translate/enrich — proxied to the Hono API
+// (api/src/routes/translate.ts). Returns the rich structured word entry.
+export const POST = proxyToApi;

--- a/src/app/api/translate/gloss/route.ts
+++ b/src/app/api/translate/gloss/route.ts
@@ -1,0 +1,6 @@
+import { proxyToApi } from '@/lib/server/api-proxy';
+
+// POST /api/translate/gloss — proxied to the Hono API
+// (api/src/routes/translate.ts). Streams a plain-text gloss; proxyToApi pipes
+// the upstream body straight through, so the stream survives the hop.
+export const POST = proxyToApi;

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -17,7 +17,7 @@ import {
   updateLesson,
   incrementDailyStat,
 } from '@/lib/data-layer';
-import { translateWord, translatePhrase } from '@/lib/claude';
+import { translateWord, translatePhrase, streamWordGloss, enrichWord } from '@/lib/claude';
 import {
   lookupWordRemote,
   cacheAcceptedTranslation,
@@ -52,6 +52,8 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
     phraseDetails: null,
     isLoading: false,
     isContextLoading: false,
+    isStreamingGloss: false,
+    isEnriching: false,
     isDictionaryResult: false,
     error: null,
     existingEntry: null,
@@ -109,6 +111,8 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
       phraseDetails: null,
       isLoading: true,
       isContextLoading: false,
+      isStreamingGloss: false,
+      isEnriching: false,
       isDictionaryResult: false,
       error: null,
       existingEntry: null,
@@ -182,34 +186,37 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
           isDictionaryResult: true,
         }));
       } else if (!hasTranslation) {
-        // No dict hit AND no saved vocab translation — fall back to AI.
+        // No dict hit AND no saved vocab translation — stream a fast AI gloss.
+        // The rich entry (senses/IPA/etymology) is opt-in via the Enrich button,
+        // so this first paint is just a concise meaning, arriving token-by-token.
         try {
-          const result = await translateWord(word, sentence);
+          const gloss = await streamWordGloss(word, sentence, (cumulative) => {
+            if (requestId !== translationRequestId.current) return;
+            setWordPanel((prev) => ({
+              ...prev,
+              translation: cumulative,
+              partOfSpeech: null,
+              dictEntry: null,
+              aiStructured: null,
+              isLoading: false,
+              isStreamingGloss: true,
+              isDictionaryResult: false,
+            }));
+          });
           if (requestId !== translationRequestId.current) return;
-          const structured =
-            result.senses && result.senses.length > 0
-              ? {
-                  senses: result.senses,
-                  ipa: result.ipa,
-                  etymology: result.etymology,
-                  relatedForms: result.relatedForms,
-                }
-              : null;
           setWordPanel((prev) => ({
             ...prev,
-            translation: result.translation,
-            partOfSpeech: result.partOfSpeech || null,
-            dictEntry: null,
-            aiStructured: structured,
+            translation: gloss,
             isLoading: false,
-            isDictionaryResult: false,
+            isStreamingGloss: false,
           }));
         } catch (err) {
           if (requestId !== translationRequestId.current) return;
-          console.error('Translation error:', err);
+          console.error('Gloss stream error:', err);
           setWordPanel((prev) => ({
             ...prev,
             isLoading: false,
+            isStreamingGloss: false,
             error: 'Failed to translate word. Check AI provider in settings.',
           }));
         }
@@ -282,6 +289,40 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
     }
   }, [wordPanel.word, wordPanel.sentence]);
 
+  // Enrich — upgrade the fast streamed gloss to the full dictionary entry
+  // (senses / IPA / etymology / related forms). Off the critical path: the user
+  // already has a meaning on screen; this just fills in the rich detail and, on
+  // accept, gives the cache a proper multi-sense entry instead of a bare gloss.
+  const enrichTranslation = useCallback(async () => {
+    const requestId = translationRequestId.current;
+    setWordPanel((prev) => ({ ...prev, isEnriching: true }));
+    try {
+      const result = await enrichWord(wordPanel.word, wordPanel.sentence);
+      if (requestId !== translationRequestId.current) return;
+      const structured =
+        result.senses && result.senses.length > 0
+          ? {
+              senses: result.senses,
+              ipa: result.ipa,
+              etymology: result.etymology,
+              relatedForms: result.relatedForms,
+            }
+          : null;
+      setWordPanel((prev) => ({
+        ...prev,
+        translation: result.translation || prev.translation,
+        partOfSpeech: result.partOfSpeech || prev.partOfSpeech,
+        aiStructured: structured ?? prev.aiStructured,
+        isEnriching: false,
+      }));
+    } catch (err) {
+      if (requestId !== translationRequestId.current) return;
+      console.error('Enrich error:', err);
+      // Keep the gloss on screen; just stop the spinner (non-blocking failure).
+      setWordPanel((prev) => ({ ...prev, isEnriching: false }));
+    }
+  }, [wordPanel.word, wordPanel.sentence]);
+
   // Resolves the existing vocab entry, awaiting an in-flight lookup if needed.
   // Prevents duplicate-row races when the user acts before getVocabByText returns.
   const resolveExistingEntry = useCallback(async (): Promise<VocabEntry | undefined> => {
@@ -300,16 +341,31 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
   const persistAcceptedTranslation = useCallback(() => {
     if (wordPanel.word.includes(' ')) return;
     if (wordPanel.dictEntry) return;
-    if (!wordPanel.aiStructured) return;
+    // Prefer the rich enriched entry; otherwise persist the streamed gloss as a
+    // single minimal sense so an accepted fast-path word still becomes a
+    // "learned" dictionary entry (Enrich beforehand upgrades it to the full one).
+    const senses =
+      wordPanel.aiStructured?.senses ??
+      (wordPanel.translation
+        ? [{ partOfSpeech: wordPanel.partOfSpeech || '', gloss: wordPanel.translation }]
+        : null);
+    if (!senses) return;
     void cacheAcceptedTranslation({
       word: wordPanel.word,
-      senses: wordPanel.aiStructured.senses,
-      ipa: wordPanel.aiStructured.ipa,
-      etymology: wordPanel.aiStructured.etymology,
-      relatedForms: wordPanel.aiStructured.relatedForms,
+      senses,
+      ipa: wordPanel.aiStructured?.ipa,
+      etymology: wordPanel.aiStructured?.etymology,
+      relatedForms: wordPanel.aiStructured?.relatedForms,
       sourceSentence: wordPanel.sentence,
     });
-  }, [wordPanel.word, wordPanel.sentence, wordPanel.dictEntry, wordPanel.aiStructured]);
+  }, [
+    wordPanel.word,
+    wordPanel.sentence,
+    wordPanel.dictEntry,
+    wordPanel.aiStructured,
+    wordPanel.translation,
+    wordPanel.partOfSpeech,
+  ]);
 
   const saveWordToVocab = useCallback(async () => {
     if (!wordPanel.translation) return;
@@ -578,6 +634,31 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
     );
   }
 
+  // What the drawer renders as the rich entry: a real dictionary hit if we have
+  // one, otherwise the AI's enriched structured result mapped into the same
+  // shape. Kept separate from wordPanel.dictEntry (which stays null for AI) so
+  // the save handlers still treat an AI result as cacheable, not a dict hit.
+  const displayEntry: ExpandedDictionaryEntry | null =
+    wordPanel.dictEntry ??
+    (wordPanel.aiStructured
+      ? {
+          word: wordPanel.word,
+          senses: wordPanel.aiStructured.senses,
+          ipa: wordPanel.aiStructured.ipa,
+          etymology: wordPanel.aiStructured.etymology,
+          relatedForms: wordPanel.aiStructured.relatedForms,
+        }
+      : null);
+
+  // Offer Enrich only for a bare single-word gloss that isn't already rich.
+  const canEnrich =
+    !wordPanel.word.includes(' ') &&
+    !wordPanel.dictEntry &&
+    !wordPanel.aiStructured &&
+    !!wordPanel.translation &&
+    !wordPanel.isLoading &&
+    !wordPanel.isStreamingGloss;
+
   return (
     <div className="flex h-dvh flex-col overflow-x-hidden bg-card">
       <div className="relative flex-1 overflow-hidden">
@@ -599,7 +680,7 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
         // WordPanelState field names differ from TranslationDrawerProps; map them
         // explicitly. A spread silently dropped these (all props optional, so tsc
         // stayed green) and the drawer rendered "No definition found" for every word.
-        entry={wordPanel.dictEntry}
+        entry={displayEntry}
         aiTranslation={wordPanel.translation}
         aiPartOfSpeech={wordPanel.partOfSpeech}
         aiContextTranslation={wordPanel.aiContextTranslation}
@@ -608,6 +689,8 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
         isDictionaryResult={wordPanel.isDictionaryResult}
         isLoading={wordPanel.isLoading}
         isContextLoading={wordPanel.isContextLoading}
+        isStreaming={wordPanel.isStreamingGloss}
+        isEnriching={wordPanel.isEnriching}
         error={wordPanel.error}
         existingEntry={wordPanel.existingEntry}
         onClose={closeWordPanel}
@@ -616,6 +699,7 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
         onMarkKnown={markAsKnown}
         onIgnore={ignoreWord}
         onRequestContextTranslation={requestContextTranslation}
+        onEnrich={canEnrich ? enrichTranslation : undefined}
         onRetranslate={retranslateWithAi}
         onLookupWord={handleNestedLookup}
       />

--- a/src/app/read/types.ts
+++ b/src/app/read/types.ts
@@ -33,6 +33,10 @@ export interface WordPanelState {
   } | null;
   isLoading: boolean;
   isContextLoading: boolean;
+  /** True while the fast-path gloss is still streaming in token-by-token. */
+  isStreamingGloss: boolean;
+  /** True while the opt-in rich "enrich" lookup is in flight. */
+  isEnriching: boolean;
   isDictionaryResult: boolean;
   error: string | null;
   existingEntry: VocabEntry | null;

--- a/src/components/TranslationDrawer/index.tsx
+++ b/src/components/TranslationDrawer/index.tsx
@@ -6,7 +6,7 @@ import type { WordState } from '@/types';
 import { sentenceContainsWord } from '@/lib/words';
 import { TranslationDrawerProps } from './types';
 import { wordStateColors, wordStateLabels } from './constants';
-import { ChevronRight, RefreshCw, Volume2, X, Zap } from 'lucide-react';
+import { ChevronRight, RefreshCw, Sparkles, Volume2, X, Zap } from 'lucide-react';
 import NestedWordButton from './components/NestedWordButton';
 import Gloss from './components/Gloss';
 
@@ -25,6 +25,8 @@ export default function TranslationDrawer({
   isDictionaryResult,
   isLoading,
   isContextLoading,
+  isStreaming,
+  isEnriching,
   error,
   existingEntry,
   onClose,
@@ -33,6 +35,7 @@ export default function TranslationDrawer({
   onMarkKnown,
   onIgnore,
   onRequestContextTranslation,
+  onEnrich,
   onRetranslate,
   onLookupWord,
 }: TranslationDrawerProps) {
@@ -250,6 +253,12 @@ export default function TranslationDrawer({
               )}
               <span className="text-foreground leading-relaxed">
                 {fallbackTranslation}
+                {isStreaming && (
+                  <span
+                    className="ml-0.5 inline-block w-1.5 h-4 -mb-0.5 bg-primary animate-pulse"
+                    aria-hidden="true"
+                  />
+                )}
               </span>
             </div>
           ) : (
@@ -275,6 +284,28 @@ export default function TranslationDrawer({
             <span className="mt-3 inline-flex items-center gap-1.5 text-xs text-[var(--clay)]">
               <span className="w-3 h-3 border-2 border-[var(--clay)] border-t-transparent rounded-full animate-spin" />
               Asking AI…
+            </span>
+          )}
+
+          {/* Enrich — upgrade a fast streamed gloss to the full dictionary entry
+              (senses, IPA, etymology, related forms). Only offered for a bare AI
+              gloss (the page passes onEnrich only when there's no rich entry yet). */}
+          {onEnrich && !isPhrase && !isLoading && !isStreaming && !isContextLoading && !isEnriching && (
+            <button
+              onClick={onEnrich}
+              className="mt-3 ml-2 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md
+                bg-muted text-muted-foreground
+                hover:bg-accent hover:text-foreground transition-colors"
+              title="Add IPA, etymology, full senses & related forms"
+            >
+              <Sparkles className="w-3 h-3" />
+              Enrich
+            </button>
+          )}
+          {isEnriching && (
+            <span className="mt-3 ml-2 inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="w-3 h-3 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
+              Enriching…
             </span>
           )}
         </section>

--- a/src/components/TranslationDrawer/types.ts
+++ b/src/components/TranslationDrawer/types.ts
@@ -46,6 +46,10 @@ export interface TranslationDrawerProps {
 
   isLoading?: boolean;
   isContextLoading?: boolean;
+  /** True while the fast gloss is still streaming — renders a live caret. */
+  isStreaming?: boolean;
+  /** True while the rich "enrich" lookup is in flight. */
+  isEnriching?: boolean;
   error?: string | null;
 
   /** Existing vocab record (if word was previously saved). */
@@ -61,6 +65,9 @@ export interface TranslationDrawerProps {
   onIgnore?: () => void;
   /** Request a fresh contextual translation from the AI (uses surrounding sentence). */
   onRequestContextTranslation?: () => void;
+  /** Upgrade a fast streamed gloss to the full dictionary entry (senses, IPA,
+      etymology, related forms). When absent the Enrich button is hidden. */
+  onEnrich?: () => void;
   /** Force a fresh LLM lookup, ignoring cache + local dict. */
   onRetranslate?: () => void;
   /** Look up a word referenced inside the entry (form-of glosses, lemma stem,

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -47,6 +47,76 @@ export async function translateWord(
 }
 
 /**
+ * Fast-path word gloss — streams a plain-text translation so the reader sees
+ * the meaning form as it generates instead of waiting for a full structured
+ * entry. Calls `onDelta` with the cumulative text on every chunk and resolves
+ * with the final trimmed gloss. Throws if the stream yields nothing (so the
+ * caller can show an error / fall back).
+ *
+ * Pair with `enrichWord` for the opt-in rich entry (senses / IPA / etymology).
+ */
+export async function streamWordGloss(
+  word: string,
+  sentence: string,
+  onDelta: (cumulative: string) => void,
+): Promise<string> {
+  const response = await fetch('/api/translate/gloss', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ word, sentence, language: getActiveLanguage() }),
+  });
+
+  if (!response.ok || !response.body) {
+    let message = 'Translation failed';
+    try {
+      const error = await response.json();
+      message = error.error || message;
+    } catch {
+      /* non-JSON error body — keep the default */
+    }
+    throw new Error(message);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+    onDelta(text);
+  }
+  text += decoder.decode();
+  const trimmed = text.trim();
+  if (!trimmed) throw new Error('Translation failed');
+  onDelta(trimmed);
+  return trimmed;
+}
+
+/**
+ * Opt-in rich dictionary entry for a word (senses, IPA, etymology, related
+ * forms) — the "enrich" action behind the streamed gloss. Same shape as
+ * translateWord; hits the dedicated /enrich endpoint.
+ */
+export async function enrichWord(
+  word: string,
+  sentence: string,
+): Promise<WordTranslation> {
+  const response = await fetch('/api/translate/enrich', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ word, sentence, language: getActiveLanguage() }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Enrich failed');
+  }
+
+  return response.json();
+}
+
+/**
  * Translate a phrase with surrounding sentence context
  * @param phrase - The phrase to translate
  * @param sentence - The full sentence containing the phrase (for context)


### PR DESCRIPTION
## Why

Word translation felt slow on both local and remote models. Three compounding causes:

1. **The on-device dictionary was being bypassed entirely.** `dictionary-db.ts` defaulted its data dir to `./data` while `db.ts` uses `../data`. Since the API runs from `./api` in local dev (`cd api && bun run …`), the dict resolved to the **nonexistent `./api/data`** — so *every* lookup silently missed and *every* word fell through to the slow AI path, skipping the 15k-entry dict. This is likely the dominant cause of the latency.
2. **Every word generated a full structured entry** (senses + IPA + etymology + related forms, up to 1500 tokens) before anything appeared.
3. **The Afrikaans spelreels ruleset (~3.3k tokens) was injected on every single-word prompt**, blowing past small local models' context windows for no benefit.

## What changed

### Fast tier — streamed gloss
A dictionary miss now streams a concise plain-text gloss from `POST /api/translate/gloss`, token-by-token, so the meaning appears almost immediately (with a live caret) instead of blocking on a full structured response.

### Enrich tier — opt-in rich entry
An **Enrich** button fetches the full dictionary entry (senses, IPA, etymology, related forms) from `POST /api/translate/enrich`, off the critical path. Accepting a bare gloss still caches it (as a single sense); enriching first caches the full entry.

Measured locally: gloss **~1.5s streamed** vs enrich **~6.7s** — the latency-sensitive path is now the cheap one.

### Cleanups
- **Dict-path fix** (separate commit) — the highest-impact change; restores instant on-device lookups in local dev.
- **spelreels dropped from both word paths**; kept only on the (af) *phrase* path, where idioms actually benefit.
- `LLMProvider` gains `stream()` — Anthropic via `messages.stream()`, OpenAI-compatible via SSE; the Agent-SDK/OAuth path buffers.
- Prompt builders extracted to `api/src/lib/translate-prompts.ts`.
- `.env.example` enables `ANTHROPIC_WORD_MODEL=claude-haiku-4-5` (the gloss path uses the word model).

## Testing

- **Unit:** new `translate-prompts.test.ts` pins the no-spelreels invariant. `npm test` 130/130, `cd api && bun run test` 110/110.
- **E2E:** new `reader-streaming-gloss.spec.ts` (click → streamed gloss → Enrich → rich fields). Updated `reader-markdown`, `reader-word-handling`, `nested-definitions`, `translation-cache` for the new endpoints. Full translation/reader surface: 19/19.
- **lint** 0 errors, **tsc** clean.

## Notes for the reviewer

- For the Haiku speed win in your own dev, add `ANTHROPIC_WORD_MODEL=claude-haiku-4-5` to `.env.local` (it's only in `.env.example` here, since `.env.local` is gitignored).
- The streamed `/gloss` commits a 200 before the first token, so a provider failure can't become a non-200; the client treats an empty stream as a failure and surfaces an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
