### PR TITLE
feat(practice): add dictation practice mode (#37)

### DIFF
--- a/e2e/dictation.spec.ts
+++ b/e2e/dictation.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Wait for the practice page to finish seeding and show the setup screen.
+async function waitForSetup(page: Page) {
+  await page.goto('/practice');
+  await expect(page.getByRole('button', { name: 'Start' })).toBeVisible({
+    timeout: 30000,
+  });
+}
+
+// Switch the setup screen into Dictation format.
+async function selectDictation(page: Page) {
+  await page.getByRole('button', { name: /^Dictation/ }).click();
+  await expect(page.getByText('Dictation Practice')).toBeVisible();
+}
+
+test.describe.serial('Dictation - Setup', () => {
+  test('format toggle switches to dictation and hides the Type/MC modes', async ({ page }) => {
+    await waitForSetup(page);
+
+    // Both formats are offered, defaulting to Cloze (with Type/MC modes).
+    await expect(page.getByRole('button', { name: /^Cloze/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Dictation/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Type', exact: true })).toBeVisible();
+
+    // Switch to dictation.
+    await selectDictation(page);
+
+    // Type/MC are cloze-only and disappear.
+    await expect(page.getByRole('button', { name: 'Type', exact: true })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'MC', exact: true })).toHaveCount(0);
+
+    // The shared sentence-grouping options stay available.
+    await expect(page.getByRole('button', { name: /Top 500/ }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: '10', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start' })).toBeEnabled();
+  });
+});
+
+test.describe.serial('Dictation - Round', () => {
+  test('hides the sentence and shows the audio controls', async ({ page }) => {
+    await waitForSetup(page);
+    await selectDictation(page);
+    await page.getByRole('button', { name: '10', exact: true }).click();
+    await page.getByRole('button', { name: 'Start' }).click();
+
+    await expect(page.getByText('Type the sentence you hear')).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Audio controls: replay + speed.
+    await expect(page.getByRole('button', { name: /Listen Again/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: '1x', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: '0.75x', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: '0.5x', exact: true })).toBeVisible();
+
+    // Full-sentence input is present; the cloze blank UI is not.
+    await expect(page.getByTestId('dictation-input')).toBeVisible();
+    await expect(page.getByText('Fill in the blank')).toHaveCount(0);
+
+    // The sentence is hidden until the user answers.
+    await expect(page.getByTestId('dictation-actual')).toHaveCount(0);
+  });
+
+  test('caps Listen Again at 3 replays', async ({ page }) => {
+    await waitForSetup(page);
+    await selectDictation(page);
+    await page.getByRole('button', { name: '10', exact: true }).click();
+    await page.getByRole('button', { name: 'Start' }).click();
+
+    await expect(page.getByText('Type the sentence you hear')).toBeVisible({
+      timeout: 10000,
+    });
+
+    // The initial autoplay is free; three explicit replays are allowed.
+    const replay = page.getByRole('button', { name: /Listen Again/ });
+    for (let i = 0; i < 3; i++) {
+      await expect(replay).toBeEnabled();
+      await replay.click();
+      await page.waitForTimeout(100);
+    }
+
+    // After the budget is spent the control locks.
+    const locked = page.getByRole('button', { name: /No replays left/ });
+    await expect(locked).toBeVisible();
+    await expect(locked).toBeDisabled();
+  });
+
+  test('a wrong answer reveals the sentence and the word-level diff', async ({ page }) => {
+    await waitForSetup(page);
+    await selectDictation(page);
+    await page.getByRole('button', { name: '10', exact: true }).click();
+    await page.getByRole('button', { name: 'Start' }).click();
+
+    await expect(page.getByText('Type the sentence you hear')).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByTestId('dictation-input').fill('xxxxx qqqqq');
+    await page.getByRole('button', { name: 'Check' }).click();
+
+    // Incorrect feedback with accuracy and the now-revealed sentence.
+    await expect(page.getByRole('heading', { name: 'Incorrect' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('dictation-accuracy')).toContainText('% correct');
+    await expect(page.getByTestId('dictation-actual')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Next Sentence' })).toBeVisible();
+  });
+
+  test('Surrender reveals the answer without typing', async ({ page }) => {
+    await waitForSetup(page);
+    await selectDictation(page);
+    await page.getByRole('button', { name: '10', exact: true }).click();
+    await page.getByRole('button', { name: 'Start' }).click();
+
+    await expect(page.getByText('Type the sentence you hear')).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Give up without typing anything.
+    await page.getByRole('button', { name: 'Surrender' }).click();
+
+    // The answer is revealed under a neutral "Answer revealed" heading.
+    await expect(page.getByRole('heading', { name: 'Answer revealed' })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByTestId('dictation-actual')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Next Sentence' })).toBeVisible();
+  });
+});
+
+test.describe.serial('Dictation - Correct path (seeded)', () => {
+  const TEST_COLLECTION = 'top2000';
+  const KNOWN = {
+    id: 'test-dictation-known-1',
+    sentence: 'Die bruin hond hardloop vinnig.',
+    clozeWord: 'hardloop',
+    clozeIndex: 3,
+    translation: 'The brown dog runs fast.',
+    source: 'tatoeba',
+    collection: TEST_COLLECTION,
+    masteryLevel: 25,
+    nextReview: '2020-01-01T00:00:00.000Z',
+    reviewCount: 3,
+    timesCorrect: 2,
+    timesIncorrect: 1,
+  };
+
+  test('typing the heard sentence exactly scores a perfect dictation and completes the round', async ({
+    page,
+  }) => {
+    // Make the seeded sentence the only review-due one in its collection so the
+    // round is deterministic (the round draws due sentences in random order).
+    const dueRes = await page.request.get(
+      `/api/cloze/due?mode=review&collection=${TEST_COLLECTION}&limit=50`,
+    );
+    for (const s of await dueRes.json()) {
+      await page.request.delete(`/api/cloze/${s.id}`);
+    }
+    const seedRes = await page.request.post('/api/cloze', { data: [KNOWN] });
+    expect(seedRes.ok()).toBeTruthy();
+
+    try {
+      await waitForSetup(page);
+      await selectDictation(page);
+
+      // Start a one-sentence review round for the seeded collection.
+      await page.getByRole('button', { name: /1000-2000\s+\d+ due/ }).click();
+
+      await expect(page.getByText('Type the sentence you hear')).toBeVisible({
+        timeout: 10000,
+      });
+      // The sentence is genuinely hidden — only the audio is presented.
+      await expect(page.getByText(KNOWN.sentence)).toHaveCount(0);
+
+      // Type exactly what is spoken.
+      await page.getByTestId('dictation-input').fill(KNOWN.sentence);
+      await page.getByRole('button', { name: 'Check' }).click();
+
+      // A flawless transcription reads as "Perfect!" at 100%.
+      await expect(page.getByRole('heading', { name: 'Perfect!' })).toBeVisible({ timeout: 5000 });
+      await expect(page.getByTestId('dictation-accuracy')).toContainText('100% correct');
+
+      // The single, passed sentence completes the round (no retry queue).
+      await page.getByRole('button', { name: 'Next Sentence' }).click();
+      await expect(page.getByText('Round Complete!')).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByText(/1\/1 correct/)).toBeVisible();
+    } finally {
+      await page.request.delete(`/api/cloze/${KNOWN.id}`);
+    }
+  });
+});

--- a/src/app/practice/__tests__/dictation.test.ts
+++ b/src/app/practice/__tests__/dictation.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { diffDictation, scoreDictation, calculateDictationPoints } from '../utils';
+import { DICTATION_PASS_THRESHOLD, DICTATION_POINTS_BASE } from '../constants';
+import type { ClozeMasteryLevel } from '@/types';
+
+describe('diffDictation', () => {
+  it('marks an exact transcription fully correct', () => {
+    const diff = diffDictation('die kat sit', 'die kat sit');
+    expect(diff.correctWords).toBe(3);
+    expect(diff.totalWords).toBe(3);
+    expect(diff.accuracy).toBe(1);
+    expect(diff.expected.every((w) => w.status === 'correct')).toBe(true);
+    expect(diff.typed.every((w) => w.status === 'correct')).toBe(true);
+  });
+
+  it('ignores case and punctuation', () => {
+    const diff = diffDictation('  Die KAT, sit! ', 'die kat sit');
+    expect(diff.accuracy).toBe(1);
+    expect(diff.correctWords).toBe(3);
+    // Original spelling/casing is preserved for display.
+    expect(diff.typed.map((w) => w.text)).toEqual(['Die', 'KAT,', 'sit!']);
+  });
+
+  it('flags a substituted word as wrong on the typed side and missing on the actual side', () => {
+    const diff = diffDictation('die hond sit', 'die kat sit');
+    expect(diff.correctWords).toBe(2);
+    expect(diff.totalWords).toBe(3);
+    expect(diff.accuracy).toBeCloseTo(2 / 3);
+
+    const typedStatuses = diff.typed.map((w) => `${w.text}:${w.status}`);
+    expect(typedStatuses).toEqual(['die:correct', 'hond:wrong', 'sit:correct']);
+
+    const expectedStatuses = diff.expected.map((w) => `${w.text}:${w.status}`);
+    expect(expectedStatuses).toEqual(['die:correct', 'kat:missing', 'sit:correct']);
+  });
+
+  it('handles a dropped word (omission)', () => {
+    const diff = diffDictation('die sit', 'die kat sit');
+    expect(diff.correctWords).toBe(2);
+    expect(diff.totalWords).toBe(3);
+    expect(diff.expected.find((w) => w.text === 'kat')?.status).toBe('missing');
+  });
+
+  it('counts every actual word correct but flags an inserted extra word', () => {
+    const diff = diffDictation('die mooi kat sit', 'die kat sit');
+    // All three actual words appear in order → accuracy is full…
+    expect(diff.correctWords).toBe(3);
+    expect(diff.accuracy).toBe(1);
+    // …but the spurious "mooi" is flagged wrong, so it isn't a *perfect* match.
+    expect(diff.typed.find((w) => w.text === 'mooi')?.status).toBe('wrong');
+    expect(scoreDictation(diff).isPerfect).toBe(false);
+  });
+
+  it('does not cascade after a reordering (LCS alignment)', () => {
+    const diff = diffDictation('kat die sit', 'die kat sit');
+    // LCS of [kat,die,sit] vs [die,kat,sit] keeps "sit" plus one of die/kat.
+    expect(diff.correctWords).toBe(2);
+    expect(diff.totalWords).toBe(3);
+  });
+
+  it('scores empty input as zero with everything missing', () => {
+    const diff = diffDictation('   ', 'die kat sit');
+    expect(diff.correctWords).toBe(0);
+    expect(diff.accuracy).toBe(0);
+    expect(diff.typed).toHaveLength(0);
+    expect(diff.expected.every((w) => w.status === 'missing')).toBe(true);
+  });
+
+  it('scores entirely wrong input as zero accuracy', () => {
+    const diff = diffDictation('foo bar baz', 'die kat sit');
+    expect(diff.correctWords).toBe(0);
+    expect(diff.accuracy).toBe(0);
+  });
+});
+
+describe('scoreDictation', () => {
+  it('passes and marks perfect on an exact match', () => {
+    const { isPass, isPerfect } = scoreDictation(diffDictation('die kat sit', 'die kat sit'));
+    expect(isPass).toBe(true);
+    expect(isPerfect).toBe(true);
+  });
+
+  it('passes but is not perfect when an extra word is typed', () => {
+    const { isPass, isPerfect } = scoreDictation(diffDictation('die kat sit nou', 'die kat sit'));
+    expect(isPass).toBe(true);
+    expect(isPerfect).toBe(false);
+  });
+
+  it('passes at exactly the threshold', () => {
+    // 3 of 4 words correct = 0.75, which is the pass threshold.
+    const diff = diffDictation('ek het dit gedoen', 'ek het dit verloor');
+    expect(diff.accuracy).toBeCloseTo(0.75);
+    expect(diff.accuracy).toBeGreaterThanOrEqual(DICTATION_PASS_THRESHOLD);
+    expect(scoreDictation(diff).isPass).toBe(true);
+  });
+
+  it('fails below the threshold', () => {
+    // 2 of 4 words correct = 0.5, below the threshold → reset.
+    const diff = diffDictation('ek het foo bar', 'ek het dit verloor');
+    expect(diff.accuracy).toBeLessThan(DICTATION_PASS_THRESHOLD);
+    expect(scoreDictation(diff).isPass).toBe(false);
+    expect(scoreDictation(diff).isPerfect).toBe(false);
+  });
+
+  it('fails empty input', () => {
+    const { isPass, isPerfect } = scoreDictation(diffDictation('', 'die kat sit'));
+    expect(isPass).toBe(false);
+    expect(isPerfect).toBe(false);
+  });
+});
+
+describe('calculateDictationPoints', () => {
+  it('awards base points for a perfect first pass (mastery 25)', () => {
+    expect(calculateDictationPoints(25, 1)).toBe(DICTATION_POINTS_BASE);
+  });
+
+  it('scales points up with the mastery reached', () => {
+    expect(calculateDictationPoints(100, 1)).toBe(DICTATION_POINTS_BASE * 4);
+  });
+
+  it('scales points down with accuracy (partial credit for minor errors)', () => {
+    // 12 * (25/25) * 0.8 = 9.6 → 10
+    expect(calculateDictationPoints(25, 0.8)).toBe(10);
+    expect(calculateDictationPoints(25, 0.8)).toBeLessThan(calculateDictationPoints(25, 1));
+  });
+
+  it('awards nothing at mastery 0 (a failed attempt)', () => {
+    expect(calculateDictationPoints(0 as ClozeMasteryLevel, 0)).toBe(0);
+  });
+});

--- a/src/app/practice/components/Dictation/DictationCard.tsx
+++ b/src/app/practice/components/Dictation/DictationCard.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { AudioLines } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Kbd } from '@/components/ui/kbd';
+import { DEFAULT_RATE, isTTSAvailable, speak } from '@/lib/tts';
+import { DICTATION_MAX_REPLAYS, DICTATION_SPEEDS } from '../../constants';
+import type { CurrentSentence } from '../../types';
+import BlacklistSentence from '../BlacklistSentence';
+
+// Dictation question card: the sentence is hidden and played as audio — the
+// learner types back what they hear. Audio plays once on mount; "Listen Again"
+// replays at the chosen speed up to DICTATION_MAX_REPLAYS times. The speed
+// buttons only set the rate for the next replay (they don't play or count), so
+// the replay budget stays predictable.
+export default function DictationCard({
+  current,
+  onSubmit,
+  onSurrender,
+  onSentenceBlacklisted,
+}: {
+  current: CurrentSentence;
+  onSubmit: (typed: string) => void;
+  onSurrender: (typed: string) => void;
+  onSentenceBlacklisted: () => void;
+}) {
+  const [typed, setTyped] = useState('');
+  const [speed, setSpeed] = useState<number>(DICTATION_SPEEDS[0]);
+  const [replaysUsed, setReplaysUsed] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Guard so the once-per-sentence autoplay doesn't fire twice under React's
+  // dev StrictMode double-invoke (and so changing speed never re-triggers it).
+  const autoplayedFor = useRef<string | null>(null);
+  const playTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const sentence = current.sentence.sentence;
+  const replaysLeft = DICTATION_MAX_REPLAYS - replaysUsed;
+  const canReplay = replaysLeft > 0;
+
+  // Drive the cosmetic "playing" pulse for roughly as long as the audio runs.
+  const play = (rateMultiplier: number) => {
+    if (playTimerRef.current) clearTimeout(playTimerRef.current);
+    setIsPlaying(true);
+    const wordCount = sentence.split(/\s+/).length;
+    playTimerRef.current = setTimeout(
+      () => setIsPlaying(false),
+      Math.min(8000, 700 + wordCount * 350),
+    );
+    speak(sentence, DEFAULT_RATE * rateMultiplier);
+  };
+
+  // A user-initiated replay — costs one of the replay budget.
+  const replay = () => {
+    if (!canReplay) return;
+    setReplaysUsed((n) => n + 1);
+    play(speed);
+  };
+
+  // Autoplay once when the sentence changes, and focus the input. The initial
+  // play is free (doesn't count against the replay budget).
+  useEffect(() => {
+    if (autoplayedFor.current !== current.sentence.id) {
+      autoplayedFor.current = current.sentence.id;
+      play(DICTATION_SPEEDS[0]);
+    }
+    inputRef.current?.focus();
+    return () => {
+      if (playTimerRef.current) clearTimeout(playTimerRef.current);
+    };
+    // play/speed are intentionally excluded — this runs once per sentence.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current.sentence.id]);
+
+  const handleSubmit = () => {
+    if (!typed.trim()) return;
+    onSubmit(typed.trim());
+  };
+
+  return (
+    <div>
+      <div className="mb-6">
+        <div className="mb-4 flex items-center justify-between">
+          <span className="text-sm font-medium text-muted-foreground">
+            Type the sentence you hear
+          </span>
+          <BlacklistSentence current={current} onSentenceBlacklisted={onSentenceBlacklisted} />
+        </div>
+
+        {/* Audio focus: a large speaker that replays on click */}
+        <div className="flex flex-col items-center gap-4 py-4">
+          <button
+            type="button"
+            onClick={replay}
+            disabled={!canReplay || !isTTSAvailable()}
+            aria-label="Replay audio"
+            data-testid="dictation-replay-icon"
+            className={`flex h-24 w-24 items-center justify-center rounded-full border-2 transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 ${
+              isPlaying
+                ? 'border-primary bg-[color-mix(in_srgb,var(--primary)_18%,var(--card))] text-primary'
+                : 'border-[var(--clay)] bg-[color-mix(in_srgb,var(--clay)_12%,var(--card))] text-foreground hover:border-primary hover:text-primary'
+            }`}
+          >
+            <AudioLines className={`h-12 w-12 ${isPlaying ? 'animate-pulse' : ''}`} />
+          </button>
+
+          {/* Speed control */}
+          <div className="flex items-center gap-1.5">
+            <span className="mr-1 text-xs font-medium text-muted-foreground">Speed</span>
+            {DICTATION_SPEEDS.map((s) => (
+              <Button
+                key={s}
+                size="sm"
+                variant={speed === s ? 'default' : 'secondary'}
+                onClick={() => setSpeed(s)}
+              >
+                {s}x
+              </Button>
+            ))}
+          </div>
+
+          {/* Replay control with remaining budget */}
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={replay}
+            disabled={!canReplay || !isTTSAvailable()}
+          >
+            <AudioLines className="h-4 w-4" />
+            {canReplay ? `Listen Again (${replaysLeft} left)` : 'No replays left'}
+          </Button>
+        </div>
+
+        {/* Full-sentence answer */}
+        <textarea
+          ref={inputRef}
+          value={typed}
+          onChange={(e) => setTyped(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey && !e.repeat) {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          rows={2}
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          placeholder="Type what you hear…"
+          data-testid="dictation-input"
+          className="w-full resize-none rounded-lg border-2 border-[var(--clay)] bg-[color-mix(in_srgb,var(--clay)_8%,var(--card))] px-3 py-2 text-lg leading-relaxed text-foreground transition-all outline-none focus:border-primary focus:ring-2 focus:ring-ring focus:ring-offset-1"
+        />
+      </div>
+
+      {/* Actions: give up and reveal the answer, or submit the attempt */}
+      <div className="flex justify-center gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => onSurrender(typed)}
+          title="Reveal the sentence and move on (counts as a miss)"
+        >
+          Surrender
+        </Button>
+        <Button type="button" size="lg" onClick={handleSubmit} disabled={!typed.trim()}>
+          Check
+        </Button>
+      </div>
+
+      {/* Shortcut hint */}
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <Kbd>Enter</Kbd>
+          Check
+        </span>
+      </div>
+
+      {/* Mastery indicator */}
+      <div className="mt-6 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+        <span>Mastery:</span>
+        <div className="flex h-2 w-24 overflow-hidden rounded-full bg-muted">
+          <div
+            className="bg-primary transition-all"
+            style={{ width: `${current.sentence.masteryLevel}%` }}
+          />
+        </div>
+        <span>{current.sentence.masteryLevel}%</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/practice/components/Dictation/DictationFeedback.tsx
+++ b/src/app/practice/components/Dictation/DictationFeedback.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { AudioLines, Check, ChevronRight, Eye, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Kbd } from '@/components/ui/kbd';
+import { isTTSAvailable } from '@/lib/tts';
+import type { DictationResult, DictationWord } from '../../types';
+
+const masteryLabels: Record<number, string> = {
+  0: 'New',
+  25: 'Learning',
+  50: 'Familiar',
+  75: 'Almost There',
+  100: 'Mastered',
+};
+
+// One word of the diff. Correct words read green; a word the user got wrong is
+// struck through in red, and a word they missed entirely is underlined in red.
+function DiffWord({ word }: { word: DictationWord }) {
+  if (word.status === 'correct') {
+    return <span className="text-primary">{word.text}</span>;
+  }
+  if (word.status === 'wrong') {
+    return <span className="text-destructive line-through">{word.text}</span>;
+  }
+  return (
+    <span className="text-destructive underline decoration-dotted underline-offset-4">
+      {word.text}
+    </span>
+  );
+}
+
+function DiffLine({ words }: { words: DictationWord[] }) {
+  if (words.length === 0) {
+    return <span className="text-muted-foreground italic">(nothing typed)</span>;
+  }
+  return (
+    <>
+      {words.map((w, i) => (
+        <span key={i}>
+          {i > 0 && ' '}
+          <DiffWord word={w} />
+        </span>
+      ))}
+    </>
+  );
+}
+
+// Dictation result screen: how the typed sentence lined up against the audio,
+// the accuracy, the SRS mastery change, and a replay. Mirrors ClozeFeedback's
+// look so the two practice formats feel like one app.
+export default function DictationFeedback({
+  result,
+  translation,
+  onNext,
+  onSpeak,
+}: {
+  result: DictationResult;
+  translation: string;
+  onNext: () => void;
+  onSpeak: () => void;
+}) {
+  const { diff, isPass, isPerfect, surrendered, points, newMastery, previousMastery } = result;
+  const accuracyPct = Math.round(diff.accuracy * 100);
+  const masteryChange = newMastery - previousMastery;
+
+  // Visual tone: a pass is green, a genuine miss is red, and a surrender is
+  // neutral — the learner chose to reveal the answer, so it's still a miss for
+  // the SRS card but isn't framed as "wrong".
+  const tone: 'pass' | 'fail' | 'neutral' = surrendered ? 'neutral' : isPass ? 'pass' : 'fail';
+  const cardClass = {
+    pass: 'border-primary bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))]',
+    fail: 'border-destructive bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))]',
+    neutral: 'border-border bg-card',
+  }[tone];
+  const iconCircle = {
+    pass: 'bg-[color-mix(in_srgb,var(--primary)_14%,var(--card))] text-primary',
+    fail: 'bg-[color-mix(in_srgb,var(--destructive)_12%,var(--card))] text-destructive',
+    neutral: 'bg-muted text-foreground',
+  }[tone];
+  const accentText = { pass: 'text-primary', fail: 'text-destructive', neutral: 'text-foreground' }[
+    tone
+  ];
+  const barClass = { pass: 'bg-primary', fail: 'bg-destructive', neutral: 'bg-muted-foreground' }[
+    tone
+  ];
+  const heading = surrendered
+    ? 'Answer revealed'
+    : isPerfect
+      ? 'Perfect!'
+      : isPass
+        ? 'Correct!'
+        : 'Incorrect';
+
+  return (
+    <div className={`rounded-xl border-2 p-6 transition-all ${cardClass}`}>
+      {/* Result header */}
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className={`flex h-10 w-10 items-center justify-center rounded-full ${iconCircle}`}>
+            {tone === 'pass' ? (
+              <Check className="h-6 w-6" />
+            ) : tone === 'fail' ? (
+              <X className="h-6 w-6" />
+            ) : (
+              <Eye className="h-6 w-6" />
+            )}
+          </div>
+          <div>
+            <h3 className={`text-xl font-bold ${accentText}`}>{heading}</h3>
+            <p
+              className="text-sm font-medium text-muted-foreground"
+              data-testid="dictation-accuracy"
+            >
+              {accuracyPct}% correct ({diff.correctWords}/{diff.totalWords} words)
+              {isPass && points > 0 && (
+                <span className="text-[var(--gold-strong)]"> · +{points} points</span>
+              )}
+            </p>
+          </div>
+        </div>
+        {isTTSAvailable() && (
+          <Button type="button" onClick={onSpeak} variant="ghost">
+            <AudioLines className="h-4 w-4" />
+            Listen Again
+          </Button>
+        )}
+      </div>
+
+      {/* What the user typed */}
+      <div className="mb-3">
+        <p className="mb-1 text-sm font-medium text-muted-foreground">You typed</p>
+        <p className="text-lg leading-relaxed font-medium">
+          <DiffLine words={diff.typed} />
+        </p>
+      </div>
+
+      {/* The actual sentence (now revealed) */}
+      <div className="mb-4">
+        <p className="mb-1 text-sm font-medium text-muted-foreground">Sentence</p>
+        <p className="text-lg leading-relaxed font-medium" data-testid="dictation-actual">
+          <DiffLine words={diff.expected} />
+        </p>
+      </div>
+
+      {/* Translation */}
+      <div className="mb-4 rounded-lg bg-muted p-3">
+        <p className="text-sm font-medium text-muted-foreground">Translation</p>
+        <p className="text-foreground">{translation}</p>
+      </div>
+
+      {/* Mastery progress */}
+      <div className="mb-4">
+        <div className="mb-2 flex items-center justify-between text-sm">
+          <span className="font-medium text-muted-foreground">Mastery Level</span>
+          <span className="flex items-center gap-2">
+            <span className={`font-semibold ${accentText}`}>{masteryLabels[newMastery]}</span>
+            {masteryChange !== 0 && (
+              <span
+                className={`text-xs font-bold ${
+                  masteryChange > 0 ? 'text-primary' : 'text-destructive'
+                }`}
+              >
+                {masteryChange > 0 ? '+' : ''}
+                {masteryChange}%
+              </span>
+            )}
+          </span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={`h-full transition-all duration-500 ${barClass}`}
+            style={{ width: `${newMastery}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-3">
+        <Button type="button" onClick={onNext} className="flex-1">
+          Next Sentence
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Keyboard hint */}
+      <div className="mt-4 flex items-center justify-center text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <Kbd>Enter</Kbd>
+          Next sentence
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/practice/constants.ts
+++ b/src/app/practice/constants.ts
@@ -1,8 +1,7 @@
-import { ClozeCollection } from "@/types";
+import { ClozeCollection } from '@/types';
 
 export const ANKI_CLOZE_DECK_SETTING_KEY = 'lector-anki-cloze-deck';
 export const ROUND_SIZES = [10, 20, 30, 40, 50] as const;
-
 
 export const COLLECTION_LABELS: Record<string, string> = {
   top500: 'Top 500',
@@ -11,3 +10,26 @@ export const COLLECTION_LABELS: Record<string, string> = {
 };
 
 export const VISIBLE_COLLECTIONS: ClozeCollection[] = ['top500', 'top1000', 'top2000'];
+
+// --- Dictation mode ---------------------------------------------------------
+
+// localStorage key for the chosen practice format (cloze | dictation).
+export const PRACTICE_FORMAT_SETTING_KEY = 'lector-practice-format';
+
+// Fraction of the sentence's words that must be correct for a dictation attempt
+// to count as a pass (advances the SRS card). Below this, the card hard-resets,
+// matching cloze's "a miss resets mastery" rule. 0.75 lets a single slip through
+// on the short (4–6 word) starter sentences while still failing a genuine miss.
+export const DICTATION_PASS_THRESHOLD = 0.75;
+
+// Base points for a perfect dictation at mastery 25 (scaled by mastery reached
+// and accuracy). Higher than cloze typing (8) because transcribing a whole
+// sentence from audio is harder than filling one blank.
+export const DICTATION_POINTS_BASE = 12;
+
+// How many times the learner may replay the audio ("Listen Again") before the
+// control locks — the sentence is revealed on submit regardless.
+export const DICTATION_MAX_REPLAYS = 3;
+
+// Playback speed multipliers offered during dictation (× the normal TTS rate).
+export const DICTATION_SPEEDS = [1, 0.75, 0.5] as const;

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -716,7 +716,13 @@ export default function PracticePage() {
                 review options below. */}
             <div className="mb-6">
               <div className="grid grid-cols-2 gap-2">
+                {/* Explicit aria-labels keep each button's accessible name to
+                    just "Cloze"/"Dictation" — the descriptive subtitle stays
+                    visible but doesn't leak into role-based locators (e.g. the
+                    cloze "Type" mode button would otherwise also match the
+                    "Type what you hear" subtitle). */}
                 <Button
+                  aria-label="Cloze"
                   onClick={() => handleSetPracticeFormat('cloze')}
                   variant={practiceFormat === 'cloze' ? 'default' : 'secondary'}
                   className="flex h-14 flex-col justify-center gap-0"
@@ -725,6 +731,7 @@ export default function PracticePage() {
                   <div className="mt-0.5 text-[11px] font-normal opacity-75">Fill in the blank</div>
                 </Button>
                 <Button
+                  aria-label="Dictation"
                   onClick={() => handleSetPracticeFormat('dictation')}
                   variant={practiceFormat === 'dictation' ? 'default' : 'secondary'}
                   className="flex h-14 flex-col justify-center gap-0"

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -24,23 +24,33 @@ import { lookupWordRemote, type ExpandedDictionaryEntry } from '@/lib/dictionary
 import { splitTrailingPunctuation } from '@/lib/words';
 import {
   createBlankedSentence,
+  calculateDictationPoints,
   calculateNextReview,
   calculatePoints,
   checkAnswer,
+  diffDictation,
   generateDistractors,
   getFuzzyStatus,
   normalize,
+  scoreDictation,
   shuffle,
 } from './utils';
 import type {
   CurrentSentence,
+  DictationResult,
   IFeedbackData,
+  PracticeFormat,
   PracticeMode,
   PracticeState,
   RoundSize,
   RoundType,
 } from './types';
-import { COLLECTION_LABELS, ROUND_SIZES, VISIBLE_COLLECTIONS } from './constants';
+import {
+  COLLECTION_LABELS,
+  PRACTICE_FORMAT_SETTING_KEY,
+  ROUND_SIZES,
+  VISIBLE_COLLECTIONS,
+} from './constants';
 import BlacklistSentence from './components/BlacklistSentence';
 import { Button } from '@/components/ui/button';
 import { Kbd, KbdGroup } from '@/components/ui/kbd';
@@ -48,6 +58,8 @@ import { SETTINGS_KEYS } from '@/app/settings/constants';
 import EmptyState from './components/EmptyState';
 import PageHeader from '@/components/PageHeader';
 import Feedback from './components/Feedback';
+import DictationCard from './components/Dictation/DictationCard';
+import DictationFeedback from './components/Dictation/DictationFeedback';
 
 export default function PracticePage() {
   // State
@@ -66,9 +78,13 @@ export default function PracticePage() {
   // setting on mount; Alt+T toggles it live during a round.
   const [showTranslation, setShowTranslation] = useState(true);
 
-  // Practice mode
+  // Practice format (cloze vs dictation) and, within cloze, the answer mode
+  const [practiceFormat, setPracticeFormat] = useState<PracticeFormat>('cloze');
   const [practiceMode, setPracticeMode] = useState<PracticeMode>('type');
   const [roundType, setRoundType] = useState<RoundType>('new');
+
+  // Dictation result (the graded diff), shown on the feedback screen
+  const [dictationResult, setDictationResult] = useState<DictationResult | null>(null);
 
   // Multiple choice state
   const [mcOptions, setMcOptions] = useState<string[]>([]);
@@ -128,6 +144,12 @@ export default function PracticePage() {
         setPracticeMode(savedMode);
       }
 
+      // Load saved practice format (cloze vs dictation)
+      const savedFormat = localStorage.getItem(PRACTICE_FORMAT_SETTING_KEY);
+      if (savedFormat === 'cloze' || savedFormat === 'dictation') {
+        setPracticeFormat(savedFormat);
+      }
+
       // Respect the "hide translation by default" setting (Alt+T toggles live)
       setShowTranslation(localStorage.getItem(SETTINGS_KEYS.HIDE_TRANSLATION) !== 'true');
 
@@ -145,6 +167,12 @@ export default function PracticePage() {
   const handleSetPracticeMode = useCallback((mode: PracticeMode) => {
     setPracticeMode(mode);
     localStorage.setItem('cloze-practice-mode', mode);
+  }, []);
+
+  // Save practice format (cloze vs dictation) to localStorage when it changes
+  const handleSetPracticeFormat = useCallback((format: PracticeFormat) => {
+    setPracticeFormat(format);
+    localStorage.setItem(PRACTICE_FORMAT_SETTING_KEY, format);
   }, []);
 
   // Handle word click for inline definitions
@@ -275,23 +303,29 @@ export default function PracticePage() {
       setCurrent({ sentence: nextSentence, blankedSentence });
       setUserAnswer('');
       setFeedbackData(null);
+      setDictationResult(null);
       setHintLetters(0);
       setMcFallback(false);
       setWordTooltip(null);
       submittingRef.current = false;
       setState('practicing');
 
-      // Generate MC options if in MC mode
-      if (practiceMode === 'mc') {
-        generateMcOptionsForSentence(nextSentence, sentenceQueue);
-      }
+      // Cloze-only setup. Dictation renders its own card, which manages audio
+      // autoplay and input focus itself, so skip MC generation and the input
+      // focus here when dictating.
+      if (practiceFormat === 'cloze') {
+        // Generate MC options if in MC mode
+        if (practiceMode === 'mc') {
+          generateMcOptionsForSentence(nextSentence, sentenceQueue);
+        }
 
-      // Focus input after state update (only in type mode)
-      if (practiceMode === 'type') {
-        setTimeout(() => inputRef.current?.focus(), 50);
+        // Focus input after state update (only in type mode)
+        if (practiceMode === 'type') {
+          setTimeout(() => inputRef.current?.focus(), 50);
+        }
       }
     },
-    [practiceMode, generateMcOptionsForSentence, clearMcTimer],
+    [practiceFormat, practiceMode, generateMcOptionsForSentence, clearMcTimer],
   );
 
   // Start a round with explicit params (used by review buttons)
@@ -364,30 +398,13 @@ export default function PracticePage() {
     inputRef.current?.focus();
   }, [current, hintLetters, userAnswer]);
 
-  // Record a completed answer: update the SRS card, points, and round stats,
-  // then show feedback. Shared by typed answers and multiple choice — the only
-  // differences are how correctness is decided (the caller's job, before the
-  // pause/sound) and the points base (8 for typing, 4 for MC), passed via `mode`.
-  const recordAnswer = useCallback(
-    async (isCorrect: boolean, submittedAnswer: string, mode: PracticeMode) => {
+  // Persist a graded answer to the shared SRS card and update round/points
+  // state. Format-agnostic: cloze and dictation both decide correctness and
+  // points their own way, then hand the result here. The card, mastery levels
+  // and retry queue are identical across formats (same clozeSentences row).
+  const commitReview = useCallback(
+    async (isCorrect: boolean, earnedPoints: number, newMastery: ClozeMasteryLevel) => {
       if (!current) return;
-
-      const previousMastery = current.sentence.masteryLevel;
-      const newMastery: ClozeMasteryLevel = isCorrect
-        ? (Math.min(previousMastery + 25, 100) as ClozeMasteryLevel)
-        : 0;
-
-      // No points in the retry phase — the answer was revealed when the card
-      // was first missed this round. Points scale with the mastery just reached.
-      const earnedPoints =
-        isCorrect && !isRetryPhase
-          ? calculatePoints(
-              newMastery,
-              hintLetters,
-              normalize(current.sentence.clozeWord).length,
-              mode,
-            )
-          : 0;
       const nextReview = calculateNextReview(newMastery);
 
       // Update database
@@ -412,6 +429,46 @@ export default function PracticePage() {
         setPoints((prev) => prev + earnedPoints);
       }
 
+      if (!isCorrect) {
+        // Add to retry queue so incorrect answers are re-tested. The card was
+        // just demoted to mastery 0 in the DB — the queued copy must carry that,
+        // or the retry would promote it straight back from its old level.
+        setRetryQueue((prev) => [
+          ...prev,
+          { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel },
+        ]);
+      }
+    },
+    [current, isRetryPhase],
+  );
+
+  // Record a completed cloze answer: decide the mastery and points, then show
+  // feedback. Shared by typed answers and multiple choice — the only
+  // differences are how correctness is decided (the caller's job, before the
+  // pause/sound) and the points base (8 for typing, 4 for MC), passed via `mode`.
+  const recordAnswer = useCallback(
+    async (isCorrect: boolean, submittedAnswer: string, mode: PracticeMode) => {
+      if (!current) return;
+
+      const previousMastery = current.sentence.masteryLevel;
+      const newMastery: ClozeMasteryLevel = isCorrect
+        ? (Math.min(previousMastery + 25, 100) as ClozeMasteryLevel)
+        : 0;
+
+      // No points in the retry phase — the answer was revealed when the card
+      // was first missed this round. Points scale with the mastery just reached.
+      const earnedPoints =
+        isCorrect && !isRetryPhase
+          ? calculatePoints(
+              newMastery,
+              hintLetters,
+              normalize(current.sentence.clozeWord).length,
+              mode,
+            )
+          : 0;
+
+      await commitReview(isCorrect, earnedPoints, newMastery);
+
       setFeedbackData({
         isCorrect,
         correctWord: splitTrailingPunctuation(current.sentence.clozeWord)[0],
@@ -426,17 +483,57 @@ export default function PracticePage() {
 
       if (isCorrect) {
         speak(current.sentence.sentence);
-      } else {
-        // Add to retry queue so incorrect answers are re-tested. The card was
-        // just demoted to mastery 0 in the DB — the queued copy must carry that,
-        // or the retry would promote it straight back from its old level.
-        setRetryQueue((prev) => [
-          ...prev,
-          { ...current.sentence, masteryLevel: 0 as ClozeMasteryLevel },
-        ]);
       }
     },
-    [current, hintLetters, isRetryPhase],
+    [current, hintLetters, isRetryPhase, commitReview],
+  );
+
+  // Record a completed dictation answer: word-level diff against the spoken
+  // sentence drives the score. A pass (≥ threshold of the words) advances the
+  // SRS card; anything less resets it, matching cloze's miss behaviour. Points
+  // scale with both the mastery reached and the transcription accuracy.
+  //
+  // Surrender reveals the answer without finishing it: it's always a miss (the
+  // card resets and re-queues, like a wrong cloze answer), regardless of what
+  // was typed so far — so it can never accidentally award a pass.
+  const recordDictation = useCallback(
+    async (typed: string, surrendered = false) => {
+      if (!current) return;
+
+      const diff = diffDictation(typed, current.sentence.sentence);
+      const score = scoreDictation(diff);
+      const isPass = surrendered ? false : score.isPass;
+      const isPerfect = surrendered ? false : score.isPerfect;
+
+      if (isPass) {
+        playCorrectSound();
+      } else {
+        playIncorrectSound();
+      }
+
+      const previousMastery = current.sentence.masteryLevel;
+      const newMastery: ClozeMasteryLevel = isPass
+        ? (Math.min(previousMastery + 25, 100) as ClozeMasteryLevel)
+        : 0;
+      const earnedPoints =
+        isPass && !isRetryPhase ? calculateDictationPoints(newMastery, diff.accuracy) : 0;
+
+      await commitReview(isPass, earnedPoints, newMastery);
+
+      setDictationResult({
+        diff,
+        typedRaw: typed,
+        isPass,
+        isPerfect,
+        surrendered,
+        points: earnedPoints,
+        newMastery,
+        previousMastery,
+      });
+
+      setState('feedback');
+    },
+    [current, isRetryPhase, commitReview],
   );
 
   // Handle answer submission (type mode)
@@ -514,7 +611,12 @@ export default function PracticePage() {
       window.addEventListener('keydown', handleKeyDown);
       return () => window.removeEventListener('keydown', handleKeyDown);
     }
-    if (state === 'practicing' && practiceMode === 'mc' && !mcLocked) {
+    if (
+      state === 'practicing' &&
+      practiceFormat === 'cloze' &&
+      practiceMode === 'mc' &&
+      !mcLocked
+    ) {
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.metaKey || e.ctrlKey || e.altKey) return;
         // Number keys 1-4 for MC selection
@@ -535,7 +637,7 @@ export default function PracticePage() {
       return () => window.removeEventListener('keydown', handleKeyDown);
     }
     // Space to trigger TTS in type mode when input is not focused
-    if (state === 'practicing' && practiceMode === 'type') {
+    if (state === 'practicing' && practiceFormat === 'cloze' && practiceMode === 'type') {
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === ' ' && document.activeElement !== inputRef.current) {
           e.preventDefault();
@@ -545,7 +647,16 @@ export default function PracticePage() {
       window.addEventListener('keydown', handleKeyDown);
       return () => window.removeEventListener('keydown', handleKeyDown);
     }
-  }, [state, handleNext, practiceMode, mcLocked, mcOptions, handleMcSelect, current]);
+  }, [
+    state,
+    handleNext,
+    practiceFormat,
+    practiceMode,
+    mcLocked,
+    mcOptions,
+    handleMcSelect,
+    current,
+  ]);
 
   // Alt+T toggles translation visibility (while practicing and on feedback)
   useEffect(() => {
@@ -596,7 +707,35 @@ export default function PracticePage() {
         {/* Setup screen */}
         {state === 'setup' && (
           <div className="py-6">
-            <PageHeader title="Cloze Practice"></PageHeader>
+            <PageHeader
+              title={practiceFormat === 'dictation' ? 'Dictation Practice' : 'Cloze Practice'}
+            ></PageHeader>
+
+            {/* Practice format: Cloze (fill the blank) vs Dictation (hear the
+                sentence, type it back). Both share the collection / round size /
+                review options below. */}
+            <div className="mb-6">
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  onClick={() => handleSetPracticeFormat('cloze')}
+                  variant={practiceFormat === 'cloze' ? 'default' : 'secondary'}
+                  className="flex h-14 flex-col justify-center gap-0"
+                >
+                  <div>Cloze</div>
+                  <div className="mt-0.5 text-[11px] font-normal opacity-75">Fill in the blank</div>
+                </Button>
+                <Button
+                  onClick={() => handleSetPracticeFormat('dictation')}
+                  variant={practiceFormat === 'dictation' ? 'default' : 'secondary'}
+                  className="flex h-14 flex-col justify-center gap-0"
+                >
+                  <div>Dictation</div>
+                  <div className="mt-0.5 text-[11px] font-normal opacity-75">
+                    Type what you hear
+                  </div>
+                </Button>
+              </div>
+            </div>
 
             {/* Review Due section */}
             {(() => {
@@ -689,25 +828,29 @@ export default function PracticePage() {
                     ))}
                   </div>
                 </div>
-                <div className="">
-                  <label className="mb-2 block text-xs font-medium text-muted-foreground">
-                    Mode
-                  </label>
-                  <div className="flex gap-1.5">
-                    <Button
-                      onClick={() => handleSetPracticeMode('type')}
-                      variant={practiceMode === 'type' ? 'default' : 'secondary'}
-                    >
-                      Type
-                    </Button>
-                    <Button
-                      onClick={() => handleSetPracticeMode('mc')}
-                      variant={practiceMode === 'mc' ? 'default' : 'secondary'}
-                    >
-                      MC
-                    </Button>
+                {/* Type/MC only applies to cloze — dictation is always
+                    type-the-whole-sentence. */}
+                {practiceFormat === 'cloze' && (
+                  <div className="">
+                    <label className="mb-2 block text-xs font-medium text-muted-foreground">
+                      Mode
+                    </label>
+                    <div className="flex gap-1.5">
+                      <Button
+                        onClick={() => handleSetPracticeMode('type')}
+                        variant={practiceMode === 'type' ? 'default' : 'secondary'}
+                      >
+                        Type
+                      </Button>
+                      <Button
+                        onClick={() => handleSetPracticeMode('mc')}
+                        variant={practiceMode === 'mc' ? 'default' : 'secondary'}
+                      >
+                        MC
+                      </Button>
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
 
               {/* Start button */}
@@ -772,9 +915,22 @@ export default function PracticePage() {
               </div>
             )}
 
-            {/* Practice state */}
+            {/* Practice state — dictation. Keyed by sentence id so the card
+                remounts per sentence (fresh input, replay budget, autoplay). */}
+            {state === 'practicing' && current && practiceFormat === 'dictation' && (
+              <DictationCard
+                key={current.sentence.id}
+                current={current}
+                onSubmit={(typed) => recordDictation(typed)}
+                onSurrender={(typed) => recordDictation(typed, true)}
+                onSentenceBlacklisted={handleSentenceBlacklisted}
+              />
+            )}
+
+            {/* Practice state — cloze */}
             {state === 'practicing' &&
               current &&
+              practiceFormat === 'cloze' &&
               (() => {
                 const fuzzyStatus = getFuzzyStatus(userAnswer, current.sentence.clozeWord);
                 const inputColorClass = {
@@ -1007,8 +1163,21 @@ export default function PracticePage() {
                 );
               })()}
 
-            {/* Feedback state */}
-            {state === 'feedback' && current && feedbackData && (
+            {/* Feedback state — dictation */}
+            {state === 'feedback' &&
+              current &&
+              practiceFormat === 'dictation' &&
+              dictationResult && (
+                <DictationFeedback
+                  result={dictationResult}
+                  translation={current.sentence.translation}
+                  onNext={handleNext}
+                  onSpeak={() => speak(current.sentence.sentence)}
+                />
+              )}
+
+            {/* Feedback state — cloze */}
+            {state === 'feedback' && current && practiceFormat === 'cloze' && feedbackData && (
               <Feedback
                 feedbackData={feedbackData}
                 current={current}

--- a/src/app/practice/types.ts
+++ b/src/app/practice/types.ts
@@ -6,6 +6,12 @@ export type FuzzyStatus = 'empty' | 'match' | 'partial' | 'wrong';
 export type PracticeState = 'setup' | 'loading' | 'practicing' | 'feedback' | 'complete' | 'empty';
 export type PracticeMode = 'type' | 'mc';
 
+// Top-level practice format. Cloze (fill in the blanked word — Type/MC) vs
+// Dictation (hear the whole sentence, type it back). Both draw from the same
+// clozeSentences pool and share the SRS card, so the only difference is how the
+// sentence is presented and answered.
+export type PracticeFormat = 'cloze' | 'dictation';
+
 export type RoundSize = (typeof ROUND_SIZES)[number];
 export type RoundType = 'new' | 'review';
 
@@ -22,4 +28,38 @@ export interface IFeedbackData {
 export interface CurrentSentence {
   sentence: ClozeSentence;
   blankedSentence: string;
+}
+
+// One word in a dictation diff, with how it lined up against the other side.
+// For the actual sentence: 'correct' (the user produced it) or 'missing'.
+// For what the user typed: 'correct' (it matched the sequence) or 'wrong'.
+export type DictationWordStatus = 'correct' | 'wrong' | 'missing';
+
+export interface DictationWord {
+  text: string; // the original word, shown as-is (case/punctuation preserved)
+  status: DictationWordStatus;
+}
+
+// Word-level diff between what the user typed and the actual sentence, computed
+// by a longest-common-subsequence alignment so reorderings, extra words and
+// dropped words are scored sensibly rather than cascading.
+export interface DictationDiff {
+  expected: DictationWord[]; // the actual sentence, each word correct|missing
+  typed: DictationWord[]; // what the user typed, each word correct|wrong
+  correctWords: number; // words matched in order (the LCS length)
+  totalWords: number; // words in the actual sentence
+  accuracy: number; // correctWords / totalWords, 0..1
+}
+
+// The graded outcome of a dictation attempt — what the feedback screen renders
+// and what drives the shared SRS update.
+export interface DictationResult {
+  diff: DictationDiff;
+  typedRaw: string; // exactly what the user submitted
+  isPass: boolean; // accuracy ≥ threshold → advances mastery (SRS "correct")
+  isPerfect: boolean; // every word right, nothing extra
+  surrendered: boolean; // user gave up and revealed the answer (always a miss)
+  points: number;
+  newMastery: ClozeMasteryLevel;
+  previousMastery: ClozeMasteryLevel;
 }

--- a/src/app/practice/utils.ts
+++ b/src/app/practice/utils.ts
@@ -1,6 +1,7 @@
 import { splitTrailingPunctuation } from '@/lib/words';
 import { ClozeMasteryLevel, ClozeSentence } from '@/types';
-import { FuzzyStatus, PracticeMode } from './types';
+import { DictationDiff, DictationWord, FuzzyStatus, PracticeMode } from './types';
+import { DICTATION_PASS_THRESHOLD, DICTATION_POINTS_BASE } from './constants';
 
 // Helper export function to create blanked sentence, moving punctuation outside the blank
 export function createBlankedSentence(sentence: string, wordIndex: number): string {
@@ -110,4 +111,78 @@ export function shuffle<T>(arr: T[]): T[] {
     [result[i], result[j]] = [result[j], result[i]];
   }
   return result;
+}
+
+// --- Dictation scoring ------------------------------------------------------
+
+// Compare what the user typed against the actual sentence at the word level.
+// Words are matched on their normalized form (case- and punctuation-insensitive,
+// per the issue) using a longest-common-subsequence alignment, so a dropped or
+// inserted word shifts alignment instead of marking everything after it wrong.
+// The returned tokens keep their original spelling for display.
+export function diffDictation(typedRaw: string, actual: string): DictationDiff {
+  const typedWords = typedRaw.trim().split(/\s+/).filter(Boolean);
+  const actualWords = actual.trim().split(/\s+/).filter(Boolean);
+  const t = typedWords.map(normalize);
+  const a = actualWords.map(normalize);
+  const n = t.length;
+  const m = a.length;
+
+  // dp[i][j] = LCS length of t[i..] and a[j..]
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = t[i] === a[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  // Backtrack the alignment, flagging which words on each side were matched.
+  const typedMatched = new Array<boolean>(n).fill(false);
+  const actualMatched = new Array<boolean>(m).fill(false);
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (t[i] === a[j]) {
+      typedMatched[i] = true;
+      actualMatched[j] = true;
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+
+  const expected: DictationWord[] = actualWords.map((text, k) => ({
+    text,
+    status: actualMatched[k] ? 'correct' : 'missing',
+  }));
+  const typed: DictationWord[] = typedWords.map((text, k) => ({
+    text,
+    status: typedMatched[k] ? 'correct' : 'wrong',
+  }));
+  const correctWords = actualMatched.reduce((acc, ok) => acc + (ok ? 1 : 0), 0);
+  const totalWords = m;
+  const accuracy = totalWords > 0 ? correctWords / totalWords : 0;
+
+  return { expected, typed, correctWords, totalWords, accuracy };
+}
+
+// Grade a dictation diff: a pass (advances the SRS card) needs at least
+// DICTATION_PASS_THRESHOLD of the words right; perfect means every word matched
+// with nothing extra typed.
+export function scoreDictation(diff: DictationDiff): { isPass: boolean; isPerfect: boolean } {
+  const isPerfect =
+    diff.totalWords > 0 && diff.accuracy === 1 && diff.typed.every((w) => w.status === 'correct');
+  const isPass = diff.totalWords > 0 && diff.accuracy >= DICTATION_PASS_THRESHOLD;
+  return { isPass, isPerfect };
+}
+
+// Points for a passed dictation: base × (mastery reached ÷ 25) × accuracy, so a
+// near-perfect transcription earns slightly less than a flawless one ("partial
+// points for minor errors"). A failed attempt resets to mastery 0 and earns none.
+export function calculateDictationPoints(mastery: ClozeMasteryLevel, accuracy: number): number {
+  const masteryMultiplier = mastery / 25;
+  return Math.max(0, Math.round(DICTATION_POINTS_BASE * masteryMultiplier * accuracy));
 }

--- a/src/components/NavHeader/constants.ts
+++ b/src/components/NavHeader/constants.ts
@@ -2,7 +2,7 @@ import { Clipboard, Pencil, List, Library, ChartBar, Settings } from 'lucide-rea
 
 export const navLinks = [
   { href: '/', label: 'Library' },
-  { href: '/practice', label: 'Cloze' },
+  { href: '/practice', label: 'Practice' },
   { href: '/journal', label: 'Journal' },
   { href: '/vocab', label: 'Vocab' },
   { href: '/stats', label: 'Statistics' },

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -3,8 +3,10 @@
 import { getActiveLanguage } from './data-layer';
 import { LANGUAGES, DEFAULT_LANGUAGE, type LanguageCode } from './languages';
 
-// Default speech rate (1.0 is normal speed)
-const DEFAULT_RATE = 0.9;
+// Default speech rate (1.0 is normal speed). Exported so callers that offer a
+// speed control (e.g. dictation practice) can scale relative to the app's
+// normal "1x" listening rate instead of hard-coding it.
+export const DEFAULT_RATE = 0.9;
 
 // Resolve the active language's TTS config. Browser-TTS voice selection is
 // driven entirely off this, so switching the target language picks an


### PR DESCRIPTION
## Summary

Implements **Dictation practice mode** (#37). Per the issue's framing, it's a top-level **Cloze ⇄ Dictation** toggle on the practice page that reuses the **same sentence-grouping options** (collection, round size, review-due). In dictation, a sentence is played via TTS with the text hidden and the learner types back what they hear.

## What's included

- **Setup toggle** — a `Cloze | Dictation` segmented control above the shared grouping options. Dictation hides the Type/MC sub-toggle (it's always type-the-sentence), retitles to "Dictation Practice", and persists the choice in `localStorage`.
- **`DictationCard`** — autoplay TTS on load, a large audio-wave icon (click to replay), **speed control 1×/0.75×/0.5×**, **Listen Again capped at 3 replays**, a full-sentence textarea (Enter submits), and a **Surrender** button that reveals the answer (scored as a miss).
- **`DictationFeedback`** — a word-level **LCS diff** (case/punctuation-insensitive, order-aware) shown side-by-side as *You typed* vs the revealed *Sentence*, with accuracy, points, and the SRS mastery change. Surrender renders a neutral "Answer revealed" card, distinct from a red "Incorrect".
- **Scoring / SRS** — reuses the same `clozeSentences` pool and mastery levels. A **pass (≥ 75% of words)** advances mastery `+25`; below that hard-resets to 0 and re-queues for retry — mirroring cloze's miss behaviour. Points scale by mastery × accuracy.
- **Stats are combined, not separate** — dictation records through the shared `commitReview` path, incrementing the same `clozePracticed` + `points` daily stats. So it feeds the **activity heatmap** ("Cloze" series) and the **streak** alongside cloze, with no separate dictation stats. (Verified live: `clozePracticed` incremented after a dictation attempt.)
- **Nav rename** — the sidebar `Cloze` link is now `Practice`, since the page hosts both formats.

## Decisions / tunables

In `src/app/practice/constants.ts`, easy to adjust:
- `DICTATION_PASS_THRESHOLD = 0.75` — fraction of words correct to count as a pass
- `DICTATION_POINTS_BASE = 12` — base points for a perfect dictation (cf. 8 for cloze typing)
- `DICTATION_MAX_REPLAYS = 3` — "Listen Again" budget before the control locks
- `DICTATION_SPEEDS = [1, 0.75, 0.5]` — playback speed multipliers

The "max 3 replays before reveal" from the issue is realised via the replay cap plus the Surrender button (reveal-on-demand). The original sentence and translation stay hidden during the question (pure listening) and are revealed on submit.

## Testing

- **16 unit tests** (`src/app/practice/__tests__/dictation.test.ts`) for `diffDictation` / `scoreDictation` / `calculateDictationPoints` — exact match, case/punctuation, substitution, omission, insertion, reordering, empty, and the pass/perfect/threshold boundaries. Full suite: 147 passing.
- **E2E** (`e2e/dictation.spec.ts`) — the format toggle hiding Type/MC, hidden sentence + audio controls, the replay cap, a wrong answer revealing the diff, Surrender, and a seeded perfect-transcription that completes the round.
- `tsc`, eslint, prettier all clean on the touched files.

Verified manually end-to-end against a local Next + Hono build.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
