### PR TITLE
feat(groups): make collection groups language-agnostic in the library

### DIFF
--- a/api/src/routes/groups.test.ts
+++ b/api/src/routes/groups.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { db } from '../db';
+import app from '../routes/groups';
+
+// collection_groups is language-agnostic: a group can hold collections of
+// different languages, and language lives on the collection, not the group.
+// GET /api/groups returns a per-group collectionCount (total across ALL
+// languages) so the library can distinguish a brand-new empty group from one
+// whose collections all belong to other languages.
+
+function reset() {
+  db.prepare('DELETE FROM collections').run();
+  db.prepare('DELETE FROM collection_groups').run();
+}
+
+function insertGroup(id: string, sortOrder: number, name = `Group ${id}`) {
+  db.prepare('INSERT INTO collection_groups (id, name, sortOrder, createdAt) VALUES (?, ?, ?, ?)').run(
+    id,
+    name,
+    sortOrder,
+    '2026-01-01T00:00:00Z',
+  );
+}
+
+function insertCollection(id: string, groupId: string | null, language: string) {
+  db.prepare(
+    `INSERT INTO collections (id, title, author, coverUrl, groupId, sortOrder, language, createdAt, lastReadAt)
+     VALUES (?, ?, 'Author', NULL, ?, 0, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`,
+  ).run(id, `Title ${id}`, groupId, language);
+}
+
+interface GroupResult {
+  id: string;
+  name: string;
+  collectionCount: number;
+}
+
+describe('groups route — language-agnostic groups', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test('GET / returns every group ordered by sortOrder, regardless of collection language', async () => {
+    insertGroup('g2', 1, 'Second');
+    insertGroup('g1', 0, 'First');
+    insertCollection('c-de', 'g1', 'de'); // g1 holds only a German collection…
+
+    const groups = (await (await app.request('/')).json()) as GroupResult[];
+
+    // …it is still returned (groups aren't filtered by language), ordered by sortOrder.
+    expect(groups.map((g) => g.id)).toEqual(['g1', 'g2']);
+  });
+
+  test('GET / counts collections across ALL languages (collectionCount)', async () => {
+    insertGroup('g1', 0);
+    insertCollection('a1', 'g1', 'af');
+    insertCollection('a2', 'g1', 'af');
+    insertCollection('d1', 'g1', 'de');
+
+    const [g1] = (await (await app.request('/')).json()) as GroupResult[];
+
+    expect(g1.collectionCount).toBe(3);
+  });
+
+  test('GET / distinguishes a brand-new empty group (0) from an other-language-only group (>0)', async () => {
+    insertGroup('only-de', 0);
+    insertGroup('empty', 1);
+    insertCollection('d1', 'only-de', 'de');
+
+    const byId = Object.fromEntries(
+      ((await (await app.request('/')).json()) as GroupResult[]).map((g) => [g.id, g.collectionCount]),
+    );
+
+    // These counts are what let the library keep `empty` visible (so it can be
+    // populated) while hiding `only-de` in an Afrikaans session.
+    expect(byId['empty']).toBe(0);
+    expect(byId['only-de']).toBe(1);
+  });
+});

--- a/api/src/routes/groups.ts
+++ b/api/src/routes/groups.ts
@@ -4,11 +4,25 @@ import { randomUUID } from 'crypto';
 
 const app = new Hono();
 
-// GET /api/groups - List all groups
+// GET /api/groups - List all groups.
+//
+// Groups are language-agnostic containers (collection_groups has no language
+// column) — language lives on the collections within. We return a total
+// collection count (across ALL languages) per group so the library can tell a
+// brand-new empty group, which stays visible so it can be populated, from a
+// group whose collections all belong to other languages, which is hidden in the
+// active language.
 app.get('/', (c) => {
   const groups = db
-    .prepare('SELECT * FROM collection_groups ORDER BY sortOrder ASC')
-    .all() as CollectionGroupRow[];
+    .prepare(
+      `SELECT g.id, g.name, g.sortOrder, g.createdAt,
+              COUNT(col.id) AS collectionCount
+         FROM collection_groups g
+         LEFT JOIN collections col ON col.groupId = g.id
+        GROUP BY g.id
+        ORDER BY g.sortOrder ASC`,
+    )
+    .all() as Array<CollectionGroupRow & { collectionCount: number }>;
 
   return c.json(groups);
 });

--- a/e2e/groups-language.spec.ts
+++ b/e2e/groups-language.spec.ts
@@ -72,7 +72,7 @@ test.describe("Collection Groups — language-agnostic", () => {
 
     // "Both" is visible and shows ONLY its Afrikaans collection.
     await expect(page.getByTestId(`group-${both}`)).toBeVisible();
-    await expect(page.getByTestId(`group-${both}`).getByText("Test AF Book")).toBeVisible();
+    await expect(page.getByTestId(`group-${both}`).getByRole("heading", { name: "Test AF Book" })).toBeVisible();
     await expect(page.getByText("Test DE Book")).toHaveCount(0);
 
     // A group whose collections are all German is hidden in the Afrikaans view.
@@ -86,12 +86,12 @@ test.describe("Collection Groups — language-agnostic", () => {
 
     // The SAME "Both" group, now showing only its German collection.
     await expect(page.getByTestId(`group-${both}`)).toBeVisible();
-    await expect(page.getByTestId(`group-${both}`).getByText("Test DE Book")).toBeVisible();
+    await expect(page.getByTestId(`group-${both}`).getByRole("heading", { name: "Test DE Book" })).toBeVisible();
     await expect(page.getByText("Test AF Book")).toHaveCount(0);
 
     // The German-only group is now visible, with its collection.
     await expect(page.getByTestId(`group-${deOnly}`)).toBeVisible();
-    await expect(page.getByTestId(`group-${deOnly}`).getByText("Test DE Only Book")).toBeVisible();
+    await expect(page.getByTestId(`group-${deOnly}`).getByRole("heading", { name: "Test DE Only Book" })).toBeVisible();
 
     // Empty group still visible.
     await expect(page.getByTestId(`group-${empty}`)).toBeVisible();

--- a/e2e/groups-language.spec.ts
+++ b/e2e/groups-language.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// `collection_groups` is a language-agnostic container: a group can hold
+// collections of different languages, and language lives on the collection, not
+// the group. The library shows a group in the active language only when it has a
+// collection in that language — OR when it has no collections at all (a
+// brand-new/emptied group stays visible so it can be populated). A group whose
+// collections are all in another language is hidden in the active language.
+test.describe("Collection Groups — language-agnostic", () => {
+  async function cleanup(page: Page) {
+    const groups = await (await page.request.get("/api/groups")).json();
+    for (const g of groups) {
+      if (g.name.startsWith("Test")) await page.request.delete(`/api/groups/${g.id}`);
+    }
+    // Collections are language-scoped, so clean each language we touch.
+    for (const lang of ["af", "de"]) {
+      const cols = await (await page.request.get(`/api/collections?language=${lang}`)).json();
+      for (const c of cols) {
+        if (c.title.startsWith("Test")) await page.request.delete(`/api/collections/${c.id}`);
+      }
+    }
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await cleanup(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanup(page);
+  });
+
+  async function makeGroup(page: Page, name: string): Promise<string> {
+    const res = await page.request.post("/api/groups", { data: { name } });
+    return (await res.json()).id;
+  }
+
+  async function makeCollection(
+    page: Page,
+    title: string,
+    language: string,
+    groupId: string,
+  ): Promise<string> {
+    const res = await page.request.post("/api/collections", {
+      data: { title, author: "Test", language, groupId },
+    });
+    return (await res.json()).id;
+  }
+
+  // Drive the client's active language via localStorage (what getActiveLanguage
+  // reads, and what the SetupGuard fast-path checks — so no /setup redirect).
+  // addInitScript runs on every navigation; the latest registration wins.
+  async function viewLibraryAs(page: Page, lang: string) {
+    await page.addInitScript((l) => localStorage.setItem("lector-target-language", l), lang);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+  }
+
+  test("a group spans languages; other-language-only groups hide; empty groups stay", async ({
+    page,
+  }) => {
+    const both = await makeGroup(page, "Test Both Langs");
+    const deOnly = await makeGroup(page, "Test DE Only");
+    const empty = await makeGroup(page, "Test Empty Group");
+
+    await makeCollection(page, "Test AF Book", "af", both);
+    await makeCollection(page, "Test DE Book", "de", both);
+    await makeCollection(page, "Test DE Only Book", "de", deOnly);
+
+    // ── Afrikaans view ───────────────────────────────────────────────────────
+    await viewLibraryAs(page, "af");
+
+    // "Both" is visible and shows ONLY its Afrikaans collection.
+    await expect(page.getByTestId(`group-${both}`)).toBeVisible();
+    await expect(page.getByTestId(`group-${both}`).getByText("Test AF Book")).toBeVisible();
+    await expect(page.getByText("Test DE Book")).toHaveCount(0);
+
+    // A group whose collections are all German is hidden in the Afrikaans view.
+    await expect(page.getByTestId(`group-${deOnly}`)).toHaveCount(0);
+
+    // A brand-new empty group stays visible so it can be populated.
+    await expect(page.getByTestId(`group-${empty}`)).toBeVisible();
+
+    // ── German view ──────────────────────────────────────────────────────────
+    await viewLibraryAs(page, "de");
+
+    // The SAME "Both" group, now showing only its German collection.
+    await expect(page.getByTestId(`group-${both}`)).toBeVisible();
+    await expect(page.getByTestId(`group-${both}`).getByText("Test DE Book")).toBeVisible();
+    await expect(page.getByText("Test AF Book")).toHaveCount(0);
+
+    // The German-only group is now visible, with its collection.
+    await expect(page.getByTestId(`group-${deOnly}`)).toBeVisible();
+    await expect(page.getByTestId(`group-${deOnly}`).getByText("Test DE Only Book")).toBeVisible();
+
+    // Empty group still visible.
+    await expect(page.getByTestId(`group-${empty}`)).toBeVisible();
+  });
+});

--- a/src/app/(index)/page.tsx
+++ b/src/app/(index)/page.tsx
@@ -241,7 +241,16 @@ export default function Home() {
     }
   }
 
-  const hasGroups = groups.length > 0;
+  // Groups are language-agnostic, but `collections` here is already scoped to the
+  // active language. Show a group when it has a collection in this language, or
+  // when it has no collections at all (a brand-new/emptied group — kept visible
+  // so it can be populated). Hide groups whose collections all belong to other
+  // languages. `collectionCount` is the group's total across all languages.
+  const visibleGroups = groups.filter(
+    (g) => (groupedCollections.get(g.id)?.length ?? 0) > 0 || (g.collectionCount ?? 0) === 0,
+  );
+
+  const hasGroups = visibleGroups.length > 0;
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
@@ -320,7 +329,7 @@ export default function Home() {
           {collections.length > 0 || hasGroups ? (
             <div className="space-y-10">
               {/* Grouped sections */}
-              {groups.map((group) => {
+              {visibleGroups.map((group) => {
                 const items = groupedCollections.get(group.id) || [];
                 const isCollapsed = collapsedGroups.has(group.id);
                 return (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,13 @@ export interface CollectionGroup {
   name: string;
   sortOrder: number;
   createdAt: string;
+  /**
+   * Total collections in this group across ALL languages (set by GET /api/groups).
+   * Groups are language-agnostic, so the library uses this to distinguish a
+   * brand-new empty group (show it) from one whose collections all belong to
+   * other languages (hide it in the active language).
+   */
+  collectionCount?: number;
 }
 
 export interface Lesson {


### PR DESCRIPTION
## What

Makes **collection groups language-agnostic** in the library. A group is a container that can hold collections of different languages — language lives on the **collection**, never on the group (`collection_groups` has no `language` column, and this PR keeps it that way).

In the library, for the active language:
- A group shows iff it has **≥1 collection in that language**, **or** it has **no collections at all** (a brand-new / emptied group stays visible so it can be populated).
- A group whose collections are **all in another language** is **hidden**.
- Collections shown within a group are already language-filtered by `GET /api/collections`.

## How

- **`api/src/routes/groups.ts`** — `GET /api/groups` now returns a per-group **`collectionCount`** (a total across *all* languages, via `LEFT JOIN collections … GROUP BY`). This is a deliberate, sanctioned cross-language aggregate: it's what lets the client distinguish a brand-new empty group (count 0 → keep visible) from one whose collections are all in other languages (count > 0 but none in this language → hide).
- **`src/app/(index)/page.tsx`** — derives `visibleGroups` from that rule; the rest of the rendering is unchanged.
- **`src/types/index.ts`** — `CollectionGroup` gains an optional `collectionCount`.

## Testing

- `api/src/routes/groups.test.ts` (bun:test) — GET returns all groups regardless of collection language, counts collections across all languages, and distinguishes an empty group (0) from an other-language-only group (> 0).
- `e2e/groups-language.spec.ts` (Playwright) — a group with collections in two languages shows only the active-language collection in each view; an other-language-only group is hidden; a brand-new empty group stays visible.
- `npm test` (172 pass) and `tsc --noEmit` clean locally; the e2e runs in CI.

## Scope

This is **only** the language-agnostic-groups slice. The broader per-language partitioning of other user data (stats, export/import, the `cached_entries` key, the route-level ratchet, etc.) is tracked in #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
