### PR TITLE
feat(practice): hide cloze review reminders in dictation mode (#191)

### DIFF
--- a/e2e/dictation.spec.ts
+++ b/e2e/dictation.spec.ts
@@ -128,10 +128,14 @@ test.describe.serial('Dictation - Round', () => {
   });
 });
 
-test.describe.serial('Dictation - Correct path (seeded)', () => {
+test.describe.serial('Dictation - Cloze review reminders hidden (#191)', () => {
   const TEST_COLLECTION = 'top2000';
-  const KNOWN = {
-    id: 'test-dictation-known-1',
+  // A review-due card (reviewCount > 0, nextReview in the past) so the cloze
+  // "Review Due" reminder actually renders. Dictation must hide that reminder:
+  // it's a focused listening drill, and the SRS review prompts are a cloze
+  // concern (issue #191).
+  const DUE = {
+    id: 'test-dictation-review-hidden-1',
     sentence: 'Die bruin hond hardloop vinnig.',
     clozeWord: 'hardloop',
     clozeIndex: 3,
@@ -145,49 +149,41 @@ test.describe.serial('Dictation - Correct path (seeded)', () => {
     timesIncorrect: 1,
   };
 
-  test('typing the heard sentence exactly scores a perfect dictation and completes the round', async ({
-    page,
-  }) => {
-    // Make the seeded sentence the only review-due one in its collection so the
-    // round is deterministic (the round draws due sentences in random order).
+  test('shows the Review Due reminder in cloze and hides it in dictation', async ({ page }) => {
+    // Make the seeded card the only review-due one in this collection so the
+    // "1000-2000 N due" entry is deterministic.
     const dueRes = await page.request.get(
       `/api/cloze/due?mode=review&collection=${TEST_COLLECTION}&limit=50`,
     );
     for (const s of await dueRes.json()) {
       await page.request.delete(`/api/cloze/${s.id}`);
     }
-    const seedRes = await page.request.post('/api/cloze', { data: [KNOWN] });
+    const seedRes = await page.request.post('/api/cloze', { data: [DUE] });
     expect(seedRes.ok()).toBeTruthy();
+
+    const reviewHeading = page.getByRole('heading', { name: /Review Due/ });
+    const reviewDueButton = page.getByRole('button', { name: /1000-2000\s+\d+ due/ });
 
     try {
       await waitForSetup(page);
+
+      // Cloze (the default format) surfaces the SRS review reminder.
+      await expect(reviewHeading).toBeVisible();
+      await expect(reviewDueButton).toBeVisible();
+
+      // Switching to dictation hides the cloze review reminders entirely…
       await selectDictation(page);
+      await expect(reviewHeading).toHaveCount(0);
+      await expect(reviewDueButton).toHaveCount(0);
+      // …while the Learn New flow stays available.
+      await expect(page.getByRole('button', { name: 'Start' })).toBeEnabled();
 
-      // Start a one-sentence review round for the seeded collection.
-      await page.getByRole('button', { name: /1000-2000\s+\d+ due/ }).click();
-
-      await expect(page.getByText('Type the sentence you hear')).toBeVisible({
-        timeout: 10000,
-      });
-      // The sentence is genuinely hidden — only the audio is presented.
-      await expect(page.getByText(KNOWN.sentence)).toHaveCount(0);
-
-      // Type exactly what is spoken.
-      await page.getByTestId('dictation-input').fill(KNOWN.sentence);
-      await page.getByRole('button', { name: 'Check' }).click();
-
-      // A flawless transcription reads as "Perfect!" at 100%.
-      await expect(page.getByRole('heading', { name: 'Perfect!' })).toBeVisible({ timeout: 5000 });
-      await expect(page.getByTestId('dictation-accuracy')).toContainText('100% correct');
-
-      // The single, passed sentence completes the round (no retry queue).
-      await page.getByRole('button', { name: 'Next Sentence' }).click();
-      await expect(page.getByText('Round Complete!')).toBeVisible({
-        timeout: 10000,
-      });
-      await expect(page.getByText(/1\/1 correct/)).toBeVisible();
+      // Switching back to cloze restores the reminder.
+      await page.getByRole('button', { name: 'Cloze', exact: true }).click();
+      await expect(reviewHeading).toBeVisible();
+      await expect(reviewDueButton).toBeVisible();
     } finally {
-      await page.request.delete(`/api/cloze/${KNOWN.id}`);
+      await page.request.delete(`/api/cloze/${DUE.id}`);
     }
   });
 });

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -744,46 +744,50 @@ export default function PracticePage() {
               </div>
             </div>
 
-            {/* Review Due section */}
-            {(() => {
-              const totalDue = VISIBLE_COLLECTIONS.reduce(
-                (sum, c) => sum + (collectionCounts?.[c]?.due || 0),
-                0,
-              );
-              if (totalDue === 0) return null;
-              return (
-                <div className="mb-8 rounded-2xl border border-[var(--gold-lip)] bg-[var(--gold-soft)] p-5">
-                  <h2 className="mb-3 text-base font-semibold text-[var(--gold-strong)]">
-                    Review Due ({totalDue})
-                  </h2>
-                  <div className="space-y-2">
-                    {VISIBLE_COLLECTIONS.map((coll) => {
-                      const due = collectionCounts?.[coll]?.due || 0;
-                      if (due === 0) return null;
-                      return (
-                        <button
-                          key={coll}
-                          onClick={() => {
-                            setSelectedCollection(coll);
-                            setRoundType('review');
-                            setRoundSize(Math.min(due, 20) as RoundSize);
-                            startRoundWith(coll, 'review', Math.min(due, 20));
-                          }}
-                          className="flex w-full items-center justify-between rounded-xl border border-border bg-card px-4 py-3 transition-all hover:border-[var(--gold-strong)] active:scale-[0.98]"
-                        >
-                          <span className="font-medium text-foreground">
-                            {COLLECTION_LABELS[coll]}
-                          </span>
-                          <span className="text-sm font-semibold text-[var(--gold-strong)]">
-                            {due} due
-                          </span>
-                        </button>
-                      );
-                    })}
+            {/* Review Due section — cloze only. Dictation is a focused
+                listening drill, so the SRS review reminders (a cloze-practice
+                concern) are hidden there and only the Learn New flow remains
+                (issue #191). */}
+            {practiceFormat === 'cloze' &&
+              (() => {
+                const totalDue = VISIBLE_COLLECTIONS.reduce(
+                  (sum, c) => sum + (collectionCounts?.[c]?.due || 0),
+                  0,
+                );
+                if (totalDue === 0) return null;
+                return (
+                  <div className="mb-8 rounded-2xl border border-[var(--gold-lip)] bg-[var(--gold-soft)] p-5">
+                    <h2 className="mb-3 text-base font-semibold text-[var(--gold-strong)]">
+                      Review Due ({totalDue})
+                    </h2>
+                    <div className="space-y-2">
+                      {VISIBLE_COLLECTIONS.map((coll) => {
+                        const due = collectionCounts?.[coll]?.due || 0;
+                        if (due === 0) return null;
+                        return (
+                          <button
+                            key={coll}
+                            onClick={() => {
+                              setSelectedCollection(coll);
+                              setRoundType('review');
+                              setRoundSize(Math.min(due, 20) as RoundSize);
+                              startRoundWith(coll, 'review', Math.min(due, 20));
+                            }}
+                            className="flex w-full items-center justify-between rounded-xl border border-border bg-card px-4 py-3 transition-all hover:border-[var(--gold-strong)] active:scale-[0.98]"
+                          >
+                            <span className="font-medium text-foreground">
+                              {COLLECTION_LABELS[coll]}
+                            </span>
+                            <span className="text-sm font-semibold text-[var(--gold-strong)]">
+                              {due} due
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              );
-            })()}
+                );
+              })()}
 
             {/* Learn New section */}
             <div className="rounded-2xl border border-border bg-card p-5">


### PR DESCRIPTION
Closes #191.

## What

Dictation is a focused listening drill, so the cloze **"Review Due"** reminders no longer render when the practice format is **dictation** — only the Learn New flow remains. Cloze practice is unchanged.

The reminder is now gated on the format:

```jsx
{practiceFormat === 'cloze' &&
  (() => { /* Review Due (N) … */ })()}
```

## Tests

The old **"Dictation – Correct path (seeded)"** e2e test started a dictation round *via* the Review Due button — the exact entry point this change removes — so its premise no longer exists. It's replaced with a test that seeds a due card and asserts the reminder **shows in cloze, hides in dictation, and returns when switching back**.

Dictation pass-scoring remains fully covered by the `dictation.test.ts` unit suite, and the other dictation e2e tests start rounds via **Start** (Learn New), so they're unaffected.

## Verification

- `prettier`, `eslint`, `tsc --noEmit`, and `vitest` (172 passing) all clean locally.
- Manually exercised the real UI against an isolated API + scratch DB: Cloze shows `Review Due (1)` / `1000-2000 1 due`; Dictation hides both (title → "Dictation Practice"); switching back restores them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
