### PR TITLE
fix(stats): activity heatmap respects timezone so today isn't dropped (#192)

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -237,7 +237,7 @@ export default function StatsPage() {
 
       {/* Activity Heatmap */}
       <div className="mb-8">
-        <ActivityHeatmap data={stats.activityData} unit="actions" />
+        <ActivityHeatmap data={stats.activityData} unit="actions" endDate={stats.endDate} />
       </div>
 
       {/* Anki Reviews */}

--- a/src/components/ActivityHeatmap/index.tsx
+++ b/src/components/ActivityHeatmap/index.tsx
@@ -3,10 +3,10 @@
 import { useMemo } from 'react';
 import { useIsDark } from '@/utils/hooks';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { DAYS_OF_WEEK, MONTHS } from './constants';
+import { DAYS_OF_WEEK } from './constants';
 import { darkColorScheme, lightColorScheme } from './theme';
-import { type ActivityHeatmapProps, type ActivityParts } from './types';
-import { formatDate, getColor } from './utils';
+import { type ActivityHeatmapProps, type ActivityParts, type HeatmapCell } from './types';
+import { buildHeatmapGrid, getColor, localEndDate } from './utils';
 
 // The activities that fold into a day's composite count, in display order. Each
 // gets a colour dot in the tooltip; `suffix` distinguishes reading (minutes).
@@ -31,13 +31,6 @@ function formatFullDate(dateStr: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-interface HeatmapCell {
-  date: string;
-  count: number;
-  dayOfWeek: number;
-  parts?: ActivityParts;
 }
 
 function DayCell({ day, unit, color }: { day: HeatmapCell; unit: string; color: string }) {
@@ -93,77 +86,23 @@ function DayCell({ day, unit, color }: { day: HeatmapCell; unit: string; color: 
 export default function ActivityHeatmap({
   data,
   unit = 'lookups',
+  endDate,
   colorScheme: colorSchemeProp,
 }: ActivityHeatmapProps) {
   const isDark = useIsDark();
   const colorScheme = colorSchemeProp || (isDark ? darkColorScheme : lightColorScheme);
   const { weeks, maxCount, monthLabels, totalActivity, activeDays } = useMemo(() => {
-    // date -> the full day record, so each cell can show its breakdown.
-    const activityMap = new Map(data.map((d) => [d.date, d]));
-
-    // Calculate max count for color scaling
+    // Color scaling and the headline totals are date-agnostic — just the data.
     const maxCount = Math.max(1, ...data.map((d) => d.count));
-
-    // Generate 365 days ending today
-    const today = new Date();
-    const startDate = new Date(today);
-    startDate.setDate(startDate.getDate() - 364);
-
-    // Adjust start to be a Sunday
-    const startDayOfWeek = startDate.getDay();
-    startDate.setDate(startDate.getDate() - startDayOfWeek);
-
-    const weeks: HeatmapCell[][] = [];
-    let currentWeek: HeatmapCell[] = [];
-
-    const monthLabels: Array<{ label: string; weekIndex: number; span: number }> = [];
-    let lastMonth = -1;
-
-    const currentDate = new Date(startDate);
-    let weekIndex = 0;
-
-    while (currentDate <= today) {
-      const dateStr = formatDate(currentDate);
-      const day = activityMap.get(dateStr);
-      const count = day?.count || 0;
-      const month = currentDate.getMonth();
-      const dayOfWeek = currentDate.getDay();
-
-      // One label per month, anchored at the column that holds the 1st (the
-      // first day of the month we encounter). span is filled in after the loop.
-      if (month !== lastMonth) {
-        monthLabels.push({ label: MONTHS[month], weekIndex, span: 0 });
-        lastMonth = month;
-      }
-
-      currentWeek.push({ date: dateStr, count, dayOfWeek, parts: day?.parts });
-
-      if (currentWeek.length === 7) {
-        weeks.push(currentWeek);
-        currentWeek = [];
-        weekIndex++;
-      }
-
-      currentDate.setDate(currentDate.getDate() + 1);
-    }
-
-    // Push remaining days
-    if (currentWeek.length > 0) {
-      weeks.push(currentWeek);
-    }
-
-    // Each label spans from its own column up to the next label's column (the
-    // last runs to the end). Spans sum to weeks.length, so they tile grid-cols-53.
-    monthLabels.forEach((m, i) => {
-      m.span = (monthLabels[i + 1]?.weekIndex ?? weeks.length) - m.weekIndex;
-    });
-
-    // Calculate totals
     const totalActivity = data.reduce((sum, d) => sum + d.count, 0);
     const activeDays = data.filter((d) => d.count > 0).length;
 
+    // The grid ends on the caller's time-zone-aware "today" (matching the data's
+    // date keys), falling back to this device's local date — never UTC (#192).
+    const { weeks, monthLabels } = buildHeatmapGrid(data, endDate ?? localEndDate());
+
     return { weeks, maxCount, monthLabels, totalActivity, activeDays };
-  }, [data]);
+  }, [data, endDate]);
 
   return (
     <TooltipProvider delay={120} closeDelay={0}>

--- a/src/components/ActivityHeatmap/types.ts
+++ b/src/components/ActivityHeatmap/types.ts
@@ -1,4 +1,3 @@
-
 export interface ActivityParts {
   dictionaryLookups: number;
   clozePracticed: number;
@@ -18,6 +17,13 @@ export interface ActivityHeatmapProps {
   data: ActivityDay[];
   /** Noun for the counted unit, e.g. "actions" or "lookups". Defaults to "lookups". */
   unit?: string;
+  /**
+   * Today's calendar date (YYYY-MM-DD) in the user's configured time zone — the
+   * last cell the grid renders. Must be derived the same way as the data's date
+   * keys (timezone-aware, never UTC) or today's column is dropped in the morning
+   * for zones ahead of UTC (issue #192). Falls back to the device's local date.
+   */
+  endDate?: string;
   colorScheme?: {
     empty: string;
     level1: string;
@@ -25,4 +31,19 @@ export interface ActivityHeatmapProps {
     level3: string;
     level4: string;
   };
+}
+
+/** One rendered grid cell: a calendar date (YYYY-MM-DD) and its activity. */
+export interface HeatmapCell {
+  date: string;
+  count: number;
+  dayOfWeek: number;
+  parts?: ActivityParts;
+}
+
+/** A month name anchored at the grid column where that month first appears. */
+export interface MonthLabel {
+  label: string;
+  weekIndex: number;
+  span: number;
 }

--- a/src/components/ActivityHeatmap/utils.test.ts
+++ b/src/components/ActivityHeatmap/utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { buildHeatmapGrid, getColor, localEndDate } from './utils';
+import { darkColorScheme } from './theme';
+import type { ActivityDay, HeatmapCell } from './types';
+
+const flat = (weeks: HeatmapCell[][]): HeatmapCell[] => weeks.flat();
+
+describe('buildHeatmapGrid', () => {
+  // 2026-06-24 is a Wednesday — verified independently via Date.UTC below so
+  // the weekday assertions don't just re-run the function's own logic.
+  const END = '2026-06-24';
+
+  it('renders today as the final cell, with its activity (issue #192)', () => {
+    // The data row for "today" is keyed by the configured-time-zone calendar
+    // date. In the morning for a zone ahead of UTC, the old grid ended on the
+    // UTC date (yesterday), so this row had no cell and today was dropped.
+    const data: ActivityDay[] = [
+      {
+        date: END,
+        count: 7,
+        parts: { dictionaryLookups: 3, clozePracticed: 4, minutesRead: 0, ankiReviews: 0 },
+      },
+    ];
+
+    const { weeks } = buildHeatmapGrid(data, END);
+    const cells = flat(weeks);
+    const last = cells[cells.length - 1];
+
+    expect(last.date).toBe(END);
+    expect(last.count).toBe(7);
+    expect(last.parts).toEqual(data[0].parts);
+    // Nothing is rendered past today.
+    expect(cells.every((c) => c.date <= END)).toBe(true);
+  });
+
+  it('keys cells by calendar date with no UTC shift (correct weekday)', () => {
+    const { weeks } = buildHeatmapGrid([], END);
+    const cells = flat(weeks);
+
+    const todayCell = cells.find((c) => c.date === END)!;
+    expect(todayCell).toBeDefined();
+    // Independent weekday source: 0=Sun … 3=Wed.
+    expect(todayCell.dayOfWeek).toBe(new Date(Date.UTC(2026, 5, 24)).getUTCDay());
+    expect(todayCell.dayOfWeek).toBe(3);
+  });
+
+  it('starts the grid on a Sunday and spans exactly 53 weeks', () => {
+    const { weeks } = buildHeatmapGrid([], END);
+
+    expect(weeks).toHaveLength(53);
+    expect(weeks[0][0].dayOfWeek).toBe(0); // Sunday
+    // 365-day window: first cell is 364 days before today, padded back to Sunday.
+    expect(weeks[0][0].date <= '2025-06-25').toBe(true);
+    expect(weeks[0][0].date >= '2025-06-19').toBe(true);
+  });
+
+  it('walks consecutive calendar days within and across weeks (DST-safe)', () => {
+    const { weeks } = buildHeatmapGrid([], END);
+    const cells = flat(weeks);
+
+    // Every step is exactly one calendar day and the weekday cycles 0..6.
+    for (let i = 1; i < cells.length; i++) {
+      const prev = new Date(cells[i - 1].date + 'T12:00:00Z');
+      const cur = new Date(cells[i].date + 'T12:00:00Z');
+      expect((cur.getTime() - prev.getTime()) / 86_400_000).toBe(1);
+      expect(cells[i].dayOfWeek).toBe((cells[i - 1].dayOfWeek + 1) % 7);
+    }
+  });
+
+  it('zero-fills days with no activity record', () => {
+    const { weeks } = buildHeatmapGrid([{ date: END, count: 2 }], END);
+    const cells = flat(weeks);
+    const someEarlier = cells[10];
+    expect(someEarlier.count).toBe(0);
+    expect(someEarlier.parts).toBeUndefined();
+  });
+
+  it('produces month labels whose spans tile the full 53-column grid', () => {
+    const { weeks, monthLabels } = buildHeatmapGrid([], END);
+    const totalSpan = monthLabels.reduce((sum, m) => sum + m.span, 0);
+    expect(totalSpan).toBe(weeks.length);
+    expect(monthLabels[0].label).toMatch(/^[A-Z][a-z]{2}$/);
+  });
+});
+
+describe('localEndDate', () => {
+  it('returns a YYYY-MM-DD string (never an empty/UTC-only value)', () => {
+    expect(localEndDate()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('getColor', () => {
+  it('returns the empty color at zero and scales up with the ratio', () => {
+    expect(getColor(0, 10, darkColorScheme)).toBe(darkColorScheme.empty);
+    expect(getColor(2, 10, darkColorScheme)).toBe(darkColorScheme.level1);
+    expect(getColor(10, 10, darkColorScheme)).toBe(darkColorScheme.level4);
+  });
+});

--- a/src/components/ActivityHeatmap/utils.ts
+++ b/src/components/ActivityHeatmap/utils.ts
@@ -1,4 +1,7 @@
+import { addDaysToDateString, dateStringInTimeZone } from '@/lib/dates';
+import { MONTHS } from './constants';
 import { darkColorScheme } from './theme';
+import type { ActivityDay, HeatmapCell, MonthLabel } from './types';
 
 export function getColor(count: number, maxCount: number, scheme: typeof darkColorScheme): string {
   if (count === 0) {
@@ -20,6 +23,86 @@ export function getColor(count: number, maxCount: number, scheme: typeof darkCol
   return scheme.level4;
 }
 
-export function formatDate(date: Date): string {
-  return date.toISOString().split('T')[0];
+/**
+ * Today's calendar date (YYYY-MM-DD) on this device — the fallback grid endpoint
+ * when a caller doesn't pass an explicit, configured-time-zone endDate. Uses the
+ * device's IANA zone rather than `toISOString()` so it never lands on the UTC
+ * date (which is "yesterday" in the morning for zones ahead of UTC — issue #192).
+ */
+export function localEndDate(): string {
+  return dateStringInTimeZone(new Date(), Intl.DateTimeFormat().resolvedOptions().timeZone);
+}
+
+/** Day of week (0 = Sunday) for a YYYY-MM-DD string, parsed at noon UTC so the
+ *  weekday is stable regardless of the runtime's own time zone. */
+function dayOfWeek(dateStr: string): number {
+  return new Date(dateStr + 'T12:00:00Z').getUTCDay();
+}
+
+/**
+ * Build the calendar grid: 365 days ending on (and including) `endDate`, padded
+ * back to the preceding Sunday so every column is a full week.
+ *
+ * Cells are keyed by calendar-date STRINGS and the whole range is walked with
+ * `addDaysToDateString` — no Date→`toISOString()` round-trips. That keeps the
+ * cell keys identical to the data's time-zone-aware date keys, so "today" lines
+ * up with its activity row instead of being shifted or dropped by a UTC
+ * conversion (issue #192).
+ */
+export function buildHeatmapGrid(
+  data: ActivityDay[],
+  endDate: string,
+): { weeks: HeatmapCell[][]; monthLabels: MonthLabel[] } {
+  // date -> the full day record, so each cell can show its breakdown.
+  const activityMap = new Map(data.map((d) => [d.date, d]));
+
+  // 365-day window, then back up to the start of its week (Sunday).
+  const windowStart = addDaysToDateString(endDate, -364);
+  const gridStart = addDaysToDateString(windowStart, -dayOfWeek(windowStart));
+
+  const weeks: HeatmapCell[][] = [];
+  let currentWeek: HeatmapCell[] = [];
+
+  const monthLabels: MonthLabel[] = [];
+  let lastMonth = -1;
+  let weekIndex = 0;
+
+  // String comparison is chronological for zero-padded YYYY-MM-DD.
+  for (let cursor = gridStart; cursor <= endDate; cursor = addDaysToDateString(cursor, 1)) {
+    const day = activityMap.get(cursor);
+    const month = Number(cursor.slice(5, 7)) - 1;
+
+    // One label per month, anchored at the column that first shows it; span is
+    // filled in after the loop.
+    if (month !== lastMonth) {
+      monthLabels.push({ label: MONTHS[month], weekIndex, span: 0 });
+      lastMonth = month;
+    }
+
+    currentWeek.push({
+      date: cursor,
+      count: day?.count || 0,
+      dayOfWeek: dayOfWeek(cursor),
+      parts: day?.parts,
+    });
+
+    if (currentWeek.length === 7) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+      weekIndex++;
+    }
+  }
+
+  // Push the trailing partial week (today usually isn't a Saturday).
+  if (currentWeek.length > 0) {
+    weeks.push(currentWeek);
+  }
+
+  // Each label spans from its own column up to the next label's column (the last
+  // runs to the end). Spans sum to weeks.length, so they tile grid-cols-53.
+  monthLabels.forEach((m, i) => {
+    m.span = (monthLabels[i + 1]?.weekIndex ?? weeks.length) - m.weekIndex;
+  });
+
+  return { weeks, monthLabels };
 }


### PR DESCRIPTION
Closes #192.

## Root cause

The stats page computes a timezone-aware `endDate`, but `ActivityHeatmap` ignored it — it re-derived the grid from `new Date()` and keyed every cell with `formatDate()` = `toISOString().split('T')[0]` (**UTC**). The activity rows, though, are keyed by the *configured-time-zone* calendar date (`getTodayDate()`).

For a zone ahead of UTC (e.g. AEST), in the local morning the UTC date is still "yesterday", so the grid ended a day early and today's activity row had no matching cell — **today was dropped** (and the whole grid could sit shifted by a day).

## Fix

- `ActivityHeatmap/utils.ts` — replace the UTC `formatDate` with a pure, testable `buildHeatmapGrid(data, endDate)` that walks `YYYY-MM-DD` **strings** via the existing DST-safe `addDaysToDateString` (no `Date`→`toISOString` round-trip). Cell keys now match the data's time-zone-aware keys exactly. Added `localEndDate()` (device-local, never UTC) as the fallback.
- `ActivityHeatmap/index.tsx` — new `endDate` prop; grid ends on `endDate ?? localEndDate()`. Removed the inline UTC loop.
- `app/stats/page.tsx` — passes the `endDate` it already derives from the `timezone` setting.

## Tests

`ActivityHeatmap/utils.test.ts` (8 cases) — the regression proof: with an `endDate` that differs from the UTC date, today renders as the **final cell** with its activity; correct weekday (no UTC shift); 53-week grid starting on Sunday; zero-fill; month-label spans tile the grid.

- `prettier`, `eslint`, `tsc --noEmit`, and `vitest` (180 passing) all clean locally.
- The existing `e2e/activity-heatmap.spec.ts` (render + totals) is unaffected — totals come from `data`, not the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
