### PR TITLE
fix(stats): thread active language into the /translate study-ping write

### DIFF
--- a/api/src/lib/study-session.test.ts
+++ b/api/src/lib/study-session.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { db } from '../db';
+import { getTodayDate } from './dates';
+import { recordStudySessionPing } from './study-session';
+
+function reset() {
+  db.prepare('DELETE FROM dailyStats').run();
+}
+
+describe('recordStudySessionPing', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test("creates today's row for the given language and stamps sessionStartedAt", () => {
+    recordStudySessionPing('de');
+
+    const rows = db
+      .prepare('SELECT date, language, sessionStartedAt FROM dailyStats')
+      .all() as { date: string; language: string; sessionStartedAt: string | null }[];
+
+    // The language-less bug created an 'af' row regardless of the active language;
+    // the row must be for 'de', on the timezone-aware day boundary.
+    expect(rows.length).toBe(1);
+    expect(rows[0].date).toBe(getTodayDate());
+    expect(rows[0].language).toBe('de');
+    expect(rows[0].sessionStartedAt).not.toBeNull();
+  });
+
+  test('writes only the given language row — never a blanket cross-language write', () => {
+    const today = getTodayDate();
+    // A pre-existing 'af' session for the same day.
+    db.prepare(
+      "INSERT INTO dailyStats (date, language, sessionStartedAt) VALUES (?, 'af', ?)",
+    ).run(today, '2026-06-21T06:00:00Z');
+
+    recordStudySessionPing('de');
+
+    const af = db
+      .prepare("SELECT sessionStartedAt FROM dailyStats WHERE date = ? AND language = 'af'")
+      .get(today) as { sessionStartedAt: string };
+    const de = db
+      .prepare("SELECT sessionStartedAt FROM dailyStats WHERE date = ? AND language = 'de'")
+      .get(today) as { sessionStartedAt: string | null } | undefined;
+
+    // 'af' is untouched, and a distinct 'de' row now exists (the old language-less
+    // write only ever touched 'af' and would never create the 'de' row).
+    expect(af.sessionStartedAt).toBe('2026-06-21T06:00:00Z');
+    expect(de).toBeTruthy();
+    expect(de!.sessionStartedAt).not.toBeNull();
+  });
+
+  test('is idempotent — a repeat ping keeps the earliest sessionStartedAt', () => {
+    recordStudySessionPing('af');
+    const today = getTodayDate();
+    const first = db
+      .prepare("SELECT sessionStartedAt FROM dailyStats WHERE date = ? AND language = 'af'")
+      .get(today) as { sessionStartedAt: string };
+    expect(first.sessionStartedAt).not.toBeNull();
+
+    recordStudySessionPing('af');
+    const second = db
+      .prepare("SELECT sessionStartedAt FROM dailyStats WHERE date = ? AND language = 'af'")
+      .get(today) as { sessionStartedAt: string };
+    const count = db
+      .prepare("SELECT COUNT(*) as n FROM dailyStats WHERE language = 'af'")
+      .get() as { n: number };
+
+    expect(second.sessionStartedAt).toBe(first.sessionStartedAt); // COALESCE keeps the first
+    expect(count.n).toBe(1);
+  });
+});

--- a/api/src/lib/study-session.test.ts
+++ b/api/src/lib/study-session.test.ts
@@ -5,6 +5,7 @@ import { recordStudySessionPing } from './study-session';
 
 function reset() {
   db.prepare('DELETE FROM dailyStats').run();
+  db.prepare("DELETE FROM settings WHERE key = 'timezone'").run();
 }
 
 describe('recordStudySessionPing', () => {
@@ -47,6 +48,28 @@ describe('recordStudySessionPing', () => {
     expect(af.sessionStartedAt).toBe('2026-06-21T06:00:00Z');
     expect(de).toBeTruthy();
     expect(de!.sessionStartedAt).not.toBeNull();
+  });
+
+  test('records the day in the configured time zone, not raw UTC', () => {
+    const setTimeZone = (zone: string) =>
+      db
+        .prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('timezone', ?)")
+        .run(JSON.stringify(zone));
+
+    // Two zones 25h apart always fall on different calendar days at any single
+    // instant, so a timezone-aware writer records two distinct dates here while
+    // the old raw-UTC writer would collapse both onto the one UTC day (1 row).
+    setTimeZone('Pacific/Kiritimati'); // UTC+14
+    recordStudySessionPing('af');
+    setTimeZone('Pacific/Pago_Pago'); // UTC-11
+    recordStudySessionPing('af');
+
+    const dates = db
+      .prepare("SELECT date FROM dailyStats WHERE language = 'af' ORDER BY date")
+      .all() as { date: string }[];
+
+    expect(dates.length).toBe(2);
+    expect(dates[0].date).not.toBe(dates[1].date);
   });
 
   test('is idempotent — a repeat ping keeps the earliest sessionStartedAt', () => {

--- a/api/src/lib/study-session.ts
+++ b/api/src/lib/study-session.ts
@@ -11,10 +11,12 @@ import { getTodayDate } from './dates';
 // every language's row for the day. This helper is the single source of truth for
 // that write — shared by /translate, /dictionary, and /study-ping so the three
 // callers can't drift apart again (which is exactly how the /translate copy ended
-// up language-less and on a raw-UTC day boundary). Uses getTodayDate() so the day
-// rollover matches every other stats writer (timezone-aware, never raw UTC).
-export function recordStudySessionPing(language: string): void {
-  const today = getTodayDate();
+// up language-less and on a raw-UTC day boundary). Defaults the day to
+// getTodayDate() so the rollover matches every other stats writer (timezone-aware,
+// never raw UTC); callers that make a second same-day write (e.g. the dictionary
+// lookup's extra counter bump) pass a shared `today` so both writes target the
+// same row even if the clock rolls over between them.
+export function recordStudySessionPing(language: string, today: string = getTodayDate()): void {
   const now = new Date().toISOString();
   db.prepare(
     `INSERT OR IGNORE INTO dailyStats

--- a/api/src/lib/study-session.ts
+++ b/api/src/lib/study-session.ts
@@ -1,0 +1,27 @@
+import { db } from '../db';
+import { getTodayDate } from './dates';
+
+// Record the once-per-day "study session started" ping for a language: ensure the
+// (date, language) dailyStats row exists, then stamp sessionStartedAt the first
+// time it's called that day (COALESCE keeps the earliest start).
+//
+// dailyStats has a compound (date, language) PK, so every write MUST target the
+// active language's row. A language-less INSERT misattributes the row to the
+// table default ('af'), and a language-less UPDATE bleeds sessionStartedAt across
+// every language's row for the day. This helper is the single source of truth for
+// that write — shared by /translate, /dictionary, and /study-ping so the three
+// callers can't drift apart again (which is exactly how the /translate copy ended
+// up language-less and on a raw-UTC day boundary). Uses getTodayDate() so the day
+// rollover matches every other stats writer (timezone-aware, never raw UTC).
+export function recordStudySessionPing(language: string): void {
+  const today = getTodayDate();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR IGNORE INTO dailyStats
+      (date, language, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
+     VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0)`,
+  ).run(today, language);
+  db.prepare(
+    'UPDATE dailyStats SET sessionStartedAt = COALESCE(sessionStartedAt, ?) WHERE date = ? AND language = ?',
+  ).run(now, today, language);
+}

--- a/api/src/routes/dictionary.ts
+++ b/api/src/routes/dictionary.ts
@@ -2,31 +2,20 @@ import { Hono } from 'hono';
 import { db } from '../db';
 import { resolveLanguage } from '../lib/active-language';
 import { getTodayDate } from '../lib/dates';
+import { recordStudySessionPing } from '../lib/study-session';
 import { lookupWord, cacheAcceptedEntry, type CacheAcceptedInput } from '../lib/dictionary-db';
 
 const app = new Hono();
 
-// Mirrors the recordStudyPing() side-effect from /api/translate, and also bumps
-// dictionaryLookups so daily lookup stats stay accurate when the on-device DB
-// serves a hit. dailyStats has a compound (date, language) PK, so the write must
-// target the looked-up language's row — otherwise the lookup is misattributed to
-// 'af' and the language-less UPDATE writes across every language's row for the
-// day. Uses getTodayDate() (timezone-aware) so the day boundary matches every
-// other stats writer (not raw UTC).
-function recordStudyPing(language: string) {
-  const today = getTodayDate();
-  const now = new Date().toISOString();
-  db.prepare(
-    `INSERT OR IGNORE INTO dailyStats
-      (date, language, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
-     VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0)`,
-  ).run(today, language);
-  db.prepare(
-    'UPDATE dailyStats SET sessionStartedAt = COALESCE(sessionStartedAt, ?) WHERE date = ? AND language = ?',
-  ).run(now, today, language);
+// Record an on-device dictionary hit: the shared session ping (sessionStartedAt
+// on the looked-up language's row) plus a dictionaryLookups bump, so daily lookup
+// stats stay accurate when the local DB serves a hit instead of the AI path. Both
+// writes target the looked-up language's (date, language) row.
+function recordDictionaryLookup(language: string) {
+  recordStudySessionPing(language);
   db.prepare(
     'UPDATE dailyStats SET dictionaryLookups = dictionaryLookups + 1 WHERE date = ? AND language = ?',
-  ).run(today, language);
+  ).run(getTodayDate(), language);
 }
 
 // GET /api/dictionary/lookup?word=<word>
@@ -41,7 +30,7 @@ app.get('/lookup', (c) => {
 
     const lang = resolveLanguage(c.req.query('language'));
     const entry = lookupWord(word.trim(), lang);
-    if (entry) recordStudyPing(lang);
+    if (entry) recordDictionaryLookup(lang);
 
     return c.json({ entry: entry ?? null });
   } catch (error) {

--- a/api/src/routes/dictionary.ts
+++ b/api/src/routes/dictionary.ts
@@ -12,10 +12,11 @@ const app = new Hono();
 // stats stay accurate when the local DB serves a hit instead of the AI path. Both
 // writes target the looked-up language's (date, language) row.
 function recordDictionaryLookup(language: string) {
-  recordStudySessionPing(language);
+  const today = getTodayDate();
+  recordStudySessionPing(language, today);
   db.prepare(
     'UPDATE dailyStats SET dictionaryLookups = dictionaryLookups + 1 WHERE date = ? AND language = ?',
-  ).run(getTodayDate(), language);
+  ).run(today, language);
 }
 
 // GET /api/dictionary/lookup?word=<word>

--- a/api/src/routes/study-ping.ts
+++ b/api/src/routes/study-ping.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { db } from '../db';
 import { getTodayDate } from '../lib/dates';
 import { resolveLanguage } from '../lib/active-language';
+import { recordStudySessionPing } from '../lib/study-session';
 
 const app = new Hono();
 
@@ -52,17 +53,8 @@ app.get('/', (c) => {
 app.post('/', (c) => {
   const today = getTodayDate();
   const lang = resolveLanguage(c.req.query('language'));
-  const now = new Date().toISOString();
 
-  db.prepare(
-    `INSERT OR IGNORE INTO dailyStats
-      (date, language, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
-     VALUES (?, ?, 0, 0, 0, 0, 0, 0, 0)`,
-  ).run(today, lang);
-
-  db.prepare(
-    'UPDATE dailyStats SET sessionStartedAt = COALESCE(sessionStartedAt, ?) WHERE date = ? AND language = ?',
-  ).run(now, today, lang);
+  recordStudySessionPing(lang);
 
   const activity = getDayActivity(today);
   return c.json({

--- a/api/src/routes/translate.ts
+++ b/api/src/routes/translate.ts
@@ -5,21 +5,7 @@ import { getSpelreelsContext } from '../lib/spelreels';
 import { resolveLanguage } from '../lib/active-language';
 import { getLanguageConfig } from '../lib/languages';
 import { buildGlossPrompt, buildWordEntryPrompt, buildPhrasePrompt } from '../lib/translate-prompts';
-
-import { db } from '../db';
-
-function recordStudyPing() {
-  const today = new Date().toISOString().split('T')[0];
-  const now = new Date().toISOString();
-  db.prepare(`
-    INSERT OR IGNORE INTO dailyStats
-      (date, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
-    VALUES (?, 0, 0, 0, 0, 0, 0, 0)
-  `).run(today);
-  db.prepare(`
-    UPDATE dailyStats SET sessionStartedAt = COALESCE(sessionStartedAt, ?) WHERE date = ?
-  `).run(now, today);
-}
+import { recordStudySessionPing } from '../lib/study-session';
 
 // Parse a rich word-entry response and stitch the legacy translation/partOfSpeech
 // fields so existing call sites that only read those don't have to change.
@@ -70,9 +56,9 @@ app.post('/gloss', async (c) => {
     return c.json({ error: 'Word is required' }, 400);
   }
 
-  recordStudyPing();
-
   const lang = resolveLanguage(language);
+  recordStudySessionPing(lang);
+
   const langName = getLanguageConfig(lang).name;
   const prompt = buildGlossPrompt(langName, word, sentence || '');
   const provider = getProvider();
@@ -125,9 +111,9 @@ app.post('/', async (c) => {
       return c.json({ error: 'Word is required' }, 400);
     }
 
-    recordStudyPing();
-
     const lang = resolveLanguage(language);
+    recordStudySessionPing(lang);
+
     const langConfig = getLanguageConfig(lang);
     const langName = langConfig.name;
 


### PR DESCRIPTION
## What

`api/src/routes/translate.ts`'s `recordStudyPing()` was the last hand-maintained copy of the daily-stats **session ping**, and it had drifted from the other two copies:

- It omitted `language` from the `INSERT`/`UPDATE`, so a study session started via an **AI gloss/translate** (a dictionary miss) was recorded under the default `'af'` row regardless of the active language.
- It used a **raw-UTC** day boundary (`new Date().toISOString().split('T')[0]`) instead of the timezone-aware `getTodayDate()` every other stats writer uses — so near midnight the ping could land on the wrong day.
- Its language-less `UPDATE … WHERE date = ?` set `sessionStartedAt` across **every** language's row for that day.

## Fix

Consolidate the three copies of the session-ping write (`translate`, `dictionary`, and the `study-ping` route) into one shared, tested helper — `recordStudySessionPing(language)` in `api/src/lib/study-session.ts` — so the callers can't drift apart again (the mirrored-copy hazard `CLAUDE.md` calls out). `dictionary` keeps its extra `dictionaryLookups` bump on top of the shared ping; behaviour of the two already-correct paths is unchanged.

## Tests

- New `api/src/lib/study-session.test.ts`: row creation for the active language, cross-language isolation (a `de` ping never touches the `af` row / always creates the `de` row), and `COALESCE` idempotency (a repeat ping keeps the earliest `sessionStartedAt`).
- Full api suite green: **116 pass / 0 fail**. Touched files typecheck clean.

## Context — this supersedes the stale #173

This is the one genuine live bug from #173. The rest of #173 was already resolved and is now stale:

- The Hono/Bun replatform (#180) deleted the Next-side DB; those routes are thin proxies, and the **Bun** stats routes (`stats`, `stats/today`, `fluency`, `study-ping`, `dictionary/lookup`) are already language-partitioned.
- `stats/streak` stays **global by design** (the documented "one streak app-wide" rule) and already counts a multi-language day once (`activeDateSet` dedupes by date).
- `collection_groups` is **intentionally language-agnostic** (#190) — no language column.

The broader, still-open partition work (other tables) is tracked in **#189**, which this refs. Closing #173 as a duplicate of #189.

Refs #189. Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
