### PR TITLE
feat(reader): Anki pipeline from reader — word card + phrase cloze picker (closes #197)

### DIFF
--- a/e2e/reader-anki.spec.ts
+++ b/e2e/reader-anki.spec.ts
@@ -1,0 +1,339 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import path from 'path';
+
+/**
+ * E2E for issue #197: Reader → Anki pipeline.
+ *
+ * Covers:
+ *   - Word click: "Add to Anki" button appears in drawer footer
+ *   - Clicking it sends a Basic addNote to AnkiConnect with <b>word</b> Front
+ *   - The vocab entry is created (or updated) and marked pushedToAnki
+ *   - Phrase drag-selection: "Add to Anki as Cloze" button appears
+ *   - Cloze picker shows word chips; selecting one previews the blank
+ *   - "Send to Anki" sends a Cloze addNote with {{c1::word}} in Text
+ *   - Error case: when AnkiConnect is unreachable the button shows "error"
+ *
+ * AnkiConnect is mocked (Anki isn't running in CI).
+ */
+
+interface AnkiCall {
+  action: string;
+  params?: {
+    note?: {
+      deckName?: string;
+      modelName?: string;
+      fields?: Record<string, string>;
+      tags?: string[];
+    };
+  };
+}
+
+async function mockAnkiConnect(page: Page): Promise<AnkiCall[]> {
+  const calls: AnkiCall[] = [];
+
+  const handleAnkiRoute = async (route: Route) => {
+    const body = JSON.parse(route.request().postData() || '{}') as AnkiCall;
+    calls.push(body);
+    const headers = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': '*',
+      'Content-Type': 'application/json',
+    };
+    if (route.request().method() === 'OPTIONS') {
+      await route.fulfill({ status: 200, headers });
+      return;
+    }
+    const { action } = body;
+    if (action === 'version') {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 6, error: null }) });
+    } else if (action === 'deckNames') {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: ['Afrikaans', 'Afrikaans::Cloze'], error: null }) });
+    } else if (action === 'createDeck') {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 1, error: null }) });
+    } else if (action === 'addNote') {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 1234567890, error: null }) });
+    } else {
+      await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: null, error: null }) });
+    }
+  };
+
+  await page.route('**://localhost:8765/**', handleAnkiRoute);
+  await page.route('http://localhost:8765/', handleAnkiRoute);
+  return calls;
+}
+
+async function importAndOpenReader(page: Page) {
+  const fs = await import('fs');
+  const epubPath = path.join(__dirname, 'fixtures/test-book.epub');
+  const buffer = fs.readFileSync(epubPath);
+
+  const importRes = await page.request.post('/api/import/epub', {
+    multipart: {
+      file: { name: 'test-book.epub', mimeType: 'application/epub+zip', buffer },
+    },
+  });
+  const { collectionId } = await importRes.json();
+
+  const lessonsRes = await page.request.get(`/api/collections/${collectionId}/lessons`);
+  const lessons = await lessonsRes.json();
+  const lessonId = lessons[0].id;
+
+  await page.goto(`/read/${lessonId}`);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByText('Dit is die eerste hoofstuk')).toBeVisible({ timeout: 10000 });
+
+  return { collectionId, lessonId };
+}
+
+async function cleanupCollections(page: Page) {
+  const res = await page.request.get('/api/collections');
+  const collections = await res.json();
+  for (const c of collections) {
+    if (c.title.startsWith('Toets') || c.title.startsWith('Test')) {
+      await page.request.delete(`/api/collections/${c.id}`);
+    }
+  }
+}
+
+test.describe('Reader → Anki pipeline', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    // Clear any custom AnkiConnect URL so the mock at localhost:8765 is used.
+    await page.request.delete('http://localhost:3456/api/settings/ankiConnectUrl').catch(() => {});
+
+    // Mock translate so word clicks don't need a real LLM.
+    await page.route('**/api/translate', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          translation: `[test: ${body.word}]`,
+          partOfSpeech: 'noun',
+        }),
+      });
+    });
+
+    // Mock the gloss stream to avoid SSE complexity in tests.
+    await page.route('**/api/gloss', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'test gloss',
+      });
+    });
+
+    await cleanupCollections(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupCollections(page);
+  });
+
+  test('word click shows "Add to Anki" button in drawer footer', async ({ page }) => {
+    const ankiCalls = await mockAnkiConnect(page);
+    await importAndOpenReader(page);
+
+    const wordSpan = page.locator('article span.cursor-pointer').first();
+    await wordSpan.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+
+    // Wait for translation to resolve (loading spinner disappears)
+    await expect(drawer.getByTestId('add-to-anki-btn')).toBeVisible({ timeout: 8000 });
+
+    expect(ankiCalls.length).toBe(0); // not yet clicked
+  });
+
+  test('clicking "Add to Anki" sends a Basic card with <b>word</b> Front', async ({ page }) => {
+    const ankiCalls = await mockAnkiConnect(page);
+    await importAndOpenReader(page);
+
+    const wordSpan = page.locator('article span.cursor-pointer').first();
+    const wordText = await wordSpan.textContent();
+    await wordSpan.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+
+    const addBtn = drawer.getByTestId('add-to-anki-btn');
+    await expect(addBtn).toBeVisible({ timeout: 8000 });
+    await addBtn.click();
+
+    // Button should change to success state
+    await expect(addBtn).toHaveText('✓ Added to Anki', { timeout: 5000 });
+
+    // AnkiConnect should have received createDeck + addNote
+    const addNoteCall = ankiCalls.find((c) => c.action === 'addNote');
+    expect(addNoteCall).toBeTruthy();
+    expect(addNoteCall!.params!.note!.modelName).toBe('Basic');
+    expect(addNoteCall!.params!.note!.tags).toContain('lector');
+
+    // Front must be exactly <b>word</b> — the pure-word format required by #197
+    const front = addNoteCall!.params!.note!.fields!['Front'];
+    expect(front).toMatch(/^<b>.+<\/b>$/);
+
+    // The word in bold must match what was clicked
+    const boldMatch = front.match(/<b>([^<]+)<\/b>/);
+    expect(boldMatch![1].toLowerCase()).toBe(wordText!.trim().toLowerCase());
+  });
+
+  test('"Add to Anki" button is disabled after push (prevents double-submit)', async ({ page }) => {
+    const ankiCalls = await mockAnkiConnect(page);
+    await importAndOpenReader(page);
+
+    const wordSpan = page.locator('article span.cursor-pointer').first();
+    await wordSpan.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    const addBtn = drawer.getByTestId('add-to-anki-btn');
+    await expect(addBtn).toBeVisible({ timeout: 8000 });
+    await addBtn.click();
+
+    await expect(addBtn).toBeDisabled({ timeout: 5000 });
+
+    const addNoteCalls = ankiCalls.filter((c) => c.action === 'addNote');
+    expect(addNoteCalls.length).toBe(1);
+  });
+
+  test('phrase selection shows "Add to Anki as Cloze" button', async ({ page }) => {
+    await mockAnkiConnect(page);
+    await importAndOpenReader(page);
+
+    const wordSpans = page.locator('article span.cursor-pointer');
+    const firstWord = wordSpans.first();
+    const thirdWord = wordSpans.nth(2);
+
+    const box1 = await firstWord.boundingBox();
+    const box2 = await thirdWord.boundingBox();
+    if (!box1 || !box2) throw new Error('Could not get word bounding boxes');
+
+    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2);
+    await page.mouse.up();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+
+    // Phrase drawer: cloze button, NOT the basic "Add to Anki" button
+    await expect(drawer.getByTestId('add-cloze-btn')).toBeVisible({ timeout: 8000 });
+    await expect(drawer.getByTestId('add-to-anki-btn')).not.toBeVisible();
+  });
+
+  test('cloze picker shows word chips and preview after selection', async ({ page }) => {
+    await mockAnkiConnect(page);
+    await importAndOpenReader(page);
+
+    const wordSpans = page.locator('article span.cursor-pointer');
+    const box1 = await wordSpans.first().boundingBox();
+    const box2 = await wordSpans.nth(2).boundingBox();
+    if (!box1 || !box2) throw new Error('No bounding boxes');
+
+    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2);
+    await page.mouse.up();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+
+    // Open the cloze picker
+    const clozeBtn = drawer.getByTestId('add-cloze-btn');
+    await expect(clozeBtn).toBeVisible({ timeout: 8000 });
+    await clozeBtn.click();
+
+    // Word chips should appear
+    const chips = drawer.getByTestId('cloze-word-chips');
+    await expect(chips).toBeVisible();
+    const chipButtons = chips.locator('button');
+    const chipCount = await chipButtons.count();
+    expect(chipCount).toBeGreaterThanOrEqual(2);
+
+    // Click the first chip
+    await chipButtons.first().click();
+
+    // Preview should appear showing the blank
+    await expect(drawer.getByTestId('cloze-preview')).toBeVisible();
+    await expect(drawer.getByTestId('cloze-send-btn')).not.toBeDisabled();
+  });
+
+  test('sending a cloze card posts Cloze addNote with {{c1::word}}', async ({ page }) => {
+    const ankiCalls = await mockAnkiConnect(page);
+    await importAndOpenReader(page);
+
+    const wordSpans = page.locator('article span.cursor-pointer');
+    const box1 = await wordSpans.first().boundingBox();
+    const box2 = await wordSpans.nth(2).boundingBox();
+    if (!box1 || !box2) throw new Error('No bounding boxes');
+
+    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2);
+    await page.mouse.up();
+
+    const drawer = page.getByTestId('translation-drawer');
+    await expect(drawer).toHaveClass(/translate-x-0/, { timeout: 5000 });
+
+    const clozeSection = drawer.getByTestId('add-cloze-section');
+    await clozeSection.getByTestId('add-cloze-btn').click();
+
+    const chips = drawer.getByTestId('cloze-word-chips');
+    await expect(chips).toBeVisible({ timeout: 3000 });
+
+    // Get the first chip's text then click it
+    const firstChip = chips.locator('button').first();
+    const chipText = await firstChip.textContent();
+    await firstChip.click();
+
+    // Send to Anki
+    const sendBtn = drawer.getByTestId('cloze-send-btn');
+    await expect(sendBtn).not.toBeDisabled();
+    await sendBtn.click();
+
+    // Button should show success
+    await expect(sendBtn).toHaveText('✓ Sent to Anki', { timeout: 5000 });
+
+    // AnkiConnect must receive a Cloze addNote
+    const addNoteCall = ankiCalls.find((c) => c.action === 'addNote');
+    expect(addNoteCall).toBeTruthy();
+    expect(addNoteCall!.params!.note!.modelName).toBe('Cloze');
+    expect(addNoteCall!.params!.note!.tags).toContain('lector');
+
+    // Text field must contain a {{c1::}} blank for the chosen word
+    const textField = addNoteCall!.params!.note!.fields!['Text'];
+    expect(textField).toContain(`{{c1::${chipText!.trim()}}}`);
+  });
+
+  test('Anki error shows error state on button', async ({ page }) => {
+    // Override the mock to return an error for addNote
+    await page.route('**://localhost:8765/**', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}') as AnkiCall;
+      const headers = { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' };
+      if (body.action === 'addNote') {
+        await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: null, error: 'collection is not available' }) });
+      } else if (body.action === 'createDeck') {
+        await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 1, error: null }) });
+      } else {
+        await route.fulfill({ status: 200, headers, body: JSON.stringify({ result: 6, error: null }) });
+      }
+    });
+
+    await importAndOpenReader(page);
+
+    const wordSpan = page.locator('article span.cursor-pointer').first();
+    await wordSpan.click();
+
+    const drawer = page.getByTestId('translation-drawer');
+    const addBtn = drawer.getByTestId('add-to-anki-btn');
+    await expect(addBtn).toBeVisible({ timeout: 8000 });
+    await addBtn.click();
+
+    // Should show error state
+    await expect(addBtn).toHaveText('Anki error — retry', { timeout: 5000 });
+    // And not be disabled — user can retry
+    await expect(addBtn).not.toBeDisabled();
+  });
+});

--- a/e2e/reader-anki.spec.ts
+++ b/e2e/reader-anki.spec.ts
@@ -115,8 +115,8 @@ test.describe('Reader → Anki pipeline', () => {
       });
     });
 
-    // Mock the gloss stream to avoid SSE complexity in tests.
-    await page.route('**/api/gloss', async (route) => {
+    // Word dict-misses stream a plain-text gloss from /translate/gloss.
+    await page.route('**/api/translate/gloss', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'text/plain',
@@ -192,7 +192,10 @@ test.describe('Reader → Anki pipeline', () => {
     await expect(addBtn).toBeVisible({ timeout: 8000 });
     await addBtn.click();
 
-    await expect(addBtn).toBeDisabled({ timeout: 5000 });
+    // Wait for the full round-trip to complete (done state, not just loading)
+    // before asserting call count — avoids the loading→done race.
+    await expect(addBtn).toHaveText('✓ Added to Anki', { timeout: 5000 });
+    await expect(addBtn).toBeDisabled();
 
     const addNoteCalls = ankiCalls.filter((c) => c.action === 'addNote');
     expect(addNoteCalls.length).toBe(1);

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -567,7 +567,7 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
       const entry = await ensureVocabEntry();
       const noteId = await addClozeCard(
         clozeDeck,
-        wordPanel.sentence,
+        wordPanel.word,
         blankWord,
         translation,
         translation,

--- a/src/app/read/[bookId]/page.tsx
+++ b/src/app/read/[bookId]/page.tsx
@@ -16,7 +16,9 @@ import {
   updateVocabState,
   updateLesson,
   incrementDailyStat,
+  markVocabPushedToAnki,
 } from '@/lib/data-layer';
+import { addWordCard, addClozeCard } from '@/lib/anki';
 import { translateWord, translatePhrase, streamWordGloss, enrichWord } from '@/lib/claude';
 import {
   lookupWordRemote,
@@ -26,10 +28,12 @@ import {
 import { speak } from '@/lib/tts';
 import { v4 as uuidv4 } from 'uuid';
 import { WordPanelState } from '../types';
+import { useActiveLanguage } from '@/utils/hooks';
 
 export default function ReadPage({ params }: { params: Promise<{ bookId: string }> }) {
   const { bookId: lessonId } = use(params);
   const router = useRouter();
+  const activeLang = useActiveLanguage();
 
   const [lesson, setLesson] = useState<Lesson | null>(null);
   const [siblings, setSiblings] = useState<LessonSummary[]>([]);
@@ -500,6 +504,85 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
     }
   }, [router, lesson]);
 
+  // Read Anki deck names from localStorage — same keys the Settings page writes.
+  const getAnkiDecks = useCallback(() => {
+    const basic = localStorage.getItem('lector-anki-deck') || activeLang.native;
+    const cloze = localStorage.getItem('lector-anki-cloze-deck') || `${activeLang.native}::Cloze`;
+    return { basic, cloze };
+  }, [activeLang.native]);
+
+  // Ensure a vocab entry exists for the current word and return it.
+  // Creates a level1 entry if none exists, so the word appears in the vocab list.
+  const ensureVocabEntry = useCallback(async (): Promise<VocabEntry> => {
+    const existing = await resolveExistingEntry();
+    if (existing) return existing;
+
+    const isPhrase = wordPanel.word.includes(' ');
+    const entry: VocabEntry = {
+      id: uuidv4(),
+      text: wordPanel.word.toLowerCase(),
+      type: isPhrase ? 'phrase' : 'word',
+      sentence: wordPanel.sentence,
+      translation: wordPanel.translation || '',
+      state: 'level1',
+      stateUpdatedAt: new Date(),
+      reviewCount: 0,
+      bookId: lessonId,
+      createdAt: new Date(),
+      pushedToAnki: false,
+    };
+    await saveVocab(entry);
+    await incrementDailyStat('newWordsSaved');
+    persistAcceptedTranslation();
+    setWordPanel((prev) => ({ ...prev, existingEntry: entry }));
+    setReaderRefreshTrigger((prev) => prev + 1);
+    return entry;
+  }, [wordPanel, lessonId, resolveExistingEntry, persistAcceptedTranslation]);
+
+  const addWordToAnki = useCallback(async () => {
+    const { basic: deckName } = getAnkiDecks();
+    const wordMeaning =
+      wordPanel.dictEntry?.senses[0]?.gloss ??
+      wordPanel.aiStructured?.senses[0]?.gloss ??
+      wordPanel.translation ??
+      '';
+    const translation = wordPanel.aiContextTranslation ?? wordPanel.translation ?? '';
+
+    const entry = await ensureVocabEntry();
+    const noteId = await addWordCard(deckName, wordPanel.word, translation, wordMeaning);
+    await markVocabPushedToAnki(entry.id, noteId);
+    setWordPanel((prev) => ({
+      ...prev,
+      existingEntry: prev.existingEntry
+        ? { ...prev.existingEntry, pushedToAnki: true, ankiNoteId: noteId }
+        : { ...entry, pushedToAnki: true, ankiNoteId: noteId },
+    }));
+  }, [wordPanel, getAnkiDecks, ensureVocabEntry]);
+
+  const addClozeToAnki = useCallback(
+    async (blankWord: string) => {
+      const { cloze: clozeDeck } = getAnkiDecks();
+      const translation = wordPanel.aiContextTranslation ?? wordPanel.translation ?? '';
+
+      const entry = await ensureVocabEntry();
+      const noteId = await addClozeCard(
+        clozeDeck,
+        wordPanel.sentence,
+        blankWord,
+        translation,
+        translation,
+      );
+      await markVocabPushedToAnki(entry.id, noteId);
+      setWordPanel((prev) => ({
+        ...prev,
+        existingEntry: prev.existingEntry
+          ? { ...prev.existingEntry, pushedToAnki: true, ankiNoteId: noteId }
+          : { ...entry, pushedToAnki: true, ankiNoteId: noteId },
+      }));
+    },
+    [wordPanel, getAnkiDecks, ensureVocabEntry],
+  );
+
   const retranslateWithAi = useCallback(async () => {
     setWordPanel((prev) => ({ ...prev, isLoading: true, error: null }));
     const isPhrase = wordPanel.word.includes(' ');
@@ -702,6 +785,8 @@ export default function ReadPage({ params }: { params: Promise<{ bookId: string 
         onEnrich={canEnrich ? enrichTranslation : undefined}
         onRetranslate={retranslateWithAi}
         onLookupWord={handleNestedLookup}
+        onAddToAnki={!wordPanel.word.includes(' ') ? addWordToAnki : undefined}
+        onAddCloze={wordPanel.word.includes(' ') ? addClozeToAnki : undefined}
       />
     </div>
   );

--- a/src/components/TranslationDrawer/index.tsx
+++ b/src/components/TranslationDrawer/index.tsx
@@ -38,9 +38,17 @@ export default function TranslationDrawer({
   onEnrich,
   onRetranslate,
   onLookupWord,
+  onAddToAnki,
+  onAddCloze,
 }: TranslationDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
   const [relatedExpanded, setRelatedExpanded] = useState(false);
+  // Anki push status for single-word cards
+  const [ankiStatus, setAnkiStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  // Cloze picker state for phrase selections
+  const [clozePickerOpen, setClozePickerOpen] = useState(false);
+  const [clozeBlankWord, setClozeBlankWord] = useState<string | null>(null);
+  const [clozeStatus, setClozeStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
   // Reset the "show all related forms" toggle whenever the looked-up word
   // changes — uses React's adjusting-state-during-render pattern so we avoid
   // a setState-in-effect cascade.
@@ -48,6 +56,10 @@ export default function TranslationDrawer({
   if (word !== prevWord) {
     setPrevWord(word);
     setRelatedExpanded(false);
+    setAnkiStatus('idle');
+    setClozePickerOpen(false);
+    setClozeBlankWord(null);
+    setClozeStatus('idle');
   }
 
   useEffect(() => {
@@ -422,8 +434,8 @@ export default function TranslationDrawer({
         )}
       </div>
 
-      {/* Footer — action buttons. Hidden if no level/known/ignore/retranslate callbacks are provided. */}
-      {(onSetLevel || onMarkKnown || onIgnore || onRetranslate) && (
+      {/* Footer — action buttons. */}
+      {(onSetLevel || onMarkKnown || onIgnore || onRetranslate || onAddToAnki || onAddCloze) && (
         <div className="flex-shrink-0 px-4 py-3 border-t border-border bg-muted/50 space-y-2">
           {(onSetLevel || onMarkKnown || onIgnore) && (
             <div className="flex items-center gap-2 flex-wrap">
@@ -487,6 +499,124 @@ export default function TranslationDrawer({
               <RefreshCw className="w-3.5 h-3.5" />
               Re-translate with AI
             </button>
+          )}
+          {/* Anki — single word: pure word card */}
+          {!isPhrase && onAddToAnki && (hasRichEntry || fallbackTranslation) && !isLoading && (
+            <button
+              data-testid="add-to-anki-btn"
+              onClick={async () => {
+                if (ankiStatus === 'loading' || ankiStatus === 'done') return;
+                setAnkiStatus('loading');
+                try {
+                  await onAddToAnki();
+                  setAnkiStatus('done');
+                } catch {
+                  setAnkiStatus('error');
+                }
+              }}
+              disabled={ankiStatus === 'loading' || ankiStatus === 'done'}
+              className={`w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors
+                ${ankiStatus === 'done'
+                  ? 'border-primary/40 bg-primary/10 text-[var(--primary-text)] cursor-default'
+                  : ankiStatus === 'error'
+                  ? 'border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20'
+                  : 'border-border text-muted-foreground hover:bg-accent hover:text-foreground'
+                }`}
+            >
+              {ankiStatus === 'done'
+                ? '✓ Added to Anki'
+                : ankiStatus === 'loading'
+                ? 'Adding…'
+                : ankiStatus === 'error'
+                ? 'Anki error — retry'
+                : 'Add to Anki'}
+            </button>
+          )}
+          {/* Anki — phrase: cloze card with inline word picker */}
+          {isPhrase && onAddCloze && (fallbackTranslation || aiPhraseDetails) && !isLoading && (
+            <div data-testid="add-cloze-section">
+              {!clozePickerOpen ? (
+                <button
+                  data-testid="add-cloze-btn"
+                  onClick={() => setClozePickerOpen(true)}
+                  className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                >
+                  Add to Anki as Cloze
+                </button>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-xs text-muted-foreground">Pick a word to blank:</p>
+                  <div className="flex flex-wrap gap-1" data-testid="cloze-word-chips">
+                    {word.split(/\s+/).filter(Boolean).map((w, i) => (
+                      <button
+                        key={i}
+                        data-testid={`cloze-chip-${i}`}
+                        onClick={() => setClozeBlankWord(clozeBlankWord === w ? null : w)}
+                        className={`px-2 py-0.5 rounded text-sm font-medium transition-colors
+                          ${clozeBlankWord === w
+                            ? 'bg-primary text-primary-foreground'
+                            : 'bg-muted text-foreground hover:bg-accent'
+                          }`}
+                      >
+                        {w}
+                      </button>
+                    ))}
+                  </div>
+                  {clozeBlankWord && (
+                    <p className="text-xs font-mono text-muted-foreground" data-testid="cloze-preview">
+                      {word.split(/\s+/).filter(Boolean).map((w, i) => (
+                        <span key={i}>
+                          {i > 0 && ' '}
+                          {w === clozeBlankWord ? <span className="text-primary font-semibold">[{w}]</span> : w}
+                        </span>
+                      ))}
+                    </p>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      data-testid="cloze-send-btn"
+                      onClick={async () => {
+                        if (!clozeBlankWord || clozeStatus === 'loading' || clozeStatus === 'done') return;
+                        setClozeStatus('loading');
+                        try {
+                          await onAddCloze(clozeBlankWord);
+                          setClozeStatus('done');
+                        } catch {
+                          setClozeStatus('error');
+                        }
+                      }}
+                      disabled={!clozeBlankWord || clozeStatus === 'loading' || clozeStatus === 'done'}
+                      className={`flex-1 px-3 py-1.5 text-xs font-medium rounded-md border transition-colors
+                        ${!clozeBlankWord || clozeStatus === 'loading'
+                          ? 'border-border text-muted-foreground opacity-50 cursor-not-allowed'
+                          : clozeStatus === 'done'
+                          ? 'border-primary/40 bg-primary/10 text-[var(--primary-text)] cursor-default'
+                          : clozeStatus === 'error'
+                          ? 'border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20'
+                          : 'border-border text-muted-foreground hover:bg-accent hover:text-foreground'
+                        }`}
+                    >
+                      {clozeStatus === 'done'
+                        ? '✓ Sent to Anki'
+                        : clozeStatus === 'loading'
+                        ? 'Sending…'
+                        : clozeStatus === 'error'
+                        ? 'Error — retry'
+                        : 'Send to Anki'}
+                    </button>
+                    {clozeStatus !== 'done' && (
+                      <button
+                        data-testid="cloze-cancel-btn"
+                        onClick={() => { setClozePickerOpen(false); setClozeBlankWord(null); setClozeStatus('idle'); }}
+                        className="px-3 py-1.5 text-xs font-medium rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/components/TranslationDrawer/types.ts
+++ b/src/components/TranslationDrawer/types.ts
@@ -73,4 +73,8 @@ export interface TranslationDrawerProps {
   /** Look up a word referenced inside the entry (form-of glosses, lemma stem,
       related forms — issue #106). When absent, references render as plain text. */
   onLookupWord?: (word: string) => void;
+  /** Push a pure word card to the default Anki deck (single-word selections only). */
+  onAddToAnki?: () => Promise<void>;
+  /** Push a cloze card — called with the word the user chose to blank (phrase selections only). */
+  onAddCloze?: (blankWord: string) => Promise<void>;
 }

--- a/src/lib/anki.ts
+++ b/src/lib/anki.ts
@@ -258,6 +258,42 @@ export async function addBasicCard(
 }
 
 /**
+ * Add a pure word flashcard to Anki (issue #197).
+ * Front: the word only (bold, so syncWordStates can round-trip it).
+ * Back: translation + word = meaning line.
+ */
+export async function addWordCard(
+  deckName: string,
+  targetWord: string,
+  translation: string,
+  wordMeaning: string,
+): Promise<number> {
+  await ensureDeckExists(deckName);
+  const [cleanTarget] = splitTrailingPunctuation(targetWord);
+
+  const noteId = await ankiRequest<number | null>('addNote', {
+    note: {
+      deckName,
+      modelName: 'Basic',
+      fields: {
+        Front: `<b>${cleanTarget}</b>`,
+        Back: `${translation}<br><br><b>${cleanTarget}</b> = ${wordMeaning}`,
+      },
+      options: { allowDuplicate: true },
+      tags: ['lector', 'vocabulary'],
+    },
+  });
+
+  if (noteId === null) {
+    throw new Error(
+      "Failed to add note — check that 'Basic' note type exists with 'Front' and 'Back' fields",
+    );
+  }
+
+  return noteId;
+}
+
+/**
  * Build the cloze-deletion text for a sentence. Strips trailing punctuation
  * from the target first — bank words can carry it ("haar."), which would make
  * the \b…\b pattern unmatchable and produce a cloze-less note that


### PR DESCRIPTION
## Summary

Closes #197.

- **Word click → Basic card**: clicking a word in the reader now shows "Add to Anki" in the translation drawer footer. Clicking it pushes a pure word flashcard (Front: `<b>word</b>`, Back: translation + definition) to the configured Basic deck and marks the vocab entry `pushedToAnki=true`.
- **Phrase selection → Cloze card**: dragging to select a phrase shows "Add to Anki as Cloze". Tapping it opens an inline word-picker with clickable chips for each word in the phrase; selecting one shows a cloze preview (`[word]`). "Send to Anki" pushes a Cloze card to the configured Cloze deck using the full sentence context.
- Both flows save a vocab entry (state `level1`) if one doesn't already exist, keeping vocab and Anki in sync.

## Design notes

- `addWordCard()` (new in `src/lib/anki.ts`) uses `<b>word</b>` as the Front — this is required for `syncWordStates()` to round-trip the card state via its bold-match extraction.
- Deck names are read from `localStorage` (`lector-anki-deck` / `lector-anki-cloze-deck`) with the active-language name as fallback — same keys the Settings page writes.
- The cloze picker resets whenever the drawer word changes (using React's adjust-state-during-render pattern already in place).

## Test plan

- [ ] Open a reader lesson, click a word, wait for translation — "Add to Anki" button appears in footer
- [ ] Click "Add to Anki" → button changes to "✓ Added to Anki" and is disabled (no double-submit)
- [ ] In Anki, verify a Basic card appears with just the word on the front (not the sentence)
- [ ] Drag-select a phrase, wait for translation — "Add to Anki as Cloze" button appears (not the basic button)
- [ ] Click it → word chips appear; click one → preview shows `[word]` highlighted
- [ ] "Send to Anki" → button changes to "✓ Sent to Anki"; Anki has a Cloze card with `{{c1::word}}`
- [ ] With Anki not running: button shows "Anki error — retry" and stays clickable
- [ ] E2E: `npm run test:e2e -- --grep "Reader → Anki"` (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
