### PR TITLE
feat(i18n): finish language data-partitioning + fix backup-restore data loss (#189)

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -265,6 +265,7 @@ function getDb(): Database {
   migrateVocabForeignKey(_db);
   migrateBooks(_db);
   migrateAddLanguageColumn(_db);
+  migrateCachedEntriesCompoundKey(_db);
 
   // dailyStats.ankiReviews — Anki reviews/day synced from AnkiConnect, counted
   // toward the activity heatmap + streak. Added after the language migration
@@ -393,6 +394,71 @@ function migrateAddLanguageColumn(database: Database) {
       `);
     })();
   }
+}
+
+// Recreate cached_entries with a compound PK (word, language) so the same word
+// can be cached per language, and carry `language` onto the sense / related-form
+// children (FK on (word, language)). Mirrors the knownWords/dailyStats rebuilds:
+// guarded, transactional, idempotent. cached_entries already has a `language`
+// column (base schema), so existing children backfill their language from the
+// parent via the join below. Foreign keys are off app-wide, so the rebuild is
+// safe (and the FK declarations are documentation + future-proofing).
+function migrateCachedEntriesCompoundKey(database: Database) {
+  const cachedSql = database
+    .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='cached_entries'")
+    .get() as { sql: string } | undefined;
+  if (!cachedSql || /PRIMARY KEY\s*\(\s*word\s*,\s*language\s*\)/i.test(cachedSql.sql)) return;
+
+  database.transaction(() => {
+    database.exec(`
+      CREATE TABLE cached_entries_new (
+        word TEXT NOT NULL,
+        language TEXT NOT NULL DEFAULT 'af',
+        ipa TEXT,
+        etymology TEXT,
+        sourceSentence TEXT,
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        PRIMARY KEY (word, language)
+      );
+      INSERT INTO cached_entries_new (word, language, ipa, etymology, sourceSentence, createdAt, updatedAt)
+        SELECT word, language, ipa, etymology, sourceSentence, createdAt, updatedAt FROM cached_entries;
+      DROP TABLE cached_entries;
+      ALTER TABLE cached_entries_new RENAME TO cached_entries;
+      CREATE INDEX IF NOT EXISTS idx_cached_entries_language ON cached_entries(language);
+
+      CREATE TABLE cached_senses_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        word TEXT NOT NULL,
+        language TEXT NOT NULL DEFAULT 'af',
+        pos TEXT,
+        gloss TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (word, language) REFERENCES cached_entries(word, language) ON DELETE CASCADE
+      );
+      INSERT INTO cached_senses_new (id, word, language, pos, gloss, sort_order)
+        SELECT s.id, s.word, COALESCE(e.language, 'af'), s.pos, s.gloss, s.sort_order
+        FROM cached_senses s LEFT JOIN cached_entries e ON e.word = s.word;
+      DROP TABLE cached_senses;
+      ALTER TABLE cached_senses_new RENAME TO cached_senses;
+      CREATE INDEX IF NOT EXISTS idx_cached_senses_word ON cached_senses(word, language);
+
+      CREATE TABLE cached_related_forms_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        word TEXT NOT NULL,
+        language TEXT NOT NULL DEFAULT 'af',
+        related_word TEXT NOT NULL,
+        relation TEXT NOT NULL,
+        FOREIGN KEY (word, language) REFERENCES cached_entries(word, language) ON DELETE CASCADE
+      );
+      INSERT INTO cached_related_forms_new (id, word, language, related_word, relation)
+        SELECT r.id, r.word, COALESCE(e.language, 'af'), r.related_word, r.relation
+        FROM cached_related_forms r LEFT JOIN cached_entries e ON e.word = r.word;
+      DROP TABLE cached_related_forms;
+      ALTER TABLE cached_related_forms_new RENAME TO cached_related_forms;
+      CREATE INDEX IF NOT EXISTS idx_cached_related_word ON cached_related_forms(word, language);
+    `);
+  })();
 }
 
 function migrateVocabForeignKey(database: Database) {

--- a/api/src/lib/dictionary-cache.test.ts
+++ b/api/src/lib/dictionary-cache.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { db } from '../db';
+import { cacheAcceptedEntry } from './dictionary-db';
+
+function reset() {
+  db.prepare('DELETE FROM cached_senses').run();
+  db.prepare('DELETE FROM cached_related_forms').run();
+  db.prepare('DELETE FROM cached_entries').run();
+}
+
+describe('cached_entries — compound (word, language) key', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test('the same word caches independently per language', () => {
+    cacheAcceptedEntry({ word: 'die', language: 'af', senses: [{ partOfSpeech: 'article', gloss: 'the' }] });
+    cacheAcceptedEntry({ word: 'die', language: 'de', senses: [{ partOfSpeech: 'article', gloss: 'the (feminine)' }] });
+
+    // Both rows coexist — the old word-only PK would have collapsed them to one.
+    const langs = db
+      .prepare("SELECT language FROM cached_entries WHERE word = 'die' ORDER BY language")
+      .all() as { language: string }[];
+    expect(langs.map((r) => r.language)).toEqual(['af', 'de']);
+
+    const afGloss = db
+      .prepare("SELECT gloss FROM cached_senses WHERE word = 'die' AND language = 'af'")
+      .all() as { gloss: string }[];
+    const deGloss = db
+      .prepare("SELECT gloss FROM cached_senses WHERE word = 'die' AND language = 'de'")
+      .all() as { gloss: string }[];
+    expect(afGloss.map((s) => s.gloss)).toEqual(['the']);
+    expect(deGloss.map((s) => s.gloss)).toEqual(['the (feminine)']);
+  });
+
+  test('re-caching a word in one language leaves the other language untouched', () => {
+    cacheAcceptedEntry({ word: 'die', language: 'af', senses: [{ partOfSpeech: 'article', gloss: 'the' }] });
+    cacheAcceptedEntry({ word: 'die', language: 'de', senses: [{ partOfSpeech: 'article', gloss: 'the (feminine)' }] });
+
+    // Overwrite the 'af' entry; 'de' must be undisturbed.
+    cacheAcceptedEntry({ word: 'die', language: 'af', senses: [{ partOfSpeech: 'verb', gloss: 'to die (loanword)' }] });
+
+    const af = db
+      .prepare("SELECT gloss FROM cached_senses WHERE word = 'die' AND language = 'af'")
+      .all() as { gloss: string }[];
+    const de = db
+      .prepare("SELECT gloss FROM cached_senses WHERE word = 'die' AND language = 'de'")
+      .all() as { gloss: string }[];
+    expect(af.map((s) => s.gloss)).toEqual(['to die (loanword)']); // replaced, not appended
+    expect(de.map((s) => s.gloss)).toEqual(['the (feminine)']); // untouched
+    expect((db.prepare("SELECT COUNT(*) AS n FROM cached_entries WHERE word = 'die'").get() as { n: number }).n).toBe(2);
+  });
+});

--- a/api/src/lib/dictionary-db.ts
+++ b/api/src/lib/dictionary-db.ts
@@ -223,13 +223,13 @@ function lookupCached(word: string, language: string): ExpandedDictionaryEntry |
   if (!row) return undefined;
 
   const senses = userDb
-    .prepare('SELECT pos, gloss FROM cached_senses WHERE word = ? ORDER BY sort_order')
-    .all(row.word) as Array<{ pos: string | null; gloss: string }>;
+    .prepare('SELECT pos, gloss FROM cached_senses WHERE word = ? AND language = ? ORDER BY sort_order')
+    .all(row.word, language) as Array<{ pos: string | null; gloss: string }>;
   if (senses.length === 0) return undefined;
 
   const related = userDb
-    .prepare('SELECT related_word, relation FROM cached_related_forms WHERE word = ?')
-    .all(row.word) as Array<{ related_word: string; relation: string }>;
+    .prepare('SELECT related_word, relation FROM cached_related_forms WHERE word = ? AND language = ?')
+    .all(row.word, language) as Array<{ related_word: string; relation: string }>;
 
   const entry: ExpandedDictionaryEntry = {
     word: row.word,
@@ -265,20 +265,19 @@ export function cacheAcceptedEntry(input: CacheAcceptedInput): string | null {
   const upsertEntry = userDb.prepare(`
     INSERT INTO cached_entries (word, language, ipa, etymology, sourceSentence, createdAt, updatedAt)
     VALUES (?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(word) DO UPDATE SET
-      language = excluded.language,
+    ON CONFLICT(word, language) DO UPDATE SET
       ipa = excluded.ipa,
       etymology = excluded.etymology,
       sourceSentence = excluded.sourceSentence,
       updatedAt = excluded.updatedAt
   `);
-  const deleteSenses = userDb.prepare('DELETE FROM cached_senses WHERE word = ?');
+  const deleteSenses = userDb.prepare('DELETE FROM cached_senses WHERE word = ? AND language = ?');
   const insertSense = userDb.prepare(
-    'INSERT INTO cached_senses (word, pos, gloss, sort_order) VALUES (?, ?, ?, ?)',
+    'INSERT INTO cached_senses (word, language, pos, gloss, sort_order) VALUES (?, ?, ?, ?, ?)',
   );
-  const deleteRelated = userDb.prepare('DELETE FROM cached_related_forms WHERE word = ?');
+  const deleteRelated = userDb.prepare('DELETE FROM cached_related_forms WHERE word = ? AND language = ?');
   const insertRelated = userDb.prepare(
-    'INSERT INTO cached_related_forms (word, related_word, relation) VALUES (?, ?, ?)',
+    'INSERT INTO cached_related_forms (word, language, related_word, relation) VALUES (?, ?, ?, ?)',
   );
 
   userDb.transaction(() => {
@@ -291,15 +290,15 @@ export function cacheAcceptedEntry(input: CacheAcceptedInput): string | null {
       now,
       now,
     );
-    deleteSenses.run(word);
+    deleteSenses.run(word, language);
     input.senses.forEach((s, i) => {
       if (!s.gloss) return;
-      insertSense.run(word, s.partOfSpeech || null, s.gloss, i);
+      insertSense.run(word, language, s.partOfSpeech || null, s.gloss, i);
     });
-    deleteRelated.run(word);
+    deleteRelated.run(word, language);
     (input.relatedForms || []).forEach((r) => {
       if (!r.form || !r.relation) return;
-      insertRelated.run(word, r.form, r.relation);
+      insertRelated.run(word, language, r.form, r.relation);
     });
   })();
   return word;

--- a/api/src/routes/chat.test.ts
+++ b/api/src/routes/chat.test.ts
@@ -68,7 +68,7 @@ describe('chat route — per-language scoping', () => {
     seed({ id: 'af1', language: 'af', minutesAgo: 1 });
     seed({ id: 'es1', language: 'es', minutesAgo: 1 });
 
-    const res = await app.request('/?lang=es');
+    const res = await app.request('/?language=es');
     expect(res.status).toBe(200);
     const msgs = (await res.json()) as { id: string }[];
     expect(msgs.map((m) => m.id)).toEqual(['es1']);
@@ -89,7 +89,7 @@ describe('chat route — per-language scoping', () => {
     seed({ id: 'es_new', language: 'es', minutesAgo: 1 });
     seed({ id: 'af_old', language: 'af', minutesAgo: 2 });
 
-    const res = await app.request(`/?lang=es&before=${encodeURIComponent(ago(1.5))}`);
+    const res = await app.request(`/?language=es&before=${encodeURIComponent(ago(1.5))}`);
     const msgs = (await res.json()) as { id: string }[];
     expect(msgs.map((m) => m.id)).toEqual(['es_old']);
   });
@@ -98,7 +98,7 @@ describe('chat route — per-language scoping', () => {
     seed({ id: 'es_old', language: 'es', minutesAgo: 2 });
     seed({ id: 'es_new', language: 'es', minutesAgo: 1 });
 
-    const res = await app.request('/?lang=es');
+    const res = await app.request('/?language=es');
     const msgs = (await res.json()) as { id: string }[];
     expect(msgs.map((m) => m.id)).toEqual(['es_old', 'es_new']);
   });
@@ -108,7 +108,7 @@ describe('chat route — per-language scoping', () => {
     seed({ id: 'af1', language: 'af', minutesAgo: 1 });
     seed({ id: 'es1', language: 'es', minutesAgo: 1 });
 
-    const res = await app.request('/?lang=af', { method: 'DELETE' });
+    const res = await app.request('/?language=af', { method: 'DELETE' });
     expect(res.status).toBe(200);
     const remaining = db.prepare('SELECT id FROM chat_messages').all() as { id: string }[];
     expect(remaining.map((r) => r.id)).toEqual(['es1']);

--- a/api/src/routes/chat.ts
+++ b/api/src/routes/chat.ts
@@ -27,7 +27,7 @@ app.get('/', (c) => {
 
   const limit = parseInt(c.req.query('limit') || '50');
   const before = c.req.query('before'); // cursor for infinite scroll
-  const lang = resolveLanguage(c.req.query('lang'));
+  const lang = resolveLanguage(c.req.query('language'));
 
   let messages: ChatMessageRow[];
 
@@ -132,7 +132,7 @@ app.post('/', async (c) => {
 
 // DELETE /api/chat — clear chat history for the active (or requested) language
 app.delete('/', (c) => {
-  const lang = resolveLanguage(c.req.query('lang'));
+  const lang = resolveLanguage(c.req.query('language'));
   db.prepare('DELETE FROM chat_messages WHERE language = ?').run(lang);
   return c.json({ ok: true });
 });

--- a/api/src/routes/cloze.ts
+++ b/api/src/routes/cloze.ts
@@ -229,9 +229,14 @@ app.get('/seed', (c) => {
 });
 
 // GET /api/cloze/:id
+// By-id routes scope to the active language (defense-in-depth): a stale
+// cross-language id 404s rather than reading/mutating another language's row.
 app.get('/:id', (c) => {
   const id = c.req.param('id');
-  const sentence = db.prepare('SELECT * FROM clozeSentences WHERE id = ?').get(id) as ClozeSentenceRow | undefined;
+  const lang = resolveLanguage(c.req.query('language'));
+  const sentence = db
+    .prepare('SELECT * FROM clozeSentences WHERE id = ? AND language = ?')
+    .get(id, lang) as ClozeSentenceRow | undefined;
 
   if (!sentence) return c.json({ error: 'Not found' }, 404);
 
@@ -245,9 +250,10 @@ app.get('/:id', (c) => {
 // PUT /api/cloze/:id
 app.put('/:id', async (c) => {
   const id = c.req.param('id');
+  const lang = resolveLanguage(c.req.query('language'));
   const body = await c.req.json();
 
-  const existing = db.prepare('SELECT id FROM clozeSentences WHERE id = ?').get(id);
+  const existing = db.prepare('SELECT id FROM clozeSentences WHERE id = ? AND language = ?').get(id, lang);
   if (!existing) return c.json({ error: 'Not found' }, 404);
 
   const updates: string[] = [];
@@ -264,7 +270,8 @@ app.put('/:id', async (c) => {
 
   if (updates.length > 0) {
     values.push(id);
-    db.prepare(`UPDATE clozeSentences SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+    values.push(lang);
+    db.prepare(`UPDATE clozeSentences SET ${updates.join(', ')} WHERE id = ? AND language = ?`).run(...values);
   }
 
   return c.json({ success: true });
@@ -273,16 +280,20 @@ app.put('/:id', async (c) => {
 // DELETE /api/cloze/:id
 app.delete('/:id', (c) => {
   const id = c.req.param('id');
-  db.prepare('DELETE FROM clozeSentences WHERE id = ?').run(id);
+  const lang = resolveLanguage(c.req.query('language'));
+  db.prepare('DELETE FROM clozeSentences WHERE id = ? AND language = ?').run(id, lang);
   return c.json({ success: true });
 });
 
 // POST /api/cloze/:id/review
 app.post('/:id/review', async (c) => {
   const id = c.req.param('id');
+  const lang = resolveLanguage(c.req.query('language'));
   const body = await c.req.json();
 
-  const sentence = db.prepare('SELECT * FROM clozeSentences WHERE id = ?').get(id) as ClozeSentenceRow | undefined;
+  const sentence = db
+    .prepare('SELECT * FROM clozeSentences WHERE id = ? AND language = ?')
+    .get(id, lang) as ClozeSentenceRow | undefined;
   if (!sentence) return c.json({ error: 'Not found' }, 404);
 
   const correct = body.correct as boolean;
@@ -297,8 +308,8 @@ app.post('/:id/review', async (c) => {
       lastReviewed = ?,
       timesCorrect = timesCorrect + ?,
       timesIncorrect = timesIncorrect + ?
-    WHERE id = ?
-  `).run(newMasteryLevel, nextReview, new Date().toISOString(), correct ? 1 : 0, correct ? 0 : 1, id);
+    WHERE id = ? AND language = ?
+  `).run(newMasteryLevel, nextReview, new Date().toISOString(), correct ? 1 : 0, correct ? 0 : 1, id, lang);
 
   return c.json({ success: true });
 });

--- a/api/src/routes/collections.ts
+++ b/api/src/routes/collections.ts
@@ -60,16 +60,19 @@ app.put('/reorder', async (c) => {
 });
 
 // GET /api/collections/:id
+// By-id routes scope to the active language (defense-in-depth): a stale
+// cross-language id 404s rather than reading/mutating another language's row.
 app.get('/:id', (c) => {
   const id = c.req.param('id');
+  const lang = resolveLanguage(c.req.query('language'));
   const collection = db.prepare(`
     SELECT c.*, COUNT(l.id) as lessonCount,
       COALESCE(AVG(l.progress_percentComplete), 0) as avgProgress
     FROM collections c
-    LEFT JOIN lessons l ON l.collectionId = c.id
-    WHERE c.id = ?
+    LEFT JOIN lessons l ON l.collectionId = c.id AND l.language = c.language
+    WHERE c.id = ? AND c.language = ?
     GROUP BY c.id
-  `).get(id) as (CollectionRow & { lessonCount: number; avgProgress: number }) | undefined;
+  `).get(id, lang) as (CollectionRow & { lessonCount: number; avgProgress: number }) | undefined;
 
   if (!collection) {
     return c.json({ error: 'Collection not found' }, 404);
@@ -81,6 +84,7 @@ app.get('/:id', (c) => {
 // PUT /api/collections/:id
 app.put('/:id', async (c) => {
   const id = c.req.param('id');
+  const lang = resolveLanguage(c.req.query('language'));
   const body = await c.req.json();
 
   const updates: string[] = [];
@@ -99,8 +103,9 @@ app.put('/:id', async (c) => {
     values.push(new Date().toISOString());
   }
   values.push(id);
+  values.push(lang);
 
-  db.prepare(`UPDATE collections SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+  db.prepare(`UPDATE collections SET ${updates.join(', ')} WHERE id = ? AND language = ?`).run(...values);
 
   return c.json({ success: true });
 });
@@ -108,8 +113,9 @@ app.put('/:id', async (c) => {
 // DELETE /api/collections/:id
 app.delete('/:id', (c) => {
   const id = c.req.param('id');
-  db.prepare('DELETE FROM lessons WHERE collectionId = ?').run(id);
-  db.prepare('DELETE FROM collections WHERE id = ?').run(id);
+  const lang = resolveLanguage(c.req.query('language'));
+  db.prepare('DELETE FROM lessons WHERE collectionId = ? AND language = ?').run(id, lang);
+  db.prepare('DELETE FROM collections WHERE id = ? AND language = ?').run(id, lang);
   return c.json({ success: true });
 });
 
@@ -138,12 +144,20 @@ app.post('/:id/lessons', async (c) => {
     'SELECT COALESCE(MAX(sortOrder), -1) as maxOrder FROM lessons WHERE collectionId = ?'
   ).get(collectionId) as { maxOrder: number };
 
+  // A lesson inherits its parent collection's language so it matches the
+  // l.language = c.language join in the library list; fall back to the active
+  // language if the collection is somehow missing.
+  const parent = db.prepare('SELECT language FROM collections WHERE id = ?').get(collectionId) as
+    | { language: string }
+    | undefined;
+  const language = parent?.language ?? resolveLanguage(c.req.query('language'));
+
   const textContent = body.textContent || '';
 
   db.prepare(`
-    INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, createdAt, lastReadAt)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, collectionId, body.title, maxOrder.maxOrder + 1, textContent, countWords(textContent), now, now);
+    INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, language, createdAt, lastReadAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, collectionId, body.title, maxOrder.maxOrder + 1, textContent, countWords(textContent), language, now, now);
 
   db.prepare('UPDATE collections SET lastReadAt = ? WHERE id = ?').run(now, collectionId);
 

--- a/api/src/routes/collections.ts
+++ b/api/src/routes/collections.ts
@@ -102,10 +102,13 @@ app.put('/:id', async (c) => {
     updates.push('lastReadAt = ?');
     values.push(new Date().toISOString());
   }
-  values.push(id);
-  values.push(lang);
-
-  db.prepare(`UPDATE collections SET ${updates.join(', ')} WHERE id = ? AND language = ?`).run(...values);
+  // Guard the empty-update case: a body with no recognized fields would otherwise
+  // build `SET  WHERE …` (a syntax error). Matches the cloze PUT handler.
+  if (updates.length > 0) {
+    values.push(id);
+    values.push(lang);
+    db.prepare(`UPDATE collections SET ${updates.join(', ')} WHERE id = ? AND language = ?`).run(...values);
+  }
 
   return c.json({ success: true });
 });

--- a/api/src/routes/data.test.ts
+++ b/api/src/routes/data.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { db } from '../db';
+
+const { default: app } = await import('../routes/data');
+
+const TABLES = [
+  'collections',
+  'collection_groups',
+  'lessons',
+  'vocab',
+  'knownWords',
+  'clozeSentences',
+  'dailyStats',
+];
+
+function reset() {
+  for (const t of TABLES) db.prepare(`DELETE FROM ${t}`).run();
+}
+
+function importData(payload: unknown) {
+  return app.request('/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+const TS = '2026-01-01T00:00:00Z';
+
+describe('data import/restore — language partitioning', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test('restores language + previously-dropped columns; no cross-language row collapse', async () => {
+    const res = await importData({
+      collectionGroups: [{ id: 'g1', name: 'Group', sortOrder: 3, createdAt: TS }],
+      collections: [
+        { id: 'c_af', title: 'AF', language: 'af', groupId: 'g1', sortOrder: 2, createdAt: TS, lastReadAt: TS },
+        { id: 'c_de', title: 'DE', language: 'de', groupId: null, sortOrder: 1, createdAt: TS, lastReadAt: TS },
+      ],
+      // Same word in two languages must NOT collapse (compound PK word, language).
+      knownWords: [
+        { word: 'die', language: 'af', state: 'known' },
+        { word: 'die', language: 'de', state: 'level2' },
+      ],
+      // Same date in two languages must NOT collapse; ankiReviews + sessionStartedAt
+      // must survive (they were dropped by the old import column list).
+      dailyStats: [
+        { date: '2026-06-20', language: 'af', minutesRead: 10, ankiReviews: 5, sessionStartedAt: '2026-06-20T08:00:00Z' },
+        { date: '2026-06-20', language: 'de', minutesRead: 3, ankiReviews: 2, sessionStartedAt: '2026-06-20T09:00:00Z' },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    // Groups restored, so collections' groupId resolves.
+    expect((db.prepare('SELECT COUNT(*) AS n FROM collection_groups').get() as { n: number }).n).toBe(1);
+
+    // collections: language + groupId + sortOrder all preserved.
+    const cAf = db.prepare("SELECT language, groupId, sortOrder FROM collections WHERE id = 'c_af'").get() as {
+      language: string; groupId: string | null; sortOrder: number;
+    };
+    expect(cAf).toEqual({ language: 'af', groupId: 'g1', sortOrder: 2 });
+    expect((db.prepare("SELECT language FROM collections WHERE id = 'c_de'").get() as { language: string }).language).toBe('de');
+
+    // knownWords: both languages survive.
+    const kw = db
+      .prepare("SELECT language, state FROM knownWords WHERE word = 'die' ORDER BY language")
+      .all() as { language: string; state: string }[];
+    expect(kw).toEqual([{ language: 'af', state: 'known' }, { language: 'de', state: 'level2' }]);
+
+    // dailyStats: both languages survive; ankiReviews + sessionStartedAt preserved.
+    const ds = db
+      .prepare("SELECT language, minutesRead, ankiReviews, sessionStartedAt FROM dailyStats WHERE date = '2026-06-20' ORDER BY language")
+      .all() as { language: string; minutesRead: number; ankiReviews: number; sessionStartedAt: string }[];
+    expect(ds).toEqual([
+      { language: 'af', minutesRead: 10, ankiReviews: 5, sessionStartedAt: '2026-06-20T08:00:00Z' },
+      { language: 'de', minutesRead: 3, ankiReviews: 2, sessionStartedAt: '2026-06-20T09:00:00Z' },
+    ]);
+  });
+
+  test('legacy backups with no language field restore as Afrikaans', async () => {
+    await importData({
+      knownWords: [{ word: 'hond', state: 'known' }], // pre-multi-language shape
+      dailyStats: [{ date: '2026-05-01', minutesRead: 4 }],
+    });
+    expect((db.prepare("SELECT language FROM knownWords WHERE word = 'hond'").get() as { language: string }).language).toBe('af');
+    expect((db.prepare("SELECT language FROM dailyStats WHERE date = '2026-05-01'").get() as { language: string }).language).toBe('af');
+  });
+
+  test('export includes language and collection_groups', async () => {
+    db.prepare("INSERT INTO knownWords (word, language, state) VALUES ('kat', 'de', 'known')").run();
+    db.prepare("INSERT INTO collection_groups (id, name, sortOrder, createdAt) VALUES ('g9', 'G', 0, ?)").run(TS);
+
+    const res = await app.request('/');
+    const data = (await res.json()) as { knownWords: { word: string; language: string }[]; collectionGroups: { id: string }[] };
+    expect(data.knownWords.find((w) => w.word === 'kat')?.language).toBe('de');
+    expect(data.collectionGroups.map((g) => g.id)).toContain('g9');
+  });
+});

--- a/api/src/routes/data.test.ts
+++ b/api/src/routes/data.test.ts
@@ -49,6 +49,10 @@ describe('data import/restore — language partitioning', () => {
         { date: '2026-06-20', language: 'af', minutesRead: 10, ankiReviews: 5, sessionStartedAt: '2026-06-20T08:00:00Z' },
         { date: '2026-06-20', language: 'de', minutesRead: 3, ankiReviews: 2, sessionStartedAt: '2026-06-20T09:00:00Z' },
       ],
+      // blacklisted is a value-bearing column that the old import dropped → reset to 0.
+      clozeSentences: [
+        { id: 'cs1', sentence: 'Ek lees.', clozeWord: 'lees', clozeIndex: 1, translation: 'I read.', source: 'tatoeba', collection: 'random', nextReview: TS, blacklisted: 1, language: 'de' },
+      ],
     });
     expect(res.status).toBe(200);
 
@@ -76,6 +80,12 @@ describe('data import/restore — language partitioning', () => {
       { language: 'af', minutesRead: 10, ankiReviews: 5, sessionStartedAt: '2026-06-20T08:00:00Z' },
       { language: 'de', minutesRead: 3, ankiReviews: 2, sessionStartedAt: '2026-06-20T09:00:00Z' },
     ]);
+
+    // clozeSentences: language + blacklisted both preserved (blacklisted was reset before).
+    const cs = db
+      .prepare("SELECT language, blacklisted FROM clozeSentences WHERE id = 'cs1'")
+      .get() as { language: string; blacklisted: number };
+    expect(cs).toEqual({ language: 'de', blacklisted: 1 });
   });
 
   test('legacy backups with no language field restore as Afrikaans', async () => {

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -138,8 +138,8 @@ app.post('/', async (c) => {
 
   if (data.clozeSentences?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect, language)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect, blacklisted, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const cs of data.clozeSentences) {
@@ -149,7 +149,7 @@ app.post('/', async (c) => {
         cs.tatoebaSentenceId || null, cs.vocabEntryId || null, cs.masteryLevel || 0,
         cs.nextReview || new Date().toISOString(), cs.reviewCount || 0,
         cs.lastReviewed || null, cs.timesCorrect || 0, cs.timesIncorrect || 0,
-        cs.language || 'af'
+        cs.blacklisted ?? 0, cs.language || 'af'
       );
       results.clozeSentences++;
     }

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -5,9 +5,12 @@ import { randomUUID } from 'crypto';
 
 const app = new Hono();
 
-// GET /api/data
+// GET /api/data — full backup. SELECT * dumps every column (incl. `language`)
+// for every language, which is correct for a whole-DB backup. collection_groups
+// is included so collections' groupId survives a restore.
 app.get('/', (c) => {
   const collections = db.prepare('SELECT * FROM collections').all();
+  const collectionGroups = db.prepare('SELECT * FROM collection_groups').all();
   const lessons = db.prepare('SELECT * FROM lessons').all();
   const vocab = db.prepare('SELECT * FROM vocab').all();
   const knownWords = db.prepare('SELECT * FROM knownWords').all();
@@ -17,25 +20,48 @@ app.get('/', (c) => {
 
   return c.json({
     exportedAt: new Date().toISOString(),
-    collections, lessons, vocab, knownWords, clozeSentences, dailyStats, settings,
+    collections, collectionGroups, lessons, vocab, knownWords, clozeSentences, dailyStats, settings,
   });
 });
 
-// POST /api/data
+// POST /api/data — restore a backup.
+//
+// Every INSERT MUST list the full column set, including `language`. The
+// partitioned tables (collections/lessons/vocab/knownWords/clozeSentences/
+// dailyStats) carry a `language`, and knownWords + dailyStats have a compound
+// (… , language) PK — so dropping the column doesn't just mislabel rows, it
+// collapses rows from different languages onto the default 'af' key (data loss).
+// Likewise list every value-bearing column (dailyStats.ankiReviews /
+// sessionStartedAt, collections.groupId / sortOrder) so INSERT OR REPLACE doesn't
+// reset them to defaults. Backups predating multi-language have no `language`
+// field; defaulting to 'af' is correct for that legacy Afrikaans-only data.
 app.post('/', async (c) => {
   const data = await c.req.json();
   const results = {
-    collections: 0, lessons: 0, vocab: 0, knownWords: 0,
+    collections: 0, collectionGroups: 0, lessons: 0, vocab: 0, knownWords: 0,
     clozeSentences: 0, dailyStats: 0, settings: 0,
   };
 
+  // Groups before collections so a restored collection's groupId resolves.
+  if (data.collectionGroups?.length) {
+    const stmt = db.prepare(`
+      INSERT OR REPLACE INTO collection_groups (id, name, sortOrder, createdAt)
+      VALUES (?, ?, ?, ?)
+    `);
+    for (const g of data.collectionGroups) {
+      stmt.run(g.id, g.name, g.sortOrder || 0, g.createdAt || new Date().toISOString());
+      results.collectionGroups++;
+    }
+  }
+
   if (data.collections?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO collections (id, title, author, coverUrl, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO collections (id, title, author, coverUrl, sortOrder, groupId, language, createdAt, lastReadAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const col of data.collections) {
       stmt.run(col.id, col.title, col.author || 'Unknown', col.coverUrl || null,
+        col.sortOrder || 0, col.groupId || null, col.language || 'af',
         col.createdAt || new Date().toISOString(), col.lastReadAt || new Date().toISOString());
       results.collections++;
     }
@@ -43,27 +69,28 @@ app.post('/', async (c) => {
 
   if (data.lessons?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO lessons (id, collectionId, title, sortOrder, textContent, progress_scrollPosition, progress_percentComplete, wordCount, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO lessons (id, collectionId, title, sortOrder, textContent, progress_scrollPosition, progress_percentComplete, wordCount, language, createdAt, lastReadAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const l of data.lessons) {
       stmt.run(l.id, l.collectionId || null, l.title, l.sortOrder || 0,
         l.textContent || '', l.progress_scrollPosition || 0, l.progress_percentComplete || 0,
-        l.wordCount || countWords(l.textContent || ''),
+        l.wordCount || countWords(l.textContent || ''), l.language || 'af',
         l.createdAt || new Date().toISOString(), l.lastReadAt || new Date().toISOString());
       results.lessons++;
     }
   }
 
-  // Legacy: import old books as collections+lessons
+  // Legacy: import old books as collections+lessons. Pre-dates multi-language, so
+  // these are Afrikaans ('af').
   if (data.books?.length) {
     const insertCollection = db.prepare(`
-      INSERT OR REPLACE INTO collections (id, title, author, coverUrl, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO collections (id, title, author, coverUrl, language, createdAt, lastReadAt)
+      VALUES (?, ?, ?, ?, 'af', ?, ?)
     `);
     const insertLesson = db.prepare(`
-      INSERT OR REPLACE INTO lessons (id, collectionId, title, sortOrder, textContent, progress_scrollPosition, progress_percentComplete, wordCount, createdAt, lastReadAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO lessons (id, collectionId, title, sortOrder, textContent, progress_scrollPosition, progress_percentComplete, wordCount, language, createdAt, lastReadAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'af', ?, ?)
     `);
 
     for (const book of data.books) {
@@ -85,15 +112,15 @@ app.post('/', async (c) => {
 
   if (data.vocab?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO vocab (id, text, type, sentence, translation, state, stateUpdatedAt, reviewCount, bookId, chapter, createdAt, pushedToAnki, ankiNoteId)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO vocab (id, text, type, sentence, translation, state, stateUpdatedAt, reviewCount, bookId, chapter, language, createdAt, pushedToAnki, ankiNoteId)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const v of data.vocab) {
       stmt.run(
         v.id, v.text, v.type || 'word', v.sentence || '', v.translation || '',
         v.state || 'new', v.stateUpdatedAt || new Date().toISOString(),
-        v.reviewCount || 0, v.bookId || null, v.chapter || null,
+        v.reviewCount || 0, v.bookId || null, v.chapter || null, v.language || 'af',
         v.createdAt || new Date().toISOString(), v.pushedToAnki ? 1 : 0,
         v.ankiNoteId || null
       );
@@ -102,17 +129,17 @@ app.post('/', async (c) => {
   }
 
   if (data.knownWords?.length) {
-    const stmt = db.prepare('INSERT OR REPLACE INTO knownWords (word, state) VALUES (?, ?)');
+    const stmt = db.prepare('INSERT OR REPLACE INTO knownWords (word, language, state) VALUES (?, ?, ?)');
     for (const w of data.knownWords) {
-      stmt.run(w.word, w.state);
+      stmt.run(w.word, w.language || 'af', w.state);
       results.knownWords++;
     }
   }
 
   if (data.clozeSentences?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO clozeSentences (id, sentence, clozeWord, clozeIndex, translation, source, collection, wordRank, tatoebaSentenceId, vocabEntryId, masteryLevel, nextReview, reviewCount, lastReviewed, timesCorrect, timesIncorrect, language)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const cs of data.clozeSentences) {
@@ -121,7 +148,8 @@ app.post('/', async (c) => {
         cs.source || 'tatoeba', cs.collection || 'random', cs.wordRank || null,
         cs.tatoebaSentenceId || null, cs.vocabEntryId || null, cs.masteryLevel || 0,
         cs.nextReview || new Date().toISOString(), cs.reviewCount || 0,
-        cs.lastReviewed || null, cs.timesCorrect || 0, cs.timesIncorrect || 0
+        cs.lastReviewed || null, cs.timesCorrect || 0, cs.timesIncorrect || 0,
+        cs.language || 'af'
       );
       results.clozeSentences++;
     }
@@ -129,13 +157,14 @@ app.post('/', async (c) => {
 
   if (data.dailyStats?.length) {
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO dailyStats (date, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO dailyStats (date, language, wordsRead, newWordsSaved, wordsMarkedKnown, minutesRead, clozePracticed, points, dictionaryLookups, ankiReviews, sessionStartedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const s of data.dailyStats) {
-      stmt.run(s.date, s.wordsRead || 0, s.newWordsSaved || 0, s.wordsMarkedKnown || 0,
-        s.minutesRead || 0, s.clozePracticed || 0, s.points || 0, s.dictionaryLookups || 0);
+      stmt.run(s.date, s.language || 'af', s.wordsRead || 0, s.newWordsSaved || 0, s.wordsMarkedKnown || 0,
+        s.minutesRead || 0, s.clozePracticed || 0, s.points || 0, s.dictionaryLookups || 0,
+        s.ankiReviews || 0, s.sessionStartedAt || null);
       results.dailyStats++;
     }
   }

--- a/api/src/routes/import.ts
+++ b/api/src/routes/import.ts
@@ -41,8 +41,8 @@ app.post(
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
       const insertLesson = db.prepare(`
-        INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, createdAt, lastReadAt)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO lessons (id, collectionId, title, sortOrder, textContent, wordCount, language, createdAt, lastReadAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       db.transaction(() => {
@@ -57,6 +57,7 @@ app.post(
             i,
             chapter.markdown,
             chapter.wordCount,
+            lang,
             now,
             now,
           );

--- a/api/src/routes/journal.ts
+++ b/api/src/routes/journal.ts
@@ -50,9 +50,12 @@ app.post('/', async (c) => {
 });
 
 // GET /api/journal/:id
+// By-id routes scope to the active language (defense-in-depth): a stale
+// cross-language id 404s rather than reading/mutating another language's entry.
 app.get('/:id', (c) => {
   const id = c.req.param('id');
-  const entry = db.prepare('SELECT * FROM journal_entries WHERE id = ?').get(id) as
+  const lang = resolveLanguage(c.req.query('language'));
+  const entry = db.prepare('SELECT * FROM journal_entries WHERE id = ? AND language = ?').get(id, lang) as
     | JournalEntryRow
     | undefined;
 
@@ -64,9 +67,10 @@ app.get('/:id', (c) => {
 // PUT /api/journal/:id - update draft body
 app.put('/:id', async (c) => {
   const id = c.req.param('id');
+  const lang = resolveLanguage(c.req.query('language'));
   const body = await c.req.json();
 
-  const existing = db.prepare('SELECT * FROM journal_entries WHERE id = ?').get(id) as
+  const existing = db.prepare('SELECT * FROM journal_entries WHERE id = ? AND language = ?').get(id, lang) as
     | JournalEntryRow
     | undefined;
   if (!existing) return c.json({ error: 'Entry not found' }, 404);
@@ -86,7 +90,8 @@ app.put('/:id', async (c) => {
   }
 
   values.push(id);
-  db.prepare(`UPDATE journal_entries SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+  values.push(lang);
+  db.prepare(`UPDATE journal_entries SET ${updates.join(', ')} WHERE id = ? AND language = ?`).run(...values);
 
   return c.json({ success: true });
 });
@@ -94,11 +99,12 @@ app.put('/:id', async (c) => {
 // DELETE /api/journal/:id
 app.delete('/:id', (c) => {
   const id = c.req.param('id');
-  const entry = db.prepare('SELECT id FROM journal_entries WHERE id = ?').get(id);
+  const lang = resolveLanguage(c.req.query('language'));
+  const entry = db.prepare('SELECT id FROM journal_entries WHERE id = ? AND language = ?').get(id, lang);
 
   if (!entry) return c.json({ error: 'Entry not found' }, 404);
 
-  db.prepare('DELETE FROM journal_entries WHERE id = ?').run(id);
+  db.prepare('DELETE FROM journal_entries WHERE id = ? AND language = ?').run(id, lang);
   return c.json({ success: true });
 });
 
@@ -106,7 +112,8 @@ app.delete('/:id', (c) => {
 // it (correctedBody + corrections, status → submitted).
 app.post('/:id/correct', async (c) => {
   const id = c.req.param('id');
-  const entry = db.prepare('SELECT * FROM journal_entries WHERE id = ?').get(id) as
+  const lang = resolveLanguage(c.req.query('language'));
+  const entry = db.prepare('SELECT * FROM journal_entries WHERE id = ? AND language = ?').get(id, lang) as
     | JournalEntryRow
     | undefined;
 
@@ -123,8 +130,8 @@ app.post('/:id/correct', async (c) => {
     db.prepare(
       `UPDATE journal_entries
        SET correctedBody = ?, corrections = ?, status = 'submitted', updatedAt = ?
-       WHERE id = ?`,
-    ).run(data.correctedBody ?? null, JSON.stringify(data.corrections ?? null), now, id);
+       WHERE id = ? AND language = ?`,
+    ).run(data.correctedBody ?? null, JSON.stringify(data.corrections ?? null), now, id, lang);
 
     return c.json({ correctedBody: data.correctedBody, corrections: data.corrections });
   } catch (error) {

--- a/api/src/routes/language-scoping.test.ts
+++ b/api/src/routes/language-scoping.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { db } from '../db';
+
+const { default: collectionsApp } = await import('../routes/collections');
+const { default: lessonsApp } = await import('../routes/lessons');
+
+const TS = '2026-01-01T00:00:00Z';
+
+function reset() {
+  db.prepare('DELETE FROM lessons').run();
+  db.prepare('DELETE FROM collections').run();
+}
+
+function seedCollection(id: string, language: string) {
+  db.prepare(
+    'INSERT INTO collections (id, title, author, language, createdAt, lastReadAt) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(id, 'C', 'A', language, TS, TS);
+}
+
+async function addLesson(collectionId: string): Promise<string> {
+  const res = await collectionsApp.request(`/${collectionId}/lessons`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'L', textContent: 'x' }),
+  });
+  return ((await res.json()) as { id: string }).id;
+}
+
+describe('lesson language partitioning', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test('a lesson added to a collection inherits the collection language', async () => {
+    seedCollection('c_de', 'de');
+    const id = await addLesson('c_de');
+    const lang = (db.prepare('SELECT language FROM lessons WHERE id = ?').get(id) as { language: string }).language;
+    expect(lang).toBe('de'); // inherited from the 'de' collection, not the 'af' column default
+  });
+
+  test('by-id lesson routes are language-scoped — a cross-language id 404s / no-ops', async () => {
+    seedCollection('c_de', 'de');
+    const id = await addLesson('c_de');
+
+    expect((await lessonsApp.request(`/${id}?language=af`)).status).toBe(404); // wrong language
+    expect((await lessonsApp.request(`/${id}?language=de`)).status).toBe(200); // right language
+
+    // DELETE under the wrong language is a no-op; under the right one it removes the row.
+    await lessonsApp.request(`/${id}?language=af`, { method: 'DELETE' });
+    expect((db.prepare('SELECT COUNT(*) AS n FROM lessons WHERE id = ?').get(id) as { n: number }).n).toBe(1);
+    await lessonsApp.request(`/${id}?language=de`, { method: 'DELETE' });
+    expect((db.prepare('SELECT COUNT(*) AS n FROM lessons WHERE id = ?').get(id) as { n: number }).n).toBe(0);
+  });
+});

--- a/api/src/routes/lessons.ts
+++ b/api/src/routes/lessons.ts
@@ -1,13 +1,19 @@
 import { Hono } from 'hono';
 import { db, LessonRow } from '../db';
 import { countWords } from '../lib/html-to-markdown';
+import { resolveLanguage } from '../lib/active-language';
 
 const app = new Hono();
 
 // GET /api/lessons/:id
+// By-id routes scope to the active language (defense-in-depth): a stale
+// cross-language id 404s rather than reading/mutating another language's lesson.
 app.get('/:id', (c) => {
   const id = c.req.param('id');
-  const lesson = db.prepare('SELECT * FROM lessons WHERE id = ?').get(id) as LessonRow | undefined;
+  const lang = resolveLanguage(c.req.query('language'));
+  const lesson = db
+    .prepare('SELECT * FROM lessons WHERE id = ? AND language = ?')
+    .get(id, lang) as LessonRow | undefined;
 
   if (!lesson) {
     return c.json({ error: 'Lesson not found' }, 404);
@@ -37,8 +43,9 @@ app.put('/:id', async (c) => {
   updates.push('lastReadAt = ?');
   values.push(new Date().toISOString());
   values.push(id);
+  values.push(resolveLanguage(c.req.query('language')));
 
-  db.prepare(`UPDATE lessons SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+  db.prepare(`UPDATE lessons SET ${updates.join(', ')} WHERE id = ? AND language = ?`).run(...values);
 
   return c.json({ success: true });
 });
@@ -46,17 +53,19 @@ app.put('/:id', async (c) => {
 // DELETE /api/lessons/:id
 app.delete('/:id', (c) => {
   const id = c.req.param('id');
-  db.prepare('DELETE FROM lessons WHERE id = ?').run(id);
+  const lang = resolveLanguage(c.req.query('language'));
+  db.prepare('DELETE FROM lessons WHERE id = ? AND language = ?').run(id, lang);
   return c.json({ success: true });
 });
 
 // PUT /api/lessons/:id/progress
 app.put('/:id/progress', async (c) => {
   const id = c.req.param('id');
+  const lang = resolveLanguage(c.req.query('language'));
   const body = await c.req.json();
   const now = new Date().toISOString();
 
-  const existing = db.prepare('SELECT id, collectionId FROM lessons WHERE id = ?').get(id) as { id: string; collectionId: string | null } | undefined;
+  const existing = db.prepare('SELECT id, collectionId FROM lessons WHERE id = ? AND language = ?').get(id, lang) as { id: string; collectionId: string | null } | undefined;
   if (!existing) {
     return c.json({ error: 'Lesson not found' }, 404);
   }
@@ -66,8 +75,8 @@ app.put('/:id/progress', async (c) => {
       progress_scrollPosition = ?,
       progress_percentComplete = ?,
       lastReadAt = ?
-    WHERE id = ?
-  `).run(body.scrollPosition ?? 0, body.percentComplete ?? 0, now, id);
+    WHERE id = ? AND language = ?
+  `).run(body.scrollPosition ?? 0, body.percentComplete ?? 0, now, id, lang);
 
   if (existing.collectionId) {
     db.prepare('UPDATE collections SET lastReadAt = ? WHERE id = ?').run(now, existing.collectionId);

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -193,13 +193,16 @@ app.get('/streak', (c) => {
 });
 
 // GET /api/stats/reading
-// Estimated reading volume derived from per-lesson scroll progress. Not
-// language-scoped: it reflects the whole library (mirrors the Next route this
-// replaces — lessons are aggregated regardless of language).
+// Estimated reading volume derived from per-lesson scroll progress, scoped to the
+// active language: the stats page is a per-language dashboard (fluency, daily
+// stats and collection counts are all per-language), so reading volume reads as
+// "how much of THIS language you've read". Streak remains the one deliberately
+// app-wide metric (see /streak).
 app.get('/reading', (c) => {
+  const lang = resolveLanguage(c.req.query('language'));
   const rows = db
-    .prepare('SELECT wordCount, progress_percentComplete AS percentComplete FROM lessons')
-    .all() as { wordCount: number; percentComplete: number }[];
+    .prepare('SELECT wordCount, progress_percentComplete AS percentComplete FROM lessons WHERE language = ?')
+    .all(lang) as { wordCount: number; percentComplete: number }[];
 
   return c.json(deriveReadingStats(rows));
 });

--- a/src/lib/data-layer.ts
+++ b/src/lib/data-layer.ts
@@ -587,7 +587,7 @@ export async function getFluencyStats(): Promise<FluencyStats> {
 }
 
 export async function getReadingStats(): Promise<import('./stats-derive').ReadingStats> {
-  const res = await fetch('/api/stats/reading');
+  const res = await fetch(`/api/stats/reading${langParam()}`);
   return res.json();
 }
 
@@ -874,7 +874,7 @@ export interface ChatMessage {
 }
 
 export async function getChatMessages(limit: number = 50, before?: string): Promise<ChatMessage[]> {
-  const params = new URLSearchParams({ limit: limit.toString() });
+  const params = new URLSearchParams({ limit: limit.toString(), language: getActiveLanguage() });
   if (before) params.set('before', before);
   const res = await fetch(`/api/chat?${params}`);
   return res.json();
@@ -887,7 +887,7 @@ export async function sendChatMessage(message: string): Promise<{
   const res = await fetch('/api/chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message }),
+    body: JSON.stringify({ message, language: getActiveLanguage() }),
   });
   if (!res.ok) {
     const err = await res.json();
@@ -897,5 +897,5 @@ export async function sendChatMessage(message: string): Promise<{
 }
 
 export async function clearChatMessages(): Promise<void> {
-  await fetch('/api/chat', { method: 'DELETE' });
+  await fetch(`/api/chat${langParam()}`, { method: 'DELETE' });
 }


### PR DESCRIPTION
Finishes the remaining language data-partitioning work tracked in #189 (post-Hono-replatform reality). All Bun-side, since the Next routes are thin proxies.

## ⚠️ Data-loss fix (the headline)
`POST /api/data` (backup restore) re-inserted every partitioned table with `INSERT OR REPLACE` and **incomplete column lists**, so a restore was lossy even single-language:
- **Rows destroyed:** `knownWords` + `dailyStats` (compound `(…, language)` PK) collapsed rows from different languages onto the default `'af'` key.
- **Fields wiped:** `dailyStats` dropped `ankiReviews` + `sessionStartedAt`; `collections` dropped `groupId` + `sortOrder` + `language`.

Fix: thread `language` through every import INSERT, complete the column lists, and back up + restore `collection_groups` (so a restored collection's `groupId` resolves). Export was already fine (`SELECT *`). Legacy backups with no `language` field restore as `'af'`.

## Other partitioning items
- **Lesson language inheritance** — lessons added to a collection (`collections.ts`) and EPUB imports (`import.ts`) inherit the collection's / active language instead of defaulting to `'af'` (which previously broke the `l.language = c.language` join in the library list).
- **`cached_entries` → compound PK `(word, language)`** — guarded, transactional, idempotent migration (mirrors the `knownWords`/`dailyStats` rebuilds) + `language` carried onto `cached_senses` / `cached_related_forms`; dictionary cache reads/writes are language-scoped. The same word can now be cached per language instead of one evicting the other.
- **By-id defense-in-depth** — `lessons` / `cloze` / `collections` / `journal` by-id GET/PUT/DELETE (+ progress/review/correct) scope to the active language, so a stale cross-language id 404s. ids are unique, so normal flows (resource language == active language) are unchanged.
- **`stats/reading` → per-language** (decision) — reading volume now matches the rest of the per-language stats dashboard (fluency, daily stats, collection counts). Streak remains the sole deliberately app-wide metric.
- **Chat** — standardized the route's query param on `language` (was the inconsistent `lang`) and threaded it from the client.

## Tests
- `data.test.ts` — restore round-trip preserves `language` + `ankiReviews`/`sessionStartedAt`/`groupId`; both languages of a shared word/date survive (no collapse); legacy backups → `'af'`.
- `dictionary-cache.test.ts` — two-language coexistence + per-language overwrite isolation.
- `language-scoping.test.ts` — lesson language inheritance + by-id cross-language 404.
- Updated the chat tests to the `language` param.
- **api `bun test`: 124 pass.** **Next `vitest`: 203 pass.** Root `tsc` + eslint clean.

## Not in this PR
- **Multi-language e2e** (the last #189 verify checkbox): the import-restore logic is covered by the unit round-trip above (which exercises the real route + DB migration), and `e2e/groups-language.spec.ts` already covers library language isolation. A dedicated import-restore/stats e2e is left as a follow-up (its main gap vs the unit test is the thin Next proxy layer; it also needs awkward stats-table cleanup).
- The optional **ratchet test** (`language-partitioning.test.ts`) — it never existed post-replatform; can be created net-new if we want the guard.

Closes the substantive remaining items in #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
