### PR TITLE
test(i18n): language-partitioning ratchet + multi-language e2e (closes #189)

### DIFF
--- a/api/src/language-partitioning.test.ts
+++ b/api/src/language-partitioning.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+
+// ── Ratchet: keep per-language data partitioned ──────────────────────────────
+// Every row in these tables carries a `language` (knownWords / dailyStats /
+// cached_* use a compound (…, language) key). Any query that reads or writes one
+// of them must EITHER scope by `language`, OR scope to a single row by its
+// globally-unique `id` / a parent `…Id`, OR be listed in ALLOWLIST as a
+// deliberate cross-language access. A new query that forgets `language` fails
+// this test — fix the query, or add it to ALLOWLIST with a reason.
+//
+// This guards the regression class behind #189 (mislabelled / lost rows, leaked
+// cross-language lists) and stands in for the never-built "ratchet ALLOWLIST"
+// that issue referenced: the ALLOWLIST below IS that list, already down to only
+// the sanctioned entries. Migrations (api/src/db.ts) legitimately rebuild tables
+// without a language filter, so they are out of scope here.
+
+const PARTITIONED = [
+  'collections', 'lessons', 'vocab', 'clozeSentences', 'journal_entries',
+  'chat_messages', 'knownWords', 'dailyStats',
+  'cached_entries', 'cached_senses', 'cached_related_forms',
+];
+
+// Deliberate cross-language statements, matched by a distinctive substring within
+// the named file. Consulted ONLY for a statement that already failed the language
+// + by-id checks, so the match just has to disambiguate among those.
+// `transient: true` marks an entry expected to disappear once related in-flight
+// work lands — it's exempt from the stale-entry check so concurrent branches
+// don't trip each other.
+const ALLOWLIST: { file: string; match: string; why: string; transient?: boolean }[] = [
+  // Whole-DB backup: export dumps every language; the import side threads language per row.
+  { file: 'routes/data.ts', match: 'SELECT * FROM collections', why: 'full-DB backup export' },
+  { file: 'routes/data.ts', match: 'SELECT * FROM lessons', why: 'full-DB backup export' },
+  { file: 'routes/data.ts', match: 'SELECT * FROM vocab', why: 'full-DB backup export' },
+  { file: 'routes/data.ts', match: 'SELECT * FROM knownWords', why: 'full-DB backup export' },
+  { file: 'routes/data.ts', match: 'SELECT * FROM clozeSentences', why: 'full-DB backup export' },
+  { file: 'routes/data.ts', match: 'SELECT * FROM dailyStats', why: 'full-DB backup export' },
+  // One streak across all languages (CLAUDE.md / issue #108): aggregates every day row.
+  { file: 'routes/stats.ts', match: 'dictionaryLookups, clozePracticed, minutesRead, ankiReviews', why: 'app-wide streak' },
+  // "Did you study today" is app-wide (Sphere Guardian MCP): sums every language for the date.
+  { file: 'routes/study-ping.ts', match: 'COALESCE(SUM(dictionaryLookups)', why: 'app-wide study-today aggregate' },
+  // Chat history TTL cleanup is age-based, not language-based — expires old rows of any language.
+  { file: 'routes/chat.ts', match: 'DELETE FROM chat_messages WHERE createdAt', why: 'age-based TTL cleanup' },
+  // The bundled sentence bank is single-language; the seed dedup reconciles within
+  // it. Per-language scoping rides with the in-flight cloze-bank rework.
+  { file: 'routes/cloze.ts', match: 'WHERE tatoebaSentenceId IS NOT NULL', why: 'single-language seed dedup', transient: true },
+];
+
+const SRC = import.meta.dir; // api/src
+
+function scannedFiles(): string[] {
+  const routes = fs
+    .readdirSync(path.join(SRC, 'routes'))
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .map((f) => `routes/${f}`);
+  return [...routes, 'lib/dictionary-db.ts', 'lib/study-session.ts'];
+}
+
+// Strip comments first so backticks/apostrophes inside them can't break literal
+// pairing (SQL strings never contain `//`, so this can't corrupt a query; the
+// `[^:]` guard keeps `://` in URL strings intact).
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/([^:])\/\/[^\n]*/g, '$1');
+}
+
+// Pull SQL string literals (backtick templates + single-quoted) out of source.
+function sqlLiterals(src: string): string[] {
+  const code = stripComments(src);
+  const out: string[] = [];
+  for (const m of code.matchAll(/`([^`]*)`/g)) out.push(m[1]);
+  for (const m of code.matchAll(/'((?:[^'\\]|\\.)*)'/g)) out.push(m[1]);
+  return out;
+}
+
+const TABLE_VERB = new RegExp(`\\b(?:INTO|FROM|UPDATE)\\s+(?:${PARTITIONED.join('|')})\\b`, 'i');
+const SQL_KEYWORD = /\b(?:SELECT|INSERT|UPDATE|DELETE)\b/i;
+
+function isByIdScoped(sql: string): boolean {
+  // A globally-unique id (collections/lessons/vocab/cloze/journal/chat .id) or a
+  // parent …Id (collectionId, groupId) pins the affected rows without language.
+  return /\bid\s*=\s*\?/i.test(sql) || /\b[A-Za-z]+Id\s*=\s*\?/.test(sql);
+}
+
+const usedAllowlist = new Set<number>();
+const violations: { file: string; sql: string }[] = [];
+
+for (const rel of scannedFiles()) {
+  const src = fs.readFileSync(path.join(SRC, rel), 'utf8');
+  for (const sql of sqlLiterals(src)) {
+    if (!SQL_KEYWORD.test(sql) || !TABLE_VERB.test(sql)) continue;
+    if (/\blanguage\b/.test(sql)) continue; // language-scoped — good
+    if (isByIdScoped(sql)) continue; // single-row / parent-id scoped — safe
+    const ai = ALLOWLIST.findIndex((a) => rel.endsWith(a.file) && sql.includes(a.match));
+    if (ai >= 0) {
+      usedAllowlist.add(ai);
+      continue;
+    }
+    violations.push({ file: rel, sql: sql.replace(/\s+/g, ' ').trim().slice(0, 140) });
+  }
+}
+
+describe('language-partitioning ratchet', () => {
+  test('no unsanctioned cross-language queries on partitioned tables', () => {
+    expect(violations).toEqual([]);
+  });
+
+  test('every non-transient ALLOWLIST entry still matches a live statement', () => {
+    const stale = ALLOWLIST
+      .map((a, i) => ({ a, i }))
+      .filter(({ a, i }) => !a.transient && !usedAllowlist.has(i))
+      .map(({ a }) => `${a.file} :: ${a.match}`);
+    expect(stale).toEqual([]);
+  });
+});

--- a/e2e/language-partition.spec.ts
+++ b/e2e/language-partition.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Per-language data partitioning (#189): user data is isolated by the active
+// language. These exercise the live Next→Bun path (not just unit tests):
+//  1. the collections list is language-scoped (no cross-bleed between languages);
+//  2. a backup/restore round-trip through /api/data preserves each row's language
+//     (the data-loss fix in #199) instead of collapsing everything onto 'af'.
+//
+// Seeds only cleanly-deletable entities (collections / lessons / groups) so the
+// shared e2e DB is left clean for specs that assert empty-DB state. The
+// knownWords/dailyStats compound-PK no-collapse case is covered by the api unit
+// test (api/src/routes/data.test.ts), which can't pollute that shared state.
+test.describe("Language data partitioning", () => {
+  async function cleanup(page: Page) {
+    for (const lang of ["af", "de"]) {
+      const cols = await (await page.request.get(`/api/collections?language=${lang}`)).json();
+      for (const c of cols) {
+        if (c.title?.startsWith("PartTest")) {
+          await page.request.delete(`/api/collections/${c.id}?language=${lang}`);
+        }
+      }
+    }
+    const groups = await (await page.request.get("/api/groups")).json();
+    for (const g of groups) {
+      if (g.name?.startsWith("PartTest")) await page.request.delete(`/api/groups/${g.id}`);
+    }
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await cleanup(page);
+  });
+  test.afterEach(async ({ page }) => {
+    await cleanup(page);
+  });
+
+  test("the collections list is scoped to the active language", async ({ page }) => {
+    await page.request.post("/api/collections", {
+      data: { title: "PartTest AF Book", author: "T", language: "af" },
+    });
+    await page.request.post("/api/collections", {
+      data: { title: "PartTest DE Book", author: "T", language: "de" },
+    });
+
+    const af = (await (await page.request.get("/api/collections?language=af")).json()) as {
+      title: string;
+    }[];
+    const de = (await (await page.request.get("/api/collections?language=de")).json()) as {
+      title: string;
+    }[];
+
+    const afTitles = af.map((c) => c.title);
+    const deTitles = de.map((c) => c.title);
+    expect(afTitles).toContain("PartTest AF Book");
+    expect(afTitles).not.toContain("PartTest DE Book");
+    expect(deTitles).toContain("PartTest DE Book");
+    expect(deTitles).not.toContain("PartTest AF Book");
+  });
+
+  test("backup/restore round-trips each row's language", async ({ page }) => {
+    // Import a backup spanning two languages, with a group shared across them and a
+    // lesson in each collection. The old restore would have flattened language to
+    // 'af'; the fix threads it per row.
+    const backup = {
+      collectionGroups: [{ id: "ptg1", name: "PartTest Group", sortOrder: 0, createdAt: "2026-01-01T00:00:00Z" }],
+      collections: [
+        { id: "ptc_af", title: "PartTest AF Book", author: "T", language: "af", groupId: "ptg1", sortOrder: 0, createdAt: "2026-01-01T00:00:00Z", lastReadAt: "2026-01-01T00:00:00Z" },
+        { id: "ptc_de", title: "PartTest DE Book", author: "T", language: "de", groupId: "ptg1", sortOrder: 1, createdAt: "2026-01-01T00:00:00Z", lastReadAt: "2026-01-01T00:00:00Z" },
+      ],
+      lessons: [
+        { id: "ptl_af", collectionId: "ptc_af", title: "AF L1", textContent: "Hallo", language: "af", createdAt: "2026-01-01T00:00:00Z", lastReadAt: "2026-01-01T00:00:00Z" },
+        { id: "ptl_de", collectionId: "ptc_de", title: "DE L1", textContent: "Hallo", language: "de", createdAt: "2026-01-01T00:00:00Z", lastReadAt: "2026-01-01T00:00:00Z" },
+      ],
+    };
+
+    const res = await page.request.post("/api/data", { data: backup });
+    expect(res.ok()).toBeTruthy();
+
+    const exported = (await (await page.request.get("/api/data")).json()) as {
+      collections: { id: string; language: string; groupId: string | null }[];
+      lessons: { id: string; language: string }[];
+      collectionGroups: { id: string }[];
+    };
+
+    const cAf = exported.collections.find((c) => c.id === "ptc_af");
+    const cDe = exported.collections.find((c) => c.id === "ptc_de");
+    expect(cAf?.language).toBe("af");
+    expect(cDe?.language).toBe("de");
+    // The shared group survived the round-trip, so the restored groupId resolves.
+    expect(cAf?.groupId).toBe("ptg1");
+    expect(exported.collectionGroups.map((g) => g.id)).toContain("ptg1");
+
+    // Lessons keep their own language (not flattened to the 'af' default).
+    expect(exported.lessons.find((l) => l.id === "ptl_af")?.language).toBe("af");
+    expect(exported.lessons.find((l) => l.id === "ptl_de")?.language).toBe("de");
+  });
+});


### PR DESCRIPTION
Completes the two deferred verification items tracked in #189. **Test-only — no production changes.**

## Ratchet — `api/src/language-partitioning.test.ts`
A guard that scans the route + cache SQL and fails if any query on a partitioned table (`collections` / `lessons` / `vocab` / `clozeSentences` / `journal_entries` / `chat_messages` / `knownWords` / `dailyStats` / `cached_*`) is **neither** language-scoped, **nor** single-row by `id`/parent `…Id`, **nor** in a documented `ALLOWLIST`. This is the "ratchet ALLOWLIST" #189 referenced (which never actually existed post-replatform) — now down to only the sanctioned cross-language reads:
- full-DB **backup export** (`/api/data` GET dumps every language),
- the **app-wide streak** aggregate,
- the **app-wide "studied today"** aggregate (study-ping),
- the **age-based chat TTL** cleanup.

The single-language **seed dedup** read is marked `transient` (it rides with the in-flight cloze-bank rework, which scopes it per-language). A second test keeps the non-transient ALLOWLIST honest — a stale exemption fails, so nobody can leave a dead entry behind.

A regression like `db.prepare('SELECT * FROM dailyStats')` in a route trips it immediately (verified: an earlier extraction bug surfaced 22 statements, confirming detection isn't a no-op).

## E2e — `e2e/language-partition.spec.ts`
Drives the live Next→Bun path:
1. the **collections list is scoped to the active language** (`?language=af` vs `?language=de` — no cross-bleed);
2. a **backup/restore round-trip** through `/api/data` preserves each row's language (the #199 data-loss fix) instead of flattening to `'af'` — collections, lessons, and a shared group all round-trip with their own language.

It's API-driven (`page.request`, no UI-selector flakiness) and self-cleaning (only seeds collections/lessons/groups, which it deletes in `beforeEach`/`afterEach`), so it never pollutes the shared e2e DB that other specs assert empty. The `knownWords`/`dailyStats` compound-PK no-collapse case stays covered by the `data.test.ts` unit round-trip (which can't pollute that state).

## Verification
- `cd api && bun test` → **126 pass** (124 + the 2 ratchet tests).
- Root `npx tsc --noEmit` + `npm run lint` clean (the e2e is in the root tsconfig scope).
- I did **not** run the full e2e harness locally (it hard-codes ports 3456/3457 and a concurrent clone is using them) — relying on CI's e2e suite per the repo testing policy.

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
