### PR TITLE
feat(settings): show version & build info in an About panel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so `git describe` can derive the version.
+          fetch-depth: 0
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "version=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+          echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -25,6 +33,12 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-amd64
           platforms: linux/amd64
+          # Build context has no .git (see .dockerignore); pass version metadata
+          # in as build args. BUILD_TIME is stamped by next.config at build time.
+          build-args: |
+            APP_VERSION=${{ steps.build_meta.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ steps.build_meta.outputs.branch }}
           cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64
           cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64,mode=max,ignore-error=true
 
@@ -35,6 +49,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so `git describe` can derive the version.
+          fetch-depth: 0
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "version=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+          echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -47,6 +69,12 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-arm64
           platforms: linux/arm64
+          # Build context has no .git (see .dockerignore); pass version metadata
+          # in as build args. BUILD_TIME is stamped by next.config at build time.
+          build-args: |
+            APP_VERSION=${{ steps.build_meta.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ steps.build_meta.outputs.branch }}
           cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64
           cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64,mode=max,ignore-error=true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,12 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-amd64
           platforms: linux/amd64
+          # Build context has no .git (see .dockerignore); on a release the tag
+          # IS the version. BUILD_TIME is stamped by next.config; branch is left
+          # unset (a tag build is detached → the About panel hides the Branch row).
+          build-args: |
+            APP_VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64
           cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-amd64,mode=max,ignore-error=true
 
@@ -112,6 +118,12 @@ jobs:
           push: true
           tags: ghcr.io/heuwels/lector:sha-${{ github.sha }}-arm64
           platforms: linux/arm64
+          # Build context has no .git (see .dockerignore); on a release the tag
+          # IS the version. BUILD_TIME is stamped by next.config; branch is left
+          # unset (a tag build is detached → the About panel hides the Branch row).
+          build-args: |
+            APP_VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64
           cache-to: type=registry,ref=ghcr.io/heuwels/lector:buildcache-arm64,mode=max,ignore-error=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,19 @@ COPY package.json package-lock.json* ./
 RUN npm ci
 
 COPY . .
+
+# Build/version metadata for Settings → About. The build context has no .git
+# (see .dockerignore), so these are supplied by the callers that do have it —
+# the docker.yml / release.yml workflows and deploy.sh — and read by
+# next.config.ts. Declared after `COPY . .` (which already invalidates per
+# commit) so they don't bust the cached `npm ci` layer. BUILD_TIME is omitted on
+# purpose: next.config stamps it via `new Date()` during `npm run build`.
+ARG APP_VERSION=
+ARG GIT_COMMIT=
+ARG GIT_BRANCH=
+ENV APP_VERSION=$APP_VERSION
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV GIT_BRANCH=$GIT_BRANCH
 RUN npm run build
 
 # ── Dictionary fetch stage ──────────────────────────────────────────────────

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,10 @@
 set -e
 
 # Configuration
+# NOTE: this publishes to ghcr.io/3stacks, whereas the CI workflows
+# (.github/workflows/docker.yml + release.yml) publish to ghcr.io/heuwels — the
+# production registry (it matches the git remote and the Dockerfile dict URL).
+# This script looks personal/stale; prefer the CI pipeline for real releases.
 REGISTRY="ghcr.io/3stacks"
 IMAGE_NAME="lector"
 VERSION="${1:-$(git describe --tags --always --dirty)}"
@@ -11,7 +15,13 @@ FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
 LATEST_IMAGE="${REGISTRY}/${IMAGE_NAME}:latest"
 
 echo "Building ${FULL_IMAGE}..."
-docker build -t "${FULL_IMAGE}" -t "${LATEST_IMAGE}" .
+# Stamp version metadata into the image (the build context has no .git — see
+# .dockerignore). BUILD_TIME is stamped by next.config during `npm run build`.
+docker build \
+  --build-arg APP_VERSION="${VERSION}" \
+  --build-arg GIT_COMMIT="$(git rev-parse HEAD)" \
+  --build-arg GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
+  -t "${FULL_IMAGE}" -t "${LATEST_IMAGE}" .
 
 echo "Pushing to registry..."
 docker push "${FULL_IMAGE}"

--- a/e2e/version-info.spec.ts
+++ b/e2e/version-info.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+// The About panel sources its values from build-time env (next.config.ts). In a
+// local/dev build they come from `git`; in the Docker image the build context
+// has no .git, so they may read "unknown". These assertions therefore check
+// that the section and its labels render with a non-empty value — never a
+// specific version format, which would break the Docker-image e2e run.
+test.describe('Settings → About', () => {
+  test('shows the version and build information', async ({ page }) => {
+    await page.goto('/settings');
+    await page.waitForLoadState('networkidle');
+
+    const about = page.locator('section', {
+      has: page.getByRole('heading', { name: 'About' }),
+    });
+    await expect(about).toBeVisible();
+
+    // Labels that always render.
+    await expect(about.getByText('Version', { exact: true })).toBeVisible();
+    await expect(about.getByText('Built', { exact: true })).toBeVisible();
+
+    // The version value is always present (at minimum the "unknown" fallback).
+    const version = about.locator('div:has(dt:text-is("Version")) dd');
+    await expect(version).toBeVisible();
+    await expect(version).not.toBeEmpty();
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,36 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
+import { execSync } from "node:child_process";
+
+// ── Build / version metadata (shown in Settings → About) ─────────────────────
+// In Docker/CI the build context has no `.git` (excluded via .dockerignore), so
+// the git-derived values are passed in as build args — see the Dockerfile and
+// the `docker.yml` / `release.yml` workflows — and read here from process.env.
+// Local `next dev` / `next build` has `.git`, so we fall back to running git
+// directly. BUILD_TIME has no git dependency: the `new Date()` fallback runs
+// during the build (including inside the Docker builder), so it is correct
+// everywhere and is never passed as a build arg.
+function git(command: string): string {
+  try {
+    return execSync(command, { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "";
+  }
+}
+
+const appVersion =
+  process.env.APP_VERSION?.trim() ||
+  git("git describe --tags --always --dirty") ||
+  "unknown";
+const gitCommit =
+  process.env.GIT_COMMIT?.trim() || git("git rev-parse HEAD") || "unknown";
+const gitBranch =
+  process.env.GIT_BRANCH?.trim() ||
+  git("git rev-parse --abbrev-ref HEAD") ||
+  "unknown";
+const buildTime = process.env.BUILD_TIME?.trim() || new Date().toISOString();
 
 const nextConfig: NextConfig = {
   output: 'standalone',
@@ -8,6 +39,14 @@ const nextConfig: NextConfig = {
   // "webpack config but no turbopack config" warning.
   // Turbopack respects .gitignore so data/ (SQLite WAL files) is already ignored.
   turbopack: {},
+  // Inlined into the bundle (client + server) so the About panel can render the
+  // build it was compiled from. Computed once above; never changes at runtime.
+  env: {
+    NEXT_PUBLIC_APP_VERSION: appVersion,
+    NEXT_PUBLIC_GIT_COMMIT: gitCommit,
+    NEXT_PUBLIC_GIT_BRANCH: gitBranch,
+    NEXT_PUBLIC_BUILD_TIME: buildTime,
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/src/app/settings/components/VersionInfo/index.tsx
+++ b/src/app/settings/components/VersionInfo/index.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { type ReactNode, useEffect, useState } from 'react';
+import {
+  buildInfo,
+  commitShort,
+  commitUrl,
+  formatBuildTime,
+  isKnown,
+  relativeBuildAge,
+} from '@/lib/build-info';
+
+function Row({
+  label,
+  mono = true,
+  children,
+}: {
+  label: string;
+  mono?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className={`text-right text-foreground ${mono ? 'font-mono' : ''}`}>{children}</dd>
+    </div>
+  );
+}
+
+export default function VersionInfo() {
+  const { version, commit, branch, buildTime } = buildInfo;
+  const href = commitUrl(commit);
+  const built = formatBuildTime(buildTime);
+
+  // Relative age depends on the current time, so compute it after mount — this
+  // keeps it out of the server-rendered HTML and avoids a hydration mismatch.
+  const [age, setAge] = useState('');
+  useEffect(() => {
+    setAge(relativeBuildAge(buildTime, Date.now()));
+  }, [buildTime]);
+
+  return (
+    <section className="panel p-6">
+      <h2 className="mb-4 text-lg font-semibold text-foreground">About</h2>
+      <dl className="space-y-3 text-sm">
+        <Row label="Version">{version}</Row>
+        {isKnown(commit) && (
+          <Row label="Commit">
+            {href ? (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                {commitShort(commit)}
+              </a>
+            ) : (
+              commitShort(commit)
+            )}
+          </Row>
+        )}
+        {isKnown(branch) && <Row label="Branch">{branch}</Row>}
+        {built && (
+          <Row label="Built" mono={false}>
+            {built}
+            {age && <span className="text-muted-foreground"> ({age})</span>}
+          </Row>
+        )}
+      </dl>
+    </section>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import AnkiSettings from './components/AnkiSettings';
 import TTSSettings from './components/TTSSettings';
 import LLMSettings from './components/LLMSettings';
 import PracticeSettings from './components/PracticeSettings';
+import VersionInfo from './components/VersionInfo';
 import PageHeader from '@/components/PageHeader';
 
 export default function SettingsPage() {
@@ -27,6 +28,7 @@ export default function SettingsPage() {
         <KnownWordsImport />
         <Export />
         <DataManagement />
+        <VersionInfo />
       </div>
     </main>
   );

--- a/src/lib/__tests__/build-info.test.ts
+++ b/src/lib/__tests__/build-info.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isKnown,
+  commitShort,
+  commitUrl,
+  formatBuildTime,
+  relativeBuildAge,
+} from '@/lib/build-info';
+
+describe('isKnown', () => {
+  it('treats the fallback sentinels as unknown', () => {
+    expect(isKnown('unknown')).toBe(false);
+    expect(isKnown('')).toBe(false);
+  });
+
+  it('treats real values as known', () => {
+    expect(isKnown('v1.34.0')).toBe(true);
+    expect(isKnown('master')).toBe(true);
+  });
+});
+
+describe('commitShort', () => {
+  it('abbreviates a full SHA to 7 chars', () => {
+    expect(commitShort('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0')).toBe('a1b2c3d');
+  });
+
+  it('passes through the fallback sentinels unchanged', () => {
+    expect(commitShort('unknown')).toBe('unknown');
+    expect(commitShort('')).toBe('');
+  });
+});
+
+describe('commitUrl', () => {
+  it('builds a GitHub commit URL for a real SHA', () => {
+    expect(commitUrl('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0')).toBe(
+      'https://github.com/heuwels/lector/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+    );
+  });
+
+  it('accepts an abbreviated SHA', () => {
+    expect(commitUrl('a1b2c3d')).toBe('https://github.com/heuwels/lector/commit/a1b2c3d');
+  });
+
+  it('honours a custom repo slug', () => {
+    expect(commitUrl('a1b2c3d', 'someone/fork')).toBe(
+      'https://github.com/someone/fork/commit/a1b2c3d',
+    );
+  });
+
+  it('returns null for non-SHA values so the UI renders plain text', () => {
+    expect(commitUrl('unknown')).toBeNull();
+    expect(commitUrl('')).toBeNull();
+    expect(commitUrl('v1.34.0')).toBeNull();
+  });
+});
+
+describe('formatBuildTime', () => {
+  it('formats an ISO timestamp as a UTC string', () => {
+    expect(formatBuildTime('2026-06-25T18:10:00.000Z')).toBe('25 Jun 2026, 18:10 UTC');
+  });
+
+  it('returns an empty string for empty or invalid input', () => {
+    expect(formatBuildTime('')).toBe('');
+    expect(formatBuildTime('not-a-date')).toBe('');
+  });
+});
+
+describe('relativeBuildAge', () => {
+  const now = Date.parse('2026-06-25T18:00:00.000Z');
+
+  it('describes a build a couple of hours old', () => {
+    expect(relativeBuildAge('2026-06-25T16:00:00.000Z', now)).toBe('2 hours ago');
+  });
+
+  it('describes a build a few days old', () => {
+    expect(relativeBuildAge('2026-06-22T18:00:00.000Z', now)).toBe('3 days ago');
+  });
+
+  it('uses "yesterday" via numeric:auto', () => {
+    expect(relativeBuildAge('2026-06-24T18:00:00.000Z', now)).toBe('yesterday');
+  });
+
+  it('returns an empty string for empty or invalid input', () => {
+    expect(relativeBuildAge('', now)).toBe('');
+    expect(relativeBuildAge('not-a-date', now)).toBe('');
+  });
+});

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -1,0 +1,94 @@
+// Build / version metadata for the Settings → About panel.
+//
+// The values are injected at build time via `env` in next.config.ts (which
+// sources them from build args in Docker/CI, or from `git` locally) and inlined
+// into the bundle. Read them as direct `process.env.NEXT_PUBLIC_*` member
+// accesses so Next replaces them statically in the client bundle — do not
+// destructure `process.env`, or the replacement won't fire.
+
+/** The GitHub repo these builds are cut from, used to link commits. */
+export const REPO_SLUG = 'heuwels/lector';
+
+export interface BuildInfo {
+  /** `git describe --tags --always --dirty`, e.g. "v1.34.0" or "v1.34.0-3-gabc1234". */
+  version: string;
+  /** Full commit SHA, or "unknown" when it couldn't be determined. */
+  commit: string;
+  /** Branch the build was cut from, or "unknown". */
+  branch: string;
+  /** ISO-8601 build timestamp, or "" when unavailable. */
+  buildTime: string;
+}
+
+export const buildInfo: BuildInfo = {
+  version: process.env.NEXT_PUBLIC_APP_VERSION || 'unknown',
+  commit: process.env.NEXT_PUBLIC_GIT_COMMIT || 'unknown',
+  branch: process.env.NEXT_PUBLIC_GIT_BRANCH || 'unknown',
+  buildTime: process.env.NEXT_PUBLIC_BUILD_TIME || '',
+};
+
+/** True when a value was actually resolved (not the "unknown"/empty fallback). */
+export function isKnown(value: string): boolean {
+  return value !== '' && value !== 'unknown';
+}
+
+/** Abbreviate a commit SHA to 7 chars; passes through "unknown"/empty unchanged. */
+export function commitShort(commit: string): string {
+  return isKnown(commit) ? commit.slice(0, 7) : commit;
+}
+
+/**
+ * GitHub URL for a commit, or `null` when the commit isn't a real SHA (so the
+ * UI can render plain text instead of a dead link).
+ */
+export function commitUrl(commit: string, repo: string = REPO_SLUG): string | null {
+  if (!/^[0-9a-f]{7,40}$/i.test(commit)) return null;
+  return `https://github.com/${repo}/commit/${commit}`;
+}
+
+/**
+ * Human-readable absolute build time in UTC, e.g. "25 Jun 2026, 18:10 UTC".
+ * Returns "" for empty or unparseable input. Fixed locale + UTC keeps it
+ * deterministic regardless of where it renders.
+ */
+export function formatBuildTime(iso: string): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const formatted = new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  }).format(date);
+  return `${formatted} UTC`;
+}
+
+/**
+ * Relative build age, e.g. "2 hours ago". `nowMs` is injected so the function
+ * stays pure and testable. Returns "" for empty or unparseable input.
+ */
+export function relativeBuildAge(iso: string, nowMs: number): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  const diffSec = Math.round((then - nowMs) / 1000);
+  const absSec = Math.abs(diffSec);
+
+  const units: [Intl.RelativeTimeFormatUnit, number][] = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60],
+  ];
+  for (const [unit, secs] of units) {
+    if (absSec >= secs) return rtf.format(Math.round(diffSec / secs), unit);
+  }
+  return rtf.format(diffSec, 'second');
+}


### PR DESCRIPTION
## Summary

Adds an **About** section at the bottom of Settings showing the app version and build information.

| Field | Source |
|---|---|
| **Version** | `git describe --tags --always --dirty` (e.g. `v1.34.0`, or `v1.34.0-4-g4455d6e-dirty` between tags) |
| **Commit** | full SHA, linked to the GitHub commit (short form displayed) |
| **Branch** | current branch — hidden on tag releases (detached HEAD) |
| **Built** | UTC timestamp + relative age (e.g. "2 hours ago") |

## How it works

- `next.config.ts` computes the four values — **build-arg override → `git` fallback → `"unknown"`** — and inlines them via the `env` config (verified to reach the client bundle under Next 16 / Turbopack).
- `.git` is excluded from the Docker build context (`.dockerignore`), so the git-derived values are supplied as **build args** by the callers that do have git: `docker.yml` (via `git describe`, hence `fetch-depth: 0`), `release.yml` (the tag *is* the version), and `deploy.sh`.
- `BUILD_TIME` is never a build arg — `next.config`'s `new Date()` fallback runs during `npm run build` (including inside the Docker builder), so it is correct in dev, `deploy.sh`, and CI alike.

## Tests

- Unit tests for the pure helpers (`commitShort`, `commitUrl`, `formatBuildTime`, `relativeBuildAge`).
- Tolerant e2e spec: asserts the panel + labels render with a non-empty version, so it passes even when the Docker-image e2e job yields `"unknown"` (that job builds without `.git` / build args by design).

## Verified locally

- Production build inlines all four values into the client chunk and the prerendered `/settings`.
- Rendered `/settings` in a real headless browser — all values resolve, the commit links out, relative age works, **zero page errors**.
- The e2e spec's exact locators (incl. `:text-is()` in `:has()` and `not.toBeEmpty()`) were run against a dev server and pass. *(The suite itself can't run in two parallel local clones — its `webServer` hardcodes :3456/:3457 — so CI executes it.)*
- `tsc --noEmit` clean; `eslint` clean on touched files.

## Note

`deploy.sh` publishes to `ghcr.io/3stacks`, whereas CI (`docker.yml` / `release.yml`) and the git remote use `ghcr.io/heuwels`. I kept `deploy.sh` working and added the build args, but flagged the registry as stale in a comment rather than silently rewriting it — the production release path is the CI workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
